### PR TITLE
fix(ui): consistent header bar background and logo update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
           args: release --clean --release-notes /tmp/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ needs.tag.outputs.new_tag }}
 
       - name: Roll changelog for next release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,7 @@ homebrew_casks:
     repository:
       owner: brizzai
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: https://github.com/brizzai/brizz-code
     description: "TUI for managing multiple Claude Code sessions in parallel"
     dependencies:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src=".github/assets/logo.svg" alt="brizz-code logo" width="120" />
+  <img src=".github/assets/logo.svg" alt="brizz-code logo" width="80" />
   <h1 align="center">brizz-code</h1>
   <p align="center">
     <strong>Run 10 Claude Code agents. Stay sane.</strong>

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1838,7 +1838,7 @@ func (h *Home) renderHeader() string {
 	}
 
 	bg := ColorSurface
-	logo := lipgloss.NewStyle().Foreground(lipgloss.Color("#F48FB1")).Background(bg).Bold(true).Render(">_")
+	logo := lipgloss.NewStyle().Foreground(ColorBrand).Background(bg).Bold(true).Render(">_")
 	title := logo + lipgloss.NewStyle().Background(bg).Render(" ") + TitleStyle.Background(bg).Render("brizz-code")
 
 	// Build status indicators — only show non-zero.
@@ -1864,7 +1864,15 @@ func (h *Home) renderHeader() string {
 
 	sp := lipgloss.NewStyle().Background(bg).Render
 	content := title + sp("  ") + stats
-	return HeaderBarStyle.Width(h.width).Render(content)
+
+	// Manually pad to full width with background-styled spaces to avoid ANSI reset issues.
+	if h.width > 0 {
+		contentWidth := lipgloss.Width(content)
+		if contentWidth < h.width {
+			content += sp(strings.Repeat(" ", h.width-contentWidth))
+		}
+	}
+	return HeaderBarStyle.Render(content)
 }
 
 func (h *Home) renderHelpBar() string {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1837,31 +1837,33 @@ func (h *Home) renderHeader() string {
 		statusCounts[s.GetStatus()]++
 	}
 
-	logo := lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Render("✦")
-	title := logo + " " + TitleStyle.Render("brizz-code")
+	bg := ColorSurface
+	logo := lipgloss.NewStyle().Foreground(lipgloss.Color("#F48FB1")).Background(bg).Bold(true).Render(">_")
+	title := logo + lipgloss.NewStyle().Background(bg).Render(" ") + TitleStyle.Background(bg).Render("brizz-code")
 
 	// Build status indicators — only show non-zero.
 	var indicators []string
 	if n := statusCounts[session.StatusRunning] + statusCounts[session.StatusStarting]; n > 0 {
-		indicators = append(indicators, StatusRunningStyle.Render(fmt.Sprintf("● %d running", n)))
+		indicators = append(indicators, StatusRunningStyle.Background(bg).Render(fmt.Sprintf("● %d running", n)))
 	}
 	if n := statusCounts[session.StatusWaiting]; n > 0 {
-		indicators = append(indicators, StatusWaitingStyle.Render(fmt.Sprintf("◐ %d waiting", n)))
+		indicators = append(indicators, StatusWaitingStyle.Background(bg).Render(fmt.Sprintf("◐ %d waiting", n)))
 	}
 	if n := statusCounts[session.StatusFinished]; n > 0 {
-		indicators = append(indicators, StatusFinishedStyle.Render(fmt.Sprintf("● %d finished", n)))
+		indicators = append(indicators, StatusFinishedStyle.Background(bg).Render(fmt.Sprintf("● %d finished", n)))
 	}
 	if n := statusCounts[session.StatusIdle]; n > 0 {
-		indicators = append(indicators, StatusIdleStyle.Render(fmt.Sprintf("○ %d idle", n)))
+		indicators = append(indicators, StatusIdleStyle.Background(bg).Render(fmt.Sprintf("○ %d idle", n)))
 	}
 	if n := statusCounts[session.StatusError]; n > 0 {
-		indicators = append(indicators, StatusErrorStyle.Render(fmt.Sprintf("✕ %d error", n)))
+		indicators = append(indicators, StatusErrorStyle.Background(bg).Render(fmt.Sprintf("✕ %d error", n)))
 	}
 
-	sep := lipgloss.NewStyle().Foreground(ColorBorder).Render(" • ")
+	sep := lipgloss.NewStyle().Foreground(ColorBorder).Background(bg).Render(" • ")
 	stats := strings.Join(indicators, sep)
 
-	content := " " + title + "  " + stats
+	sp := lipgloss.NewStyle().Background(bg).Render
+	content := title + sp("  ") + stats
 	return HeaderBarStyle.Width(h.width).Render(content)
 }
 

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -21,6 +21,7 @@ var (
 	ColorRed     = lipgloss.Color("#f7768e")
 	ColorGray    = lipgloss.Color("#565f89")
 	ColorWhite   = lipgloss.Color("#c0caf5")
+	ColorBrand   = lipgloss.Color("#F48FB1") // brizz pink — theme-independent
 	ColorOrange  = lipgloss.Color("#ff9e64")
 	ColorPurple  = lipgloss.Color("#bb9af7")
 )


### PR DESCRIPTION
## Summary
- Replace `✦` logo with `>_` in company pink (`#F48FB1`)
- Fix header bar background not extending full width by inheriting `ColorSurface` on all inner elements
- Remove extra left padding

## Test plan
- [ ] Launch TUI and verify header bar background is solid across full width
- [ ] Verify `>_` logo renders in pink across all 5 themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)