### PR TITLE
fix(ci): set git identity for release tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Create and push tag
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           TAG="${{ steps.version.outputs.tag }}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists, skipping creation"


### PR DESCRIPTION
## Summary
- Fix release workflow failing with `empty ident name not allowed` when creating annotated git tags
- Add `git config user.name/email` for `github-actions[bot]` before `git tag -a`

## Test plan
- [ ] Merge and trigger a `/ship` to verify tag creation succeeds

/no-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)