### PR TITLE
feat(diagnostics): Add rendering & terminal diagnostics for scroll issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Terminal environment and rendering stats in bug reports to help diagnose scroll/rendering issues
+
 ## [1.1.0] - 2026-03-21
 
 ### Added

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -27,6 +27,26 @@ type Report struct {
 	RecentErrors  []string // pre-formatted from ErrorHistory
 	RecentActions []string // pre-formatted from ActionLog
 	RecentLogs    string   // last 100 lines of debug.log
+
+	// Terminal environment (helps diagnose rendering/scrolling issues).
+	TerminalEnv TerminalEnv
+	TUIWidth    int // Bubble Tea reported width
+	TUIHeight   int // Bubble Tea reported height
+}
+
+// TerminalEnv captures terminal-related environment and settings.
+type TerminalEnv struct {
+	TERM               string
+	TermProgram        string // $TERM_PROGRAM (e.g. iTerm2, Apple_Terminal, tmux)
+	TermProgramVersion string // $TERM_PROGRAM_VERSION
+	ColorTerm          string // $COLORTERM (e.g. truecolor)
+	Lang               string // $LANG
+	LCAll              string // $LC_ALL
+	InsideTmux         bool   // $TMUX is set (nested tmux)
+	InsideSSH          bool   // $SSH_TTY or $SSH_CLIENT is set
+	TmuxDefaultTerm    string // tmux show-option -gv default-terminal
+	TmuxMouse          string // tmux show-option -gv mouse
+	SttySize           string // rows x cols from stty
 }
 
 // Collect gathers system diagnostics.
@@ -44,10 +64,35 @@ func Collect(version string, sessionCount int) *Report {
 	r.ClaudeVersion = runCmd("claude", "--version")
 	r.GhVersion = firstLine(runCmd("gh", "--version"))
 
+	r.TerminalEnv = collectTerminalEnv()
+
 	r.Config = readConfig()
 	r.RecentLogs = readRecentLogs(100)
 
 	return r
+}
+
+// collectTerminalEnv gathers terminal-related environment variables and tmux settings.
+func collectTerminalEnv() TerminalEnv {
+	env := TerminalEnv{
+		TERM:               os.Getenv("TERM"),
+		TermProgram:        os.Getenv("TERM_PROGRAM"),
+		TermProgramVersion: os.Getenv("TERM_PROGRAM_VERSION"),
+		ColorTerm:          os.Getenv("COLORTERM"),
+		Lang:               os.Getenv("LANG"),
+		LCAll:              os.Getenv("LC_ALL"),
+		InsideTmux:         os.Getenv("TMUX") != "",
+		InsideSSH:          os.Getenv("SSH_TTY") != "" || os.Getenv("SSH_CLIENT") != "",
+	}
+
+	// Get terminal size via stty.
+	env.SttySize = runCmd("stty", "size")
+
+	// Get tmux global settings relevant to rendering.
+	env.TmuxDefaultTerm = runCmd("tmux", "show-option", "-gv", "default-terminal")
+	env.TmuxMouse = runCmd("tmux", "show-option", "-gv", "mouse")
+
+	return env
 }
 
 // FormatMarkdownWithDesc formats the report with a user-provided description.
@@ -117,6 +162,46 @@ func (r *Report) formatMarkdown(description string) string {
 		fmt.Fprintf(&b, "- **gh CLI**: %s\n", r.GhVersion)
 	}
 	fmt.Fprintf(&b, "- **Sessions**: %d\n", r.SessionCount)
