### PR TITLE
fix: remove goreleaser changelog disable so release notes work

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,9 +47,6 @@ checksum:
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
-changelog:
-  disable: true
-
 release:
   github:
     owner: brizzai


### PR DESCRIPTION
goreleaser's changelog: disable: true also suppresses --release-notes, causing empty release notes.