### PR TITLE
chore: README overhaul + rename default branch to master

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything
+* @hayke102

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,7 @@ jobs:
       - name: Build
         run: go build ./...
       - name: Test
-        run: go test -race -coverprofile=coverage.out ./...
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage.out
-          fail_ci_if_error: false
+        run: go test -race ./...
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Sessions live under their repo. Branch name, dirty state, and full PR status on 
 ### And more
 
 - **Session resume** — restart with **`r`**, Claude picks up exactly where it left off
-- **Full terminal attach** — **`Enter`** for full PTY, **`Tab`** for split mode, **`Ctrl+Q`** to detach
+- **Full terminal attach** — **`Enter`** for full PTY, **`Tab`** for split mode (beta), **`Ctrl+Q`** to detach
 - **Auto-naming** — sessions title themselves from your prompt
 - **5 themes** — tokyo-night, catppuccin-mocha, rose-pine, nord, gruvbox (**`S`** to switch)
 - **Chrome tab control** — **`p`** opens PR in Chrome, reuses existing tab
@@ -147,7 +147,7 @@ If you use Claude Code as your primary agent and want the tightest integration, 
 | `j` / `k` | Navigate up/down |
 | `Enter` | Attach to session |
 | `Ctrl+Q` | Detach from session |
-| `Tab` | Focus/unfocus preview (split mode) |
+| `Tab` | Focus/unfocus preview (split mode, beta) |
 | `Space` | Jump to next waiting/finished session |
 | `a` | New session (current repo) |
 | `n` | New session (workspace picker) |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <strong>Run 10 Claude Code agents. Stay sane.</strong>
   </p>
   <p align="center">
-    A terminal UI for orchestrating multiple Claude Code sessions in parallel.
+    A terminal cockpit for orchestrating Claude Code sessions in parallel.
     <br />
     See which agents need you. Jump in, direct, jump out.
   </p>
@@ -13,8 +13,7 @@
     <a href="https://github.com/brizzai/brizz-code/releases/latest"><img src="https://img.shields.io/github/v/release/brizzai/brizz-code" alt="GitHub release"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0"></a>
     <a href="https://golang.org/doc/devel/release.html"><img src="https://img.shields.io/github/go-mod/go-version/brizzai/brizz-code" alt="Go version"></a>
-    <a href="https://github.com/brizzai/brizz-code/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/brizzai/brizz-code/ci.yml?branch=main" alt="Build Status"></a>
-    <a href="https://codecov.io/gh/brizzai/brizz-code"><img src="https://codecov.io/gh/brizzai/brizz-code/graph/badge.svg" alt="codecov"></a>
+    <a href="https://github.com/brizzai/brizz-code/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/brizzai/brizz-code/ci.yml?branch=master" alt="Build Status"></a>
   </p>
 </p>
 
@@ -25,16 +24,21 @@
 </p>
 
 <p align="center">
-  <em>Sessions grouped by repo &middot; Real-time status via hooks &middot; PR badges &middot; One-key approve</em>
+  <em>Sessions grouped by repo &middot; Real-time status via hooks &middot; PR state &middot; One-key approve</em>
 </p>
 
 <br />
 
-Your one-stop shop for managing Claude Code sessions. Stop tab-switching — start orchestrating.
+```
+You (orchestrator)
+ └─ brizz-code (awareness + control)
+      ├─ Claude Code session → feat/auth branch
+      ├─ Claude Code session → fix/login-bug branch
+      ├─ Claude Code session → feat/ci-setup branch
+      └─ ...
+```
 
-- 🔍 **See everything** — real-time status of every agent across all repos
-- ⚡ **Act fast** — `Space` to jump, `Y` to approve, two keys and you're done
-- 🌳 **Git-native** — sessions grouped by repo, branch, PR status, worktrees
+Each session is one agent, one branch, one task. Claude handles the coding — commits, PRs, tests. You handle the directing. brizz-code is your cockpit.
 
 ## Install
 