+	b.WriteString("\n")
+
+	// Terminal environment.
+	te := r.TerminalEnv
+	b.WriteString("### Terminal Environment\n")
+	fmt.Fprintf(&b, "- **TERM**: `%s`\n", te.TERM)
+	if te.TermProgram != "" {
+		ver := te.TermProgram
+		if te.TermProgramVersion != "" {
+			ver += " " + te.TermProgramVersion
+		}
+		fmt.Fprintf(&b, "- **Terminal**: %s\n", ver)
+	}
+	if te.ColorTerm != "" {
+		fmt.Fprintf(&b, "- **COLORTERM**: %s\n", te.ColorTerm)
+	}
+	if te.SttySize != "" {
+		fmt.Fprintf(&b, "- **stty size**: %s\n", te.SttySize)
+	}
+	if r.TUIWidth > 0 || r.TUIHeight > 0 {
+		fmt.Fprintf(&b, "- **TUI size**: %dx%d\n", r.TUIWidth, r.TUIHeight)
+	}
+	if te.Lang != "" {
+		fmt.Fprintf(&b, "- **LANG**: %s\n", te.Lang)
+	}
+	if te.LCAll != "" {
+		fmt.Fprintf(&b, "- **LC_ALL**: %s\n", te.LCAll)
+	}
+	if te.InsideTmux {
+		b.WriteString("- **Nested tmux**: yes ($TMUX is set)\n")
+	}
+	if te.InsideSSH {
+		b.WriteString("- **SSH session**: yes\n")
+	}
+	if te.TmuxDefaultTerm != "" {
+		fmt.Fprintf(&b, "- **tmux default-terminal**: `%s`\n", te.TmuxDefaultTerm)
+	}
+	if te.TmuxMouse != "" {
+		fmt.Fprintf(&b, "- **tmux mouse**: %s\n", te.TmuxMouse)
+	}
 	b.WriteString("\n")
 
 	// Debug logs.

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -46,7 +46,7 @@ type TerminalEnv struct {
 	InsideSSH          bool   // $SSH_TTY or $SSH_CLIENT is set
 	TmuxDefaultTerm    string // tmux show-option -gv default-terminal
 	TmuxMouse          string // tmux show-option -gv mouse
-	SttySize           string // rows x cols from stty
+	SttySize           string // rows cols from stty (space-separated)
 }
 
 // Collect gathers system diagnostics.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -710,10 +710,10 @@ func (h *Home) View() string {
 	}
 
 	// Pad to fill content area.
