### PR TITLE
fix(docs): update PR template to reference changelog fragments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,4 @@
 - [ ] Linter passes (`make lint`)
 - [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
 - [ ] Documentation updated (if applicable)
-- [ ] `CHANGELOG.md` updated under `[Unreleased]` (if user-facing change)
+- [ ] Changelog fragment added in `changelog/unreleased/` (if user-facing change; see `changelog/README.md`)


### PR DESCRIPTION
## Summary

- PR checklist still told contributors to edit `CHANGELOG.md` directly, but we switched to fragment-based changelogs (`changelog/unreleased/`). This caused confusion in #45.

## Test plan

- [x] Visual inspection of the template change

🤖 Generated with [Claude Code](https://claude.com/claude-code)