### PR TITLE
fix(ui): clean up temp file on bug report write failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session stuck at "waiting" status after user interrupts/escapes a permission prompt
 - Agent team sessions showing idle/running instead of waiting when sub-agent needs approval
 - Status oscillating between idle and finished when stale waiting hook is present
+- Temp file not cleaned up when bug report body write fails
 
 ## [1.1.0] - 2026-03-21
 

--- a/internal/ui/bugreport.go
+++ b/internal/ui/bugreport.go
@@ -130,12 +130,12 @@ func (d *BugReportDialog) openGitHubIssue(description string) tea.Cmd {
 			debuglog.Logger.Error("bug report: failed to create temp file", "err", err)
 			return bugReportOpenErrMsg{err: err}
 		}
+		defer os.Remove(tmpFile.Name())
 		if _, err := tmpFile.WriteString(body); err != nil {
 			tmpFile.Close()
 			return bugReportOpenErrMsg{err: err}
 		}
 		tmpFile.Close()
-		defer os.Remove(tmpFile.Name())
 
 		// Create issue via API (no URL length limit), then open in browser.
 		cmd := exec.Command("gh", "issue", "create",


### PR DESCRIPTION
## Summary

- Fix temp file leak in `openGitHubIssue` when `WriteString` fails: `defer os.Remove()` was registered after the write check, so an early return would skip cleanup. Moved it to right after `CreateTemp` succeeds.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] Documentation updated (if applicable)
- [x] `CHANGELOG.md` updated under `[Unreleased]` (if user-facing change)

## Test plan
- [x] Code review — the fix is a one-line move, easy to verify by inspection