-	lines := strings.Count(b.String(), "\n") + 1
-	for lines < h.height-helpBarHeight {
+	lineCount := strings.Count(b.String(), "\n") + 1
+	for lineCount < h.height-helpBarHeight {
 		b.WriteString("\n")
-		lines++
+		lineCount++
 	}
 
 	// Focus mode bar / Filter bar / Help bar.
@@ -723,41 +723,43 @@ func (h *Home) View() string {
 		b.WriteString(border + "\n")
 		b.WriteString(" " + HelpKeyStyle.Render("esc") + " " + HelpDescStyle.Render("Unfocus") + "  " +
 			DimStyle.Render("all keys forwarded to session"))
+		lineCount += 2 // border + shortcut line
 	} else if h.filterActive {
 		border := lipgloss.NewStyle().Foreground(ColorBorder).Render(strings.Repeat("─", h.width))
 		b.WriteString("\n")
 		b.WriteString(border + "\n")
 		b.WriteString(" " + HelpKeyStyle.Render("/") + " " + h.filterInput.View())
+		lineCount += 2
 	} else if h.filterText != "" {
 		// Show active filter indicator even when not typing.
 		border := lipgloss.NewStyle().Foreground(ColorBorder).Render(strings.Repeat("─", h.width))
 		b.WriteString("\n")
 		b.WriteString(border + "\n")
 		b.WriteString(" " + HelpKeyStyle.Render("/") + " " + DimStyle.Render(h.filterText) + "  " + DimStyle.Render("(/ to edit, esc to clear)"))
+		lineCount += 2
 	} else {
-		// Help bar.
+		// Help bar (border + "\n " + shortcuts = 2 lines).
 		b.WriteString("\n")
 		b.WriteString(h.renderHelpBar())
+		lineCount += 2
 	}
 
 	// Error message (overwrites last line if present).
 	if h.err != nil && time.Since(h.errTime) < 5*time.Second {
 		b.WriteString("\n")
 		b.WriteString(ErrorStyle.Render(" " + h.err.Error()))
+		lineCount++
 	}
 
-	output := b.String()
-
 	// Track height mismatches (counter for bug report, log only on first occurrence).
-	outputLines := strings.Count(output, "\n") + 1
-	if h.height > 0 && outputLines != h.height {
-		diff := outputLines - h.height
+	// Uses incremental lineCount instead of re-scanning the output.
+	if h.height > 0 && lineCount != h.height {
+		diff := lineCount - h.height
 		prevCount := h.renderStats.HeightMismatchCount
 		h.renderStats.RecordHeightMismatch(diff)
-		// Log only the first mismatch to avoid spam.
 		if prevCount == 0 {
 			debuglog.Logger.Warn("View height mismatch detected",
-				"output_lines", outputLines,
+				"output_lines", lineCount,
 				"expected", h.height,
 				"diff", diff,
 				"layout", h.layoutMode(),
@@ -765,7 +767,7 @@ func (h *Home) View() string {
 		}
 	}
 
-	return output
+	return b.String()
 }
 
 // --- Key handling ---

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -147,6 +147,9 @@ type Home struct {
 	workerStarted bool
 
 	startTime time.Time // app start time for uptime tracking
+
+	// Rendering diagnostics (accumulated counters for bug reports).
+	renderStats RenderStats
 }
 
 // NewHome creates the main TUI model.
@@ -204,6 +207,15 @@ func (h *Home) Init() tea.Cmd {
 func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		h.renderStats.RecordResize(msg.Width, msg.Height)
+		// Only log resizes after the initial one (startup always sends one).
+		if h.width > 0 && (msg.Width != h.width || msg.Height != h.height) {
+			debuglog.Logger.Info("window resized",
+				"from", fmt.Sprintf("%dx%d", h.width, h.height),
+				"to", fmt.Sprintf("%dx%d", msg.Width, msg.Height),
+				"resize_count", h.renderStats.ResizeCount,
+			)
+		}
 		h.width = msg.Width
 		h.height = msg.Height
 		h.sidebarDirty = true
@@ -734,7 +746,26 @@ func (h *Home) View() string {
 		b.WriteString(ErrorStyle.Render(" " + h.err.Error()))
 	}
 
-	return b.String()
+	output := b.String()
+
+	// Track height mismatches (counter for bug report, log only on first occurrence).
+	outputLines := strings.Count(output, "\n") + 1
+	if h.height > 0 && outputLines != h.height {
+		diff := outputLines - h.height
+		prevCount := h.renderStats.HeightMismatchCount
+		h.renderStats.RecordHeightMismatch(diff)
+		// Log only the first mismatch to avoid spam.
+		if prevCount == 0 {
+			debuglog.Logger.Warn("View height mismatch detected",
+				"output_lines", outputLines,
+				"expected", h.height,
+				"diff", diff,
+				"layout", h.layoutMode(),
+			)
+		}
+	}
+
+	return output
 }
 
 // --- Key handling ---
@@ -964,7 +995,7 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 	case "!":
 		h.actionLog.Add("open bug report", "", true)
-		h.bugReport.Show(h.version, len(h.sessions), h.errorHistory, h.actionLog)
+		h.bugReport.Show(h.version, len(h.sessions), h.errorHistory, h.actionLog, h.width, h.height, &h.renderStats, time.Since(h.startTime))
 		analytics.Track(analytics.EventBugReportOpened, nil)
 		return h, nil
 	case "?":
@@ -2016,12 +2047,16 @@ func (h *Home) syncViewport() {
 	if contentHeight < 1 {
 		contentHeight = 1
 	}
+	prevOffset := h.viewOffset
 	// Scroll to keep cursor visible.
 	if h.cursor < h.viewOffset {
 		h.viewOffset = h.cursor
 	}
 	if h.cursor >= h.viewOffset+contentHeight {
 		h.viewOffset = h.cursor - contentHeight + 1
+	}
+	if h.viewOffset != prevOffset {
+		h.renderStats.RecordViewportDrift()
 	}
 }
 

--- a/internal/ui/bugreport.go
+++ b/internal/ui/bugreport.go
@@ -29,6 +29,7 @@ type BugReportDialog struct {
 
 	descInput     textinput.Model
 	report        *diagnostics.Report
+	renderStats   string // pre-formatted render stats markdown
 	errorEntries  []ErrorEntry
 	actionEntries []ActionEntry
 	contentLines  int // total rendered content lines
@@ -45,7 +46,7 @@ func NewBugReportDialog() *BugReportDialog {
 }
 
 // Show collects diagnostics and shows the dialog.
-func (d *BugReportDialog) Show(version string, sessionCount int, errors *ErrorHistory, actions *ActionLog) {
+func (d *BugReportDialog) Show(version string, sessionCount int, errors *ErrorHistory, actions *ActionLog, tuiWidth, tuiHeight int, rs *RenderStats, uptime time.Duration) {
 	d.visible = true
 	d.scroll = 0
 	d.submitting = false
@@ -53,6 +54,9 @@ func (d *BugReportDialog) Show(version string, sessionCount int, errors *ErrorHi
 	d.descInput.Focus()
 
 	d.report = diagnostics.Collect(version, sessionCount)
+	d.report.TUIWidth = tuiWidth
+	d.report.TUIHeight = tuiHeight
+	d.renderStats = rs.FormatMarkdown(uptime)
 	d.errorEntries = errors.Entries()
 	d.actionEntries = actions.Entries()
 
@@ -107,8 +111,11 @@ func (d *BugReportDialog) openGitHubIssue(description string) tea.Cmd {
 	// Build title from description, truncated.
 	title := truncate(description, 60)
 
-	// Inject user description into the report.
+	// Inject user description and render stats into the report.
 	body := d.report.FormatMarkdownWithDesc(description)
+	if d.renderStats != "" {
+		body += "\n" + d.renderStats
+	}
 
 	return func() tea.Msg {
 		debuglog.Logger.Info("bug report: creating GitHub issue via API")

--- a/internal/ui/bugreport.go
+++ b/internal/ui/bugreport.go
@@ -56,7 +56,11 @@ func (d *BugReportDialog) Show(version string, sessionCount int, errors *ErrorHi
 	d.report = diagnostics.Collect(version, sessionCount)
 	d.report.TUIWidth = tuiWidth
 	d.report.TUIHeight = tuiHeight
-	d.renderStats = rs.FormatMarkdown(uptime)
+	if rs != nil {
+		d.renderStats = rs.FormatMarkdown(uptime)
+	} else {
+		d.renderStats = ""
+	}
 	d.errorEntries = errors.Entries()
 	d.actionEntries = actions.Entries()
 

--- a/internal/ui/renderstats.go
+++ b/internal/ui/renderstats.go
@@ -63,9 +63,9 @@ func (rs *RenderStats) FormatMarkdown(uptime time.Duration) string {
 	b.WriteString("\n")
 
 	// Flag suspicious patterns.
-	if uptime > 0 {
+	if uptime >= time.Minute {
 		resizesPerMin := float64(rs.ResizeCount) / uptime.Minutes()
-		if resizesPerMin > 10 {
+		if resizesPerMin > 1 {
 			fmt.Fprintf(&b, "- **WARNING**: %.0f resizes/min (expected <1)\n", resizesPerMin)
 		}
 	}

--- a/internal/ui/renderstats.go
+++ b/internal/ui/renderstats.go
@@ -1,0 +1,87 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// RenderStats accumulates rendering-related events for diagnostics.
+// Instead of logging every event (which would spam the debug log),
+// counters are tracked and dumped into the bug report.
+type RenderStats struct {
+	// Window resize tracking.
+	ResizeCount    int       // total WindowSizeMsg events received
+	LastResizeTime time.Time // when the last resize happened
+	LastResizeW    int       // last resize width
+	LastResizeH    int       // last resize height
+
+	// Viewport drift tracking.
+	ViewportDriftCount int // times viewOffset changed in syncViewport
+
+	// Height mismatch tracking.
+	HeightMismatchCount int // total View() calls where output lines != h.height
+	LastMismatchDiff    int // last observed diff (output_lines - expected)
+}
+
+// RecordResize records a WindowSizeMsg event.
+func (rs *RenderStats) RecordResize(w, h int) {
+	rs.ResizeCount++
+	rs.LastResizeTime = time.Now()
+	rs.LastResizeW = w
+	rs.LastResizeH = h
+}
+
+// RecordViewportDrift records a viewOffset change in syncViewport.
+func (rs *RenderStats) RecordViewportDrift() {
+	rs.ViewportDriftCount++
+}
+
+// RecordHeightMismatch records a View() height mismatch.
+func (rs *RenderStats) RecordHeightMismatch(diff int) {
+	rs.HeightMismatchCount++
+	rs.LastMismatchDiff = diff
+}
+
+// FormatMarkdown formats the render stats for the bug report.
+func (rs *RenderStats) FormatMarkdown(uptime time.Duration) string {
+	var b strings.Builder
+
+	b.WriteString("### Rendering Stats\n")
+	fmt.Fprintf(&b, "- **Uptime**: %s\n", formatDuration(uptime))
+	fmt.Fprintf(&b, "- **Window resizes**: %d", rs.ResizeCount)
+	if rs.ResizeCount > 0 {
+		ago := time.Since(rs.LastResizeTime)
+		fmt.Fprintf(&b, " (last: %dx%d, %s ago)", rs.LastResizeW, rs.LastResizeH, formatDuration(ago))
+	}
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "- **Viewport offset changes**: %d\n", rs.ViewportDriftCount)
+	fmt.Fprintf(&b, "- **View height mismatches**: %d", rs.HeightMismatchCount)
+	if rs.HeightMismatchCount > 0 {
+		fmt.Fprintf(&b, " (last diff: %+d lines)", rs.LastMismatchDiff)
+	}
+	b.WriteString("\n")
+
+	// Flag suspicious patterns.
+	if uptime > 0 {
+		resizesPerMin := float64(rs.ResizeCount) / uptime.Minutes()
+		if resizesPerMin > 10 {
+			fmt.Fprintf(&b, "- **WARNING**: %.0f resizes/min (expected <1)\n", resizesPerMin)
+		}
+	}
+	if rs.HeightMismatchCount > 0 {
+		b.WriteString("- **WARNING**: View height mismatches detected — likely cause of scroll drift\n")
+	}
+
+	return b.String()
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm%ds", int(d.Minutes()), int(d.Seconds())%60)
+	}
+	return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
+}


### PR DESCRIPTION
## Summary
- Add **Terminal Environment** section to bug reports: TERM, terminal app, stty vs TUI size, nested tmux/SSH detection, tmux mouse/default-terminal settings
- Add **Rendering Stats** section: window resize count (with rate warning), viewport drift count, View height mismatch count — all accumulated as counters (zero log spam in normal operation)
- Add targeted debug logging: window resize (only on actual size change), first height mismatch occurrence
- Pass TUI dimensions to diagnostics for stty vs Bubble Tea size comparison

## Context
Users reported a bug where "every keypress makes the screen scroll up" — the UI slowly drifts away. This is hard to reproduce. These diagnostics will help identify the root cause next time it's reported via the `!` bug report dialog.

## Test plan
- [ ] Run `make build` — compiles clean
- [ ] Launch TUI, navigate with j/k — verify no new log entries in `~/.config/brizz-code/debug.log`
- [ ] Press `!` to open bug report — verify Terminal Environment and Rendering Stats sections appear
- [ ] Resize terminal window — verify resize is logged once in debug.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)