### PR TITLE
fix(ui): prevent bug report dialog freeze when gh CLI is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bug report dialog freezing permanently when `gh` CLI is not installed
 - Session stuck at "waiting" status after user interrupts/escapes a permission prompt
 
 ## [1.1.0] - 2026-03-21

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -332,6 +332,7 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case bugReportOpenErrMsg:
+		h.bugReport.submitting = false
 		h.setError(msg.err)
 		return h, nil
 

--- a/internal/ui/bugreport.go
+++ b/internal/ui/bugreport.go
@@ -109,7 +109,7 @@ func (d *BugReportDialog) Update(msg tea.Msg) (*BugReportDialog, tea.Cmd) {
 
 func (d *BugReportDialog) openGitHubIssue(description string) tea.Cmd {
 	if _, err := exec.LookPath("gh"); err != nil {
-		return nil
+		return func() tea.Msg { return bugReportOpenErrMsg{err: fmt.Errorf("gh CLI not found")} }
 	}
 
 	// Build title from description, truncated.

--- a/internal/ui/bugreport_test.go
+++ b/internal/ui/bugreport_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestBugReportDialog_EnterWithGhMissing_ReturnsCmd(t *testing.T) {
+	d := NewBugReportDialog()
+	d.visible = true
+	d.descInput.SetValue("something broke")
+
+	_, cmd := d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd when gh is missing, got nil (dialog would freeze)")
+	}
+	if !d.submitting {
+		t.Fatal("expected submitting to be true after enter")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(bugReportOpenErrMsg); !ok {
+		t.Fatalf("expected bugReportOpenErrMsg, got %T", msg)
+	}
+}
+
+func TestBugReportDialog_EnterWithEmptyDesc_Noop(t *testing.T) {
+	d := NewBugReportDialog()
+	d.visible = true
+	d.descInput.SetValue("")
+
+	_, cmd := d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if cmd != nil {
+		t.Fatal("expected nil cmd for empty description")
+	}
+	if d.submitting {
+		t.Fatal("submitting should stay false for empty description")
+	}
+}
+
+func TestBugReportDialog_EnterWhileSubmitting_Noop(t *testing.T) {
+	d := NewBugReportDialog()
+	d.visible = true
+	d.submitting = true
+	d.descInput.SetValue("something broke")
+
+	_, cmd := d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if cmd != nil {
+		t.Fatal("expected nil cmd while already submitting")
+	}
+}
+
+func TestBugReportDialog_Esc_Hides(t *testing.T) {
+	d := NewBugReportDialog()
+	d.visible = true
+	d.submitting = true
+
+	_, cmd := d.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if d.visible {
+		t.Fatal("expected dialog to be hidden after esc")
+	}
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from esc")
+	}
+	msg := cmd()
+	if _, ok := msg.(bugReportClosedMsg); !ok {
+		t.Fatalf("expected bugReportClosedMsg, got %T", msg)
+	}
+}

--- a/internal/ui/bugreport_test.go
+++ b/internal/ui/bugreport_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestBugReportDialog_EnterWithGhMissing_ReturnsCmd(t *testing.T) {
+	// Ensure gh is not found regardless of the test environment.
+	t.Setenv("PATH", t.TempDir())
+
 	d := NewBugReportDialog()
 	d.visible = true
 	d.descInput.SetValue("something broke")


### PR DESCRIPTION
openGitHubIssue returned nil when gh was not installed, leaving submitting=true permanently and freezing the dialog. Return a proper bugReportOpenErrMsg instead, and clear submitting on error so the dialog stays usable.

## Summary

When the `gh` CLI is not installed, pressing Enter in the bug report dialog sets `submitting = true` but `openGitHubIssue` returns `nil` - no `tea.Cmd` runs, no message is sent back, and the dialog is permanently frozen (can't type, can't submit, only Esc works).

**Two fixes:**
- **`bugreport.go`**: `openGitHubIssue` now returns a `bugReportOpenErrMsg` when `gh` is missing instead of `nil`
- **`app.go`**: the `bugReportOpenErrMsg` handler now clears `submitting` so the dialog unfreezes (also fixes the case where `gh` exists but the API call fails mid-flight)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] Documentation updated (if applicable)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (if user-facing change)

## Test plan
- [x] \`TestBugReportDialog_EnterWithGhMissing_ReturnsCmd\` — core regression test
- [x] \`TestBugReportDialog_EnterWithEmptyDesc_Noop\` — empty description does nothing
- [x] \`TestBugReportDialog_EnterWhileSubmitting_Noop\` — double-submit guard
- [x] \`TestBugReportDialog_Esc_Hides\` — Esc always works, even while submitting