@@ -47,7 +51,7 @@ brew install brizzai/tap/brizz-code
 ### Shell script
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/brizzai/brizz-code/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/brizzai/brizz-code/master/install.sh | bash
 ```
 
 Requires [`gh`](https://cli.github.com/) authenticated with repo access.
@@ -66,70 +70,75 @@ Requires Go 1.24+.
 - [tmux](https://github.com/tmux/tmux) (`brew install tmux`)
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
 
-## Features
-
-### Real-Time Status Detection
-
-Know what every agent is doing without checking each one. Status updates via Claude Code hooks — no polling, no guessing, no delay.
-
-`● running` &nbsp; `◐ waiting` &nbsp; `● finished` &nbsp; `○ idle` &nbsp; `✕ error`
-
-### Jump + Approve Loop
-
-**`Space`** jumps to the next session that needs attention. **`Y`** approves the permission prompt without attaching. Two keys, back to orchestrating. This is the core loop — cycle through waiting sessions and approve them in seconds.
-
-### Sessions Grouped by Repo
-
-Sessions are organized under their git repo with branch name, dirty indicator, and PR status. Collapse and expand repo groups. Filter by title with **`/`**.
-
-### GitHub PR Badges
-
-See PR status at a glance on every repo header: `#42 ✓` approved, `#17` pending review, `#8 ✕` CI failing. Unresolved review threads counted via GraphQL. Requires [`gh`](https://cli.github.com/) (optional — hidden if not installed).
-
-### Git Worktree Support
-
-Press **`w`** to create a new worktree with branch picker. Zero config — works out of the box with any git repo. Worktree creation is non-blocking: a spinner shows in the sidebar while it builds. Custom workspace commands via `.bc.json` per repo.
-
-### Auto-Naming
-
-Sessions title themselves from your first prompt. "Add JWT authentication middleware" becomes the session name automatically. After 3 prompts, the title updates to reflect the session's actual scope. Rename manually with **`R`** to lock the title.
-
-### Full Terminal Attach
-
-**`Enter`** gives you a full PTY session inside the agent — colors, scrollback, mouse events, everything. **`Ctrl+Q`** detaches cleanly without killing the session. Or use **`Tab`** for split-view focus mode with keyboard forwarding.
-
-### Fork Sessions
-
-Press **`f`** to fork a session — branches off the Claude conversation at that point. Explore alternative directions without losing the original.
-
-### Session Resume
-
-Sessions automatically capture Claude's conversation ID. Restart with **`r`** and Claude picks up exactly where it left off — no context lost.
-
-### 5 Built-In Themes
-
-**tokyo-night** (default) · **catppuccin-mocha** · **rose-pine** · **nord** · **gruvbox**
-
-Switch live from the settings dialog (**`S`**) with instant preview.
-
-### Chrome Tab Control
-
-**`p`** opens the PR in Chrome via a native messaging extension — reuses the existing tab instead of opening duplicates. Falls back to system browser if the extension isn't installed.
-
-### Built-In Bug Reports
-
-Press **`!`** to open the bug report dialog. It captures error history, your recent actions, system diagnostics, and debug logs — then opens a pre-filled GitHub issue. No manual copy-paste.
-
 ## Quick Start
 
 ```bash
-# Launch the TUI
+# Launch
 brizz-code
 
-# Press 'a' to create a session in the current repo
-# Press 'n' for workspace picker with path autocomplete
-# Press '?' for all keybindings
+# 'a' — new session in current repo
+# 'n' — workspace picker with path autocomplete
+# '?' — all keybindings
 ```
