### PR TITLE
fix(status): override stale waiting status when pane shows idle prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Session stuck at "waiting" status after user interrupts/escapes a permission prompt
+
 ## [1.1.0] - 2026-03-21
 
 ### Added

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -390,18 +390,10 @@ func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, log *s
 	// - If user interrupts/escapes, no hook fires — pane override catches this
 	// - Content change detection below handles the gap if hooks are delayed
 	if paneStatus == StatusFinished {
-		prevStatus := s.Status
-		if s.Acknowledged {
-			s.Status = StatusIdle
-		} else {
-			s.Status = StatusFinished
-		}
+		s.Status = StatusFinished
 		s.lastContentHash = ""
 		s.lastContentChangeAt = time.Time{}
-		if prevStatus != s.Status {
-			log.Info("hook says waiting but pane shows idle prompt, overriding",
-				"newStatus", s.Status)
-		}
+		log.Info("hook says waiting but pane shows idle prompt, overriding to finished")
 		return
 	}
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -324,7 +324,7 @@ func (s *Session) updateStatusFromHook(oldStatus Status, hookStatus string, hook
 	case "running":
 		s.applyHookRunning(oldStatus, paneContent, paneStatus, log)
 	case "waiting":
-		s.applyHookWaiting(paneContent, log)
+		s.applyHookWaiting(paneContent, paneStatus, log)
 	case "finished":
 		s.applyHookFinished(paneStatus, log)
 	case "dead":
@@ -378,17 +378,25 @@ func (s *Session) applyHookRunning(oldStatus Status, paneContent string, paneSta
 
 // applyHookWaiting handles hook status "waiting" with content change detection.
 // Must be called with s.mu held.
-func (s *Session) applyHookWaiting(paneContent string, log *slog.Logger) {
-	// Hook says waiting — trust hooks fully, never override from pane.
+func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, log *slog.Logger) {
+	// Hook says waiting — trust hooks unless pane clearly shows idle prompt.
 	//
-	// Why no pane override at all:
-	// - waiting→finished: ❯ prompt match false-positives on Claude's menu
-	//   selector (e.g. "❯ 1. Yes, allow once")
-	// - waiting→running: stale "Running…" / spinner text from subagent output
-	//   above the permission prompt triggers whimsical/spinner patterns
+	// Why we allow pane override for finished only:
+	// - detectWaiting runs before detectFinished in the detection pipeline,
+	//   so a real permission prompt yields paneStatus=StatusWaiting, not StatusFinished.
+	//   The "❯ 1. Yes" false-positive concern is already handled by detection order.
+	// - waiting→running is NOT overridden (stale spinner text can false-positive)
 	// - If user approves, UserPromptSubmit hook fires within milliseconds
-	// - If user denies/escapes, idle_prompt hook at ~60s handles it
+	// - If user interrupts/escapes, no hook fires — pane override catches this
 	// - Content change detection below handles the gap if hooks are delayed
+	if paneStatus == StatusFinished {
+		s.Status = StatusFinished
+		s.lastContentHash = ""
+		s.lastContentChangeAt = time.Time{}
+		log.Info("hook says waiting but pane shows idle prompt, overriding to finished")
+		return
+	}
+
 	s.Status = StatusWaiting
 	s.Acknowledged = false
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -390,10 +390,18 @@ func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, log *s
 	// - If user interrupts/escapes, no hook fires — pane override catches this
 	// - Content change detection below handles the gap if hooks are delayed
 	if paneStatus == StatusFinished {
-		s.Status = StatusFinished
+		prevStatus := s.Status
+		if s.Acknowledged {
+			s.Status = StatusIdle
+		} else {
+			s.Status = StatusFinished
+		}
 		s.lastContentHash = ""
 		s.lastContentChangeAt = time.Time{}
-		log.Info("hook says waiting but pane shows idle prompt, overriding to finished")
+		if prevStatus != s.Status {
+			log.Info("hook says waiting but pane shows idle prompt, overriding",
+				"newStatus", s.Status)
+		}
 		return
 	}
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestStripANSI(t *testing.T) {
@@ -64,88 +63,6 @@ func TestDetectStatus(t *testing.T) {
 			got := detectStatus(tt.content, log)
 			if got != tt.want {
 				t.Errorf("detectStatus(%q) = %q, want %q", tt.name, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestApplyHookWaiting_PaneOverride(t *testing.T) {
-	log := slog.Default()
-
-	tests := []struct {
-		name           string
-		acknowledged   bool
-		paneStatus     Status
-		wantStatus     Status
-		wantHashReset  bool
-		wantEarlyExit  bool // should return before content hash tracking
-	}{
-		{
-			name:          "pane finished overrides to finished",
-			acknowledged:  false,
-			paneStatus:    StatusFinished,
-			wantStatus:    StatusFinished,
-			wantHashReset: true,
-			wantEarlyExit: true,
-		},
-		{
-			name:          "pane finished with acknowledged overrides to idle",
-			acknowledged:  true,
-			paneStatus:    StatusFinished,
-			wantStatus:    StatusIdle,
-			wantHashReset: true,
-			wantEarlyExit: true,
-		},
-		{
-			name:         "pane waiting keeps waiting",
-			acknowledged: false,
-			paneStatus:   StatusWaiting,
-			wantStatus:   StatusWaiting,
-		},
-		{
-			name:         "pane running keeps waiting",
-			acknowledged: false,
-			paneStatus:   StatusRunning,
-			wantStatus:   StatusWaiting,
-		},
-		{
-			name:         "empty pane status keeps waiting",
-			acknowledged: false,
-			paneStatus:   "",
-			wantStatus:   StatusWaiting,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Session{
-				Status:              StatusWaiting,
-				Acknowledged:        tt.acknowledged,
-				lastContentHash:     "somehash",
-				lastContentChangeAt: time.Now(),
-			}
-
-			// Use empty pane content for non-override cases to avoid
-			// content change detection interfering with the test.
-			paneContent := ""
-			if tt.wantHashReset {
-				paneContent = "some pane content"
-			}
-
-			s.mu.Lock()
-			s.applyHookWaiting(paneContent, tt.paneStatus, log)
-			s.mu.Unlock()
-
-			if s.Status != tt.wantStatus {
-				t.Errorf("Status = %q, want %q", s.Status, tt.wantStatus)
-			}
-			if tt.wantHashReset {
-				if s.lastContentHash != "" {
-					t.Errorf("lastContentHash should be reset, got %q", s.lastContentHash)
-				}
-				if !s.lastContentChangeAt.IsZero() {
-					t.Errorf("lastContentChangeAt should be zero, got %v", s.lastContentChangeAt)
-				}
 			}
 		})
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStripANSI(t *testing.T) {
@@ -63,6 +64,88 @@ func TestDetectStatus(t *testing.T) {
 			got := detectStatus(tt.content, log)
 			if got != tt.want {
 				t.Errorf("detectStatus(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyHookWaiting_PaneOverride(t *testing.T) {
+	log := slog.Default()
+
+	tests := []struct {
+		name           string
+		acknowledged   bool
+		paneStatus     Status
+		wantStatus     Status
+		wantHashReset  bool
+		wantEarlyExit  bool // should return before content hash tracking
+	}{
+		{
+			name:          "pane finished overrides to finished",
+			acknowledged:  false,
+			paneStatus:    StatusFinished,
+			wantStatus:    StatusFinished,
+			wantHashReset: true,
+			wantEarlyExit: true,
+		},
+		{
+			name:          "pane finished with acknowledged overrides to idle",
+			acknowledged:  true,
+			paneStatus:    StatusFinished,
+			wantStatus:    StatusIdle,
+			wantHashReset: true,
+			wantEarlyExit: true,
+		},
+		{
+			name:         "pane waiting keeps waiting",
+			acknowledged: false,
+			paneStatus:   StatusWaiting,
+			wantStatus:   StatusWaiting,
+		},
+		{
+			name:         "pane running keeps waiting",
+			acknowledged: false,
+			paneStatus:   StatusRunning,
+			wantStatus:   StatusWaiting,
+		},
+		{
+			name:         "empty pane status keeps waiting",
+			acknowledged: false,
+			paneStatus:   "",
+			wantStatus:   StatusWaiting,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Session{
+				Status:              StatusWaiting,
+				Acknowledged:        tt.acknowledged,
+				lastContentHash:     "somehash",
+				lastContentChangeAt: time.Now(),
+			}
+
+			// Use empty pane content for non-override cases to avoid
+			// content change detection interfering with the test.
+			paneContent := ""
+			if tt.wantHashReset {
+				paneContent = "some pane content"
+			}
+
+			s.mu.Lock()
+			s.applyHookWaiting(paneContent, tt.paneStatus, log)
+			s.mu.Unlock()
+
+			if s.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", s.Status, tt.wantStatus)
+			}
+			if tt.wantHashReset {
+				if s.lastContentHash != "" {
+					t.Errorf("lastContentHash should be reset, got %q", s.lastContentHash)
+				}
+				if !s.lastContentChangeAt.IsZero() {
+					t.Errorf("lastContentChangeAt should be zero, got %v", s.lastContentChangeAt)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- When a user interrupts/escapes a PermissionRequest, no hook fires to clear the "waiting" state — the session gets stuck at "waiting" forever
- Fix: allow pane detection to override waiting→finished when the pane shows the idle `❯` prompt
- Safe because `detectWaiting` runs before `detectFinished` in the pipeline, so a real permission prompt always yields `StatusWaiting`, not `StatusFinished`

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [ ] Manually verify: start a session, trigger a PermissionRequest, interrupt with Ctrl+C — status should transition from waiting to finished within ~2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)