### PR TITLE
fix: goreleaser homebrew tap token + cask migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
           args: release --clean --release-notes /tmp/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ needs.tag.outputs.new_tag }}
 
       - name: Roll changelog for next release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,7 @@ homebrew_casks:
     repository:
       owner: brizzai
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: https://github.com/brizzai/brizz-code
     description: "TUI for managing multiple Claude Code sessions in parallel"
     dependencies:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src=".github/assets/logo.svg" alt="brizz-code logo" width="120" />
+  <img src=".github/assets/logo.svg" alt="brizz-code logo" width="80" />
   <h1 align="center">brizz-code</h1>
   <p align="center">
     <strong>Run 10 Claude Code agents. Stay sane.</strong>


### PR DESCRIPTION
## Summary
- Add `HOMEBREW_TAP_TOKEN` to goreleaser config and release workflow for cross-repo push
- Migrate `brews` → `homebrew_casks` (goreleaser v2 deprecation)
- Resize logo to 80px

Fixes the 403 error on release: `could not update "Casks/brizz-code.rb": 403 Resource not accessible by integration`

## Test plan
- [ ] Merge and verify next release pushes cask to homebrew-tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)