+
+## Features
+
+### Real-Time Status
+
+Every agent's state, always visible. Hook-based detection — no polling, no delay.
+
+`● running` &nbsp; `◐ waiting` &nbsp; `● finished` &nbsp; `○ idle` &nbsp; `✕ error`
+
+### Jump + Approve
+
+**`Space`** jumps to the next session that needs attention. **`Y`** approves the prompt without attaching. Two keys, done. Cycle through a dozen waiting agents in seconds.
+
+### Git-Native Sessions
+
+Sessions live under their repo. Branch name, dirty state, and full PR status on every header — CI pass/fail, review state, changes requested, unresolved threads. Collapse groups, filter with **`/`**, switch branches with **`b`**. Requires [`gh`](https://cli.github.com/) for PR info (optional).
+
+### Worktrees
+
+**`w`** creates a new worktree with branch picker. Zero config — works with any repo. Each worktree gets its own isolated session. Custom workspace commands via `.bc.json` if you need them.
+
+### Fork Sessions
+
+**`f`** forks a session — branches off the Claude conversation at that point. Try a different approach without losing the original. Both sessions keep running independently.
+
+### And more
+
+- **Session resume** — restart with **`r`**, Claude picks up exactly where it left off
+- **Full terminal attach** — **`Enter`** for full PTY, **`Tab`** for split mode, **`Ctrl+Q`** to detach
+- **Auto-naming** — sessions title themselves from your prompt
+- **5 themes** — tokyo-night, catppuccin-mocha, rose-pine, nord, gruvbox (**`S`** to switch)
+- **Chrome tab control** — **`p`** opens PR in Chrome, reuses existing tab
+- **Bug reports** — **`!`** captures diagnostics and opens a pre-filled GitHub issue
+
+## Why brizz-code?
+
+There are a dozen multi-agent session managers now. Most try to support every AI CLI under the sun. brizz-code takes the opposite approach: **go deep on Claude Code, and nothing else.**
+
+Every feature is designed around how Claude Code actually works — hooks, conversation resume, session IDs, prompt structure. No generic "send keystrokes and hope" abstraction layer.
+
+### vs. the alternatives
+
+|                                     | brizz-code | claude-squad | ccmanager | agent-deck |
+|-------------------------------------|:----------:|:------------:|:---------:|:----------:|
+| **Status detection**                | Hooks (real-time, no delay) | Pane scraping | Hooks | Hooks |
+| **PR state** (CI + reviews + threads) | ✓ | — | — | — |
+| **One-key approve** (`Y`)           | ✓ | auto-yes flag | auto-approve | — |
+| **Session resume** (`claude --resume`) | ✓ | — | — | — |
+| **Smart session naming**            | ✓ | — | — | — |
+| **Fork conversation** (`f`)         | ✓ | — | — | — |
+| **Open PR in browser** (`p`)       | ✓ | — | — | — |
+| **Git worktrees**                   | ✓ | ✓ | ✓ | ✓ |
+| **Multi-agent** (Codex, Gemini…)    | — | ✓ | ✓ | ✓ |
+| **Linux**                           | — | ✓ | ✓ | ✓ |
+| **No tmux dependency**              | — | — | ✓ | — |
+
+**The trade-off is intentional.** Claude-squad and ccmanager support 5+ agents — but treat them all the same. brizz-code knows what Claude Code *is*. It reads hook status files. It resumes conversations. It knows your PR has 2 unresolved threads. It names sessions from your actual prompt. That depth is only possible by going narrow.
+
+If you use Claude Code as your primary agent and want the tightest integration, this is it.
 
 ## Keybindings
 
@@ -156,19 +165,6 @@ brizz-code
 | `!` | Bug report / diagnostics |
 | `?` | Help |
 | `q` | Quit |
-
-## How It Fits
-
-```
-You (orchestrator)
- └─ brizz-code (awareness + control)
-      ├─ Claude Code session → feat/auth branch
-      ├─ Claude Code session → fix/login-bug branch
-      ├─ Claude Code session → feat/ci-setup branch
-      └─ ...
-```
-
-Each session is one agent, one branch, one task. Claude handles the coding — commits, PRs, tests. You handle the directing. brizz-code is your cockpit.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Overhauled README for open source launch: tighter copy, cockpit metaphor, restructured features (5 primary + one-liner secondary), comparison table vs alternatives
- Renamed default branch from `main` to `master` across CI workflows, goreleaser, contributing docs, CLAUDE.md
- Marked split mode as beta in README
- Added CODEOWNERS, updated CI workflow

## Test plan
- [ ] Verify CI badge renders correctly with `branch=master`
- [ ] Verify install.sh URL resolves with `/master/`
- [ ] Review README rendering on GitHub
- [ ] Confirm comparison table accuracy against alternatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)