### PR TITLE
feat(ui): RTS-style session hotkeys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Status: Running, Waiting, Finished, Idle, Error, Starting
 - Status icons: ● (running/finished), ◐ (waiting), ○ (idle/starting), ✕ (error)
 - Keybindings: j/k nav, Enter attach, Space jump to next waiting/finished, a new session (instant, repo-scoped), n new session (any repo, path autocomplete), w new worktree session (base branch + new branch), d delete (Y to also destroy workspace), r restart, R rename, e editor, p open PR in browser, Y quick approve (waiting sessions), / filter, : or Ctrl+P command palette, S settings, ! bug report/diagnostics, ? help, q quit
+- Session hotkeys (RTS-style): `Alt+0-9` (or `=` then digit) binds the selected session to a slot; plain `0-9` jumps to the bound session (double-tap within 400ms also attaches); `[N]` badge in sidebar marks bound sessions; bindings persist in SQLite `slot_bindings` table (FK cascade on session delete)
 - Command palette (: / Ctrl+P): fuzzy-searchable list of all actions; palette-only commands include "Reload All Sessions" (restarts all dead/error sessions)
 - Tmux status bar configured per session with detach hint (ctrl+q)
 - Attach uses PTY with Ctrl+Q intercept for clean detach (creack/pty + golang.org/x/term)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Status: Running, Waiting, Finished, Idle, Error, Starting
 - Status icons: ● (running/finished), ◐ (waiting), ○ (idle/starting), ✕ (error)
 - Keybindings: j/k nav, Enter attach, Space jump to next waiting/finished, a new session (instant, repo-scoped), n new session (any repo, path autocomplete), w new worktree session (base branch + new branch), d delete (Y to also destroy workspace), r restart, R rename, e editor, p open PR in browser, Y quick approve (waiting sessions), / filter, : or Ctrl+P command palette, S settings, ! bug report/diagnostics, ? help, q quit
-- Session hotkeys (RTS-style): `Alt+0-9` (or `=` then digit) binds the selected session to a slot; plain `0-9` jumps to the bound session (double-tap within 400ms also attaches); `[N]` badge in sidebar marks bound sessions; bindings persist in SQLite `slot_bindings` table (FK cascade on session delete)
+- Session hotkeys (RTS-style): `Alt+0-9` (or `=` then digit) binds the selected session to a slot; re-pressing `Alt+<N>` on a session already in slot N unbinds; `==` then digit clears any slot; plain `0-9` jumps to the bound session (double-tap within 400ms also attaches); `[N]` badge in sidebar marks bound sessions; bindings persist in SQLite `slot_bindings` table (FK cascade on session delete)
 - Command palette (: / Ctrl+P): fuzzy-searchable list of all actions; palette-only commands include "Reload All Sessions" (restarts all dead/error sessions)
 - Tmux status bar configured per session with detach hint (ctrl+q)
 - Attach uses PTY with Ctrl+Q intercept for clean detach (creack/pty + golang.org/x/term)

--- a/changelog/unreleased/fix-hook-finished-oscillation.md
+++ b/changelog/unreleased/fix-hook-finished-oscillation.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Status detection: sessions with `hook=finished` no longer flap between "running" and "finished" during active sub-agent work. `applyHookFinished` now corroborates pane-detected "finished" with tmux window activity — if the pane was written to in the last 3 seconds, hold the previous state instead of flipping.

--- a/changelog/unreleased/fix-permission-menu-cursor.md
+++ b/changelog/unreleased/fix-permission-menu-cursor.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Status detection: permission menus where the cursor is on option 2 or 3 (not just option 1) are now correctly detected as "waiting" instead of flipping the session to idle.

--- a/changelog/unreleased/fix-subagent-up-arrow-running.md
+++ b/changelog/unreleased/fix-subagent-up-arrow-running.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Status detection: sessions running Explore sub-agents (with the `· ↑ tokens` output counter) stay marked as "running" instead of collapsing to "idle" when a stale waiting hook is in play.

--- a/changelog/unreleased/fix-whimsical-conversation-false-positive.md
+++ b/changelog/unreleased/fix-whimsical-conversation-false-positive.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Status detection: idle sessions no longer get stuck at "running" when their scrollback contains text that mentions the whimsical token counter (e.g. commit messages or docs referencing `· ↓`/`· ↑` + `tokens`).

--- a/changelog/unreleased/session-hotkeys.md
+++ b/changelog/unreleased/session-hotkeys.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+RTS-style session hotkeys: bind the selected session to a numbered slot with `Alt+0-9` (or `=` then a digit), jump with plain `0-9`, double-tap within 400ms to also attach. Bound sessions show a `[N]` badge in the sidebar and persist across restarts.

--- a/changelog/unreleased/session-hotkeys.md
+++ b/changelog/unreleased/session-hotkeys.md
@@ -1,4 +1,4 @@
 ---
 type: added
 ---
-RTS-style session hotkeys: bind the selected session to a numbered slot with `Alt+0-9` (or `=` then a digit), jump with plain `0-9`, double-tap within 400ms to also attach. Bound sessions show a `[N]` badge in the sidebar and persist across restarts.
+RTS-style session hotkeys: bind the selected session to a numbered slot with `Alt+0-9` (or `=` then a digit), jump with plain `0-9`, double-tap within 400ms to also attach. Unbind by re-pressing `Alt+<N>` on the already-bound session, or `==` then the digit to clear any slot. Bound sessions show a `[N]` badge in the sidebar and persist across restarts.

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/rmhubbert/bubbletea-overlay v0.6.6 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,10 +60,13 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rmhubbert/bubbletea-overlay v0.6.6 h1:hDs8EuQdQRb+ti1zRsRSm4YUCnwD8fQcGCrGbqrwjQA=
+github.com/rmhubbert/bubbletea-overlay v0.6.6/go.mod h1:EI4cLG6YAA7GIHTKOpf9yYijDEZuI6Iuw/IIIWLaYoo=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 h1:jiDhWWeC7jfWqR9c/uplMOqJ0sbNlNWv0UkzE0vX1MA=

--- a/internal/session/golden_test.go
+++ b/internal/session/golden_test.go
@@ -27,6 +27,7 @@ var goldenTests = []struct {
 	{"pane_running_subagent_spelunking_up_arrow.txt", StatusRunning, "sub-agent (Explore) with whimsical `· ↑ tokens` output counter"},
 	{"pane_finished_idle_prompt.txt", StatusFinished, "idle Claude prompt (❯)"},
 	{"pane_finished_permission_mode.txt", StatusFinished, "permission mode bar (⏵⏵)"},
+	{"pane_finished_conversation_whimsical_markers.txt", StatusFinished, "idle pane with scrollback text mentioning `· ↓`/`· ↑` + `tokens` (meta false-positive guard)"},
 }
 
 func TestGoldenDetection(t *testing.T) {

--- a/internal/session/golden_test.go
+++ b/internal/session/golden_test.go
@@ -24,6 +24,7 @@ var goldenTests = []struct {
 }{
 	{"pane_waiting_permission_3opt.txt", StatusWaiting, "3-option permission menu with Esc to cancel"},
 	{"pane_waiting_permission_cursor_opt2.txt", StatusWaiting, "permission menu with cursor on option 2 (not option 1)"},
+	{"pane_running_subagent_spelunking_up_arrow.txt", StatusRunning, "sub-agent (Explore) with whimsical `· ↑ tokens` output counter"},
 	{"pane_finished_idle_prompt.txt", StatusFinished, "idle Claude prompt (❯)"},
 	{"pane_finished_permission_mode.txt", StatusFinished, "permission mode bar (⏵⏵)"},
 }

--- a/internal/session/golden_test.go
+++ b/internal/session/golden_test.go
@@ -23,6 +23,7 @@ var goldenTests = []struct {
 	desc     string // what this fixture tests
 }{
 	{"pane_waiting_permission_3opt.txt", StatusWaiting, "3-option permission menu with Esc to cancel"},
+	{"pane_waiting_permission_cursor_opt2.txt", StatusWaiting, "permission menu with cursor on option 2 (not option 1)"},
 	{"pane_finished_idle_prompt.txt", StatusFinished, "idle Claude prompt (❯)"},
 	{"pane_finished_permission_mode.txt", StatusFinished, "permission mode bar (⏵⏵)"},
 }

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -359,6 +359,45 @@ func TestScenarioOverriddenWaitingResumesOnSpinner(t *testing.T) {
 	})
 }
 
+func TestScenarioRealANSIPermissionCursorOnOption2(t *testing.T) {
+	// Regression: when the user moves the menu cursor off option 1, detectWaiting
+	// used to require "❯ 1." and failed. The pipeline then fell through to
+	// detectFinished which false-matched "❯ 2. …" as an idle prompt, flipping
+	// the acknowledged session to idle. Captured from snapshot
+	// 2026-04-13T12-36-25_brainstorm-conversation-cache-.
+	fixture := "pane_waiting_permission_cursor_opt2.txt"
+	if _, err := os.Stat(filepath.Join("testdata", fixture)); err != nil {
+		t.Skipf("fixture %s not available", fixture)
+	}
+
+	runScenario(t, Scenario{
+		Name: "permission menu, cursor on option 2: stays waiting across ticks",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "waiting", Pane: "@fixture:" + fixture},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusWaiting},
+			{At: 4 * time.Second, Expected: StatusWaiting},
+			{At: 8 * time.Second, Expected: StatusWaiting},
+		},
+	})
+}
+
+func TestScenarioPermissionCursorOnOption3(t *testing.T) {
+	// Plain-text counterpart for cursor-on-option-3 — no real ANSI fixture
+	// needed because detection runs on StripANSI'd content.
+	pane := "some output\nDo you want to proceed?\n  1. Yes\n  2. No, tell Claude\n❯ 3. Ask every time\nEsc to cancel\n"
+	runScenario(t, Scenario{
+		Name: "permission menu, cursor on option 3: detected as waiting",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "waiting", Pane: pane},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusWaiting},
+		},
+	})
+}
+
 func TestScenarioFinishedAutoResumeRunning(t *testing.T) {
 	runScenario(t, Scenario{
 		Name: "hook=finished but pane shows spinner → override to running",

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -398,6 +398,42 @@ func TestScenarioPermissionCursorOnOption3(t *testing.T) {
 	})
 }
 
+func TestScenarioStaleWaitingWithSubagentSpelunking(t *testing.T) {
+	// Regression: when a user approves a permission and Claude launches an
+	// Explore sub-agent, hooks stop firing. The pane shows active sub-agent
+	// work ("✳ Spelunking… (3m 14s · ↑ 1.8k tokens)"). Before the fix,
+	// detectRunning's whimsical check only matched `· ↓ tokens`, so the
+	// sub-agent activity line was ignored. Detection periodically returned
+	// Finished, applyHookWaiting's pane override fired, and the session
+	// (acknowledged) collapsed to idle.
+	//
+	// With `· ↑` matching, detection reliably returns Running on the
+	// spelunking fixture, so the override to finished never fires even
+	// when Acknowledged=true.
+	// Captured from snapshot 2026-04-13T18-03-40_align-button-figma-design-syst.
+	fixture := "pane_running_subagent_spelunking_up_arrow.txt"
+	if _, err := os.Stat(filepath.Join("testdata", fixture)); err != nil {
+		t.Skipf("fixture %s not available", fixture)
+	}
+
+	runScenario(t, Scenario{
+		Name: "stale waiting hook + acknowledged + sub-agent spelunking: transitions waiting→running, never idle",
+		Events: []ScenarioEvent{
+			// Waiting on permission prompt, user previously acknowledged the session.
+			{At: 0, Hook: "waiting", Pane: "permission prompt\n❯ 1. Yes\n  2. No\nEsc to cancel\n", Acknowledge: true},
+			// User approves; Claude launches Explore sub-agent. No new hook fires.
+			{At: 3 * time.Second, Pane: "@fixture:" + fixture},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusWaiting},
+			// Content changed while waiting AND pane shows whimsical running signal:
+			// must end up Running. Before the fix, pane detection would intermittently
+			// return Finished → Acknowledged collapsed it to Idle.
+			{At: 3 * time.Second, Expected: StatusRunning},
+		},
+	})
+}
+
 func TestScenarioFinishedAutoResumeRunning(t *testing.T) {
 	runScenario(t, Scenario{
 		Name: "hook=finished but pane shows spinner → override to running",

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -736,13 +736,17 @@ func detectRunning(recentLines []string, _ string, log *slog.Logger) Status {
 
 	// Whimsical activity pattern (Claude 2.1.25+: "Clauding… (53s · ↓ 749 tokens)"
 	// for inbound tokens, or "Spelunking… (3m 14s · ↑ 1.8k tokens)" for sub-agent
-	// output). Either arrow + "tokens" on the same line is durable running signal.
+	// output). The `tokens)` suffix anchors this to the parens-enclosed counter —
+	// conversation text that mentions `· ↓` / `· ↑` / `tokens` (e.g. commit messages,
+	// docs, or chat discussing this very detection) won't close with `tokens)`.
 	// Only check bottom 10 lines — the token counter line is always near the bottom.
 	whimsicalN := min(10, len(recentLines))
 	for _, line := range recentLines[:whimsicalN] {
-		lower := strings.ToLower(line)
-		if strings.Contains(lower, "tokens") && (strings.Contains(lower, "· ↓") || strings.Contains(lower, "· ↑")) {
-			log.Debug("detectStatus: matched whimsical activity pattern", "line", line)
+		trimmed := strings.TrimRight(line, " \t")
+		lower := strings.ToLower(trimmed)
+		if strings.HasSuffix(lower, "tokens)") &&
+			(strings.Contains(lower, "· ↓") || strings.Contains(lower, "· ↑")) {
+			log.Debug("detectStatus: matched whimsical activity pattern", "line", trimmed)
 			return StatusRunning
 		}
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -758,25 +758,26 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 	}
 
 	// Structural check: numbered permission menu.
-	// Requires three cues: a "❯ 1." line, a "2." line, AND "Esc to cancel"
-	// nearby. The Esc to cancel line only appears in Claude's interactive
-	// prompts, preventing false-positives from user input numbered lists.
-	hasMenu1 := false
-	hasMenu2 := false
+	// Requires three cues: a cursor-on-numbered-option line ("❯ N."), at least
+	// one other numbered option line, AND "Esc to cancel" nearby. The cursor
+	// may sit on any option (1, 2, 3…) depending on what the user has highlighted.
+	// Esc to cancel only appears in Claude's interactive prompts, preventing
+	// false-positives from user input numbered lists.
+	hasCursorOnOption := false
+	hasOtherOption := false
 	hasEscCancel := false
 	for i := 0; i < bottomN; i++ {
 		trimmed := strings.TrimSpace(recentLines[i])
-		if strings.HasPrefix(trimmed, "❯ 1.") {
-			hasMenu1 = true
-		}
-		if strings.HasPrefix(trimmed, "2.") {
-			hasMenu2 = true
+		if strings.HasPrefix(trimmed, "❯ ") && isNumberedMenuOption(strings.TrimPrefix(trimmed, "❯ ")) {
+			hasCursorOnOption = true
+		} else if isNumberedMenuOption(trimmed) {
+			hasOtherOption = true
 		}
 		if strings.Contains(strings.ToLower(trimmed), "esc to cancel") {
 			hasEscCancel = true
 		}
 	}
-	if hasMenu1 && hasMenu2 && hasEscCancel {
+	if hasCursorOnOption && hasOtherOption && hasEscCancel {
 		log.Debug("detectStatus: matched permission menu structure")
 		return StatusWaiting
 	}
@@ -805,6 +806,21 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 	return ""
 }
 
+// isNumberedMenuOption reports whether s starts with "<digits>.".
+// Used to distinguish permission-menu cursor lines ("❯ 2. Yes…") from
+// idle prompt lines ("❯ " or "❯ some user text").
+func isNumberedMenuOption(s string) bool {
+	sawDigit := false
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			sawDigit = true
+			continue
+		}
+		return sawDigit && r == '.'
+	}
+	return false
+}
+
 // detectFinished checks for prompt indicators and idle patterns.
 func detectFinished(recentLines []string, recentContent string, log *slog.Logger) Status {
 	if len(recentLines) == 0 {
@@ -816,6 +832,20 @@ func detectFinished(recentLines []string, recentContent string, log *slog.Logger
 	for i := 0; i < scanLimit; i++ {
 		line := strings.TrimSpace(recentLines[i])
 		if line == ">" || line == "❯" || strings.HasPrefix(line, "> ") || strings.HasPrefix(line, "❯ ") {
+			// Skip permission-menu cursor lines ("❯ 2. Yes…") — those are
+			// waiting state, not idle prompts. Defense-in-depth: detectWaiting
+			// should have caught these earlier, but if a new menu variant
+			// slips past it, we don't want to silently flip to finished.
+			remainder := line
+			switch {
+			case strings.HasPrefix(line, "❯ "):
+				remainder = strings.TrimPrefix(line, "❯ ")
+			case strings.HasPrefix(line, "> "):
+				remainder = strings.TrimPrefix(line, "> ")
+			}
+			if isNumberedMenuOption(remainder) {
+				continue
+			}
 			log.Debug("detectStatus: matched prompt", "line", line, "linesFromBottom", i)
 			return StatusFinished
 		}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -489,13 +489,39 @@ func (s *Session) applyHookFinished(paneStatus Status, log *slog.Logger) {
 		s.Status = StatusRunning
 		s.Acknowledged = false
 		log.Info("hook says finished but pane shows running, overriding")
-	} else if paneStatus == StatusWaiting {
+		return
+	}
+	if paneStatus == StatusWaiting {
 		// Hook says finished (e.g. parent Stop when delegating to sub-agent)
 		// but pane shows a permission prompt — sub-agent is waiting for approval.
 		s.Status = StatusWaiting
 		s.Acknowledged = false
 		log.Info("hook says finished but pane shows waiting, overriding")
-	} else if s.Acknowledged {
+		return
+	}
+	// Pane detection says "finished" or gave no signal. Before committing to
+	// that, corroborate with tmux window_activity: if the pane was written to
+	// in the last few seconds, Claude's TUI is actively rendering (spinner
+	// animation, sub-agent output bursts that briefly push the spinner line
+	// out of the recent-lines window). Hold the previous state instead of
+	// flipping, so a single-tick pane-detection miss doesn't cause idle/finished
+	// oscillation while Claude is actually working.
+	//
+	// This is only safe in the hook=finished path: here recent activity means
+	// "Claude is writing output", which argues against finished. In the
+	// hook=waiting path (see applyHookWaiting), activity can be sub-agent
+	// output while the permission prompt sits unanswered, so activity there
+	// can't distinguish "user approved" from "user still deciding".
+	if s.tmuxSession != nil {
+		if activity, ok := s.tmuxSession.GetActivity(); ok {
+			if time.Since(time.Unix(activity, 0)) < 3*time.Second {
+				log.Info("hook says finished, pane ambiguous/idle, but tmux activity <3s — holding state",
+					"paneStatus", paneStatus, "current", s.Status)
+				return
+			}
+		}
+	}
+	if s.Acknowledged {
 		s.Status = StatusIdle
 	} else {
 		s.Status = StatusFinished

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -734,12 +734,14 @@ func detectRunning(recentLines []string, _ string, log *slog.Logger) Status {
 		}
 	}
 
-	// Whimsical activity pattern (Claude 2.1.25+: "Clauding… (53s · ↓ 749 tokens)").
+	// Whimsical activity pattern (Claude 2.1.25+: "Clauding… (53s · ↓ 749 tokens)"
+	// for inbound tokens, or "Spelunking… (3m 14s · ↑ 1.8k tokens)" for sub-agent
+	// output). Either arrow + "tokens" on the same line is durable running signal.
 	// Only check bottom 10 lines — the token counter line is always near the bottom.
 	whimsicalN := min(10, len(recentLines))
 	for _, line := range recentLines[:whimsicalN] {
 		lower := strings.ToLower(line)
-		if strings.Contains(lower, "· ↓") && strings.Contains(lower, "tokens") {
+		if strings.Contains(lower, "tokens") && (strings.Contains(lower, "· ↓") || strings.Contains(lower, "· ↑")) {
 			log.Debug("detectStatus: matched whimsical activity pattern", "line", line)
 			return StatusRunning
 		}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -152,6 +152,18 @@ func (s *StateDB) migrate() error {
 		}
 	}
 
+	_, err = s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS slot_bindings (
+			slot_number INTEGER PRIMARY KEY CHECK (slot_number BETWEEN 0 AND 9),
+			session_id  TEXT NOT NULL UNIQUE,
+			FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+		)
+	`)
+	if err != nil {
+		debuglog.Logger.Error("migration failed: create slot_bindings table", "error", err)
+		return err
+	}
+
 	return nil
 }
 
@@ -323,6 +335,60 @@ func (s *StateDB) ResetTitleGenerated(id string) error {
 // UpdatePromptCount updates the prompt count for a session.
 func (s *StateDB) UpdatePromptCount(id string, count int) error {
 	_, err := s.db.Exec("UPDATE sessions SET prompt_count = ? WHERE id = ?", count, id)
+	return err
+}
+
+// BindSlot assigns a session to a slot. The slot and session are both unique:
+// any existing binding for the slot or the session is removed first, so a
+// session holds at most one slot at a time.
+func (s *StateDB) BindSlot(slot int, sessionID string) error {
+	if slot < 0 || slot > 9 {
+		return fmt.Errorf("slot %d out of range 0-9", slot)
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(`DELETE FROM slot_bindings WHERE slot_number = ? OR session_id = ?`, slot, sessionID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`INSERT INTO slot_bindings (slot_number, session_id) VALUES (?, ?)`, slot, sessionID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// UnbindSlot removes the binding for a slot, if any.
+func (s *StateDB) UnbindSlot(slot int) error {
+	_, err := s.db.Exec(`DELETE FROM slot_bindings WHERE slot_number = ?`, slot)
+	return err
+}
+
+// LoadSlotBindings returns the slot → session_id map.
+func (s *StateDB) LoadSlotBindings() (map[int]string, error) {
+	rows, err := s.db.Query(`SELECT slot_number, session_id FROM slot_bindings`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[int]string)
+	for rows.Next() {
+		var slot int
+		var id string
+		if err := rows.Scan(&slot, &id); err != nil {
+			return nil, err
+		}
+		out[slot] = id
+	}
+	return out, rows.Err()
+}
+
+// DeleteSlotBindingForSession clears any slot pointing at the given session.
+// FK cascade handles this when a session row is deleted, but callers that
+// remove bindings without deleting the session use this directly.
+func (s *StateDB) DeleteSlotBindingForSession(sessionID string) error {
+	_, err := s.db.Exec(`DELETE FROM slot_bindings WHERE session_id = ?`, sessionID)
 	return err
 }
 

--- a/internal/session/storage_test.go
+++ b/internal/session/storage_test.go
@@ -584,3 +584,114 @@ func TestMigrationIdempotent(t *testing.T) {
 		t.Errorf("expected 1 session, got %d", len(sessions))
 	}
 }
+
+func TestSlotBindings(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now()
+	saveSession := func(id string) {
+		if err := db.SaveSession(&SessionRow{
+			ID: id, Title: id, ProjectPath: "/tmp/p",
+			Status: "idle", CreatedAt: now,
+		}); err != nil {
+			t.Fatalf("SaveSession %s: %v", id, err)
+		}
+	}
+	saveSession("sess-a")
+	saveSession("sess-b")
+	saveSession("sess-c")
+
+	// Initial: no bindings.
+	bindings, err := db.LoadSlotBindings()
+	if err != nil {
+		t.Fatalf("LoadSlotBindings: %v", err)
+	}
+	if len(bindings) != 0 {
+		t.Errorf("expected 0 bindings, got %d", len(bindings))
+	}
+
+	// Bind.
+	if err := db.BindSlot(1, "sess-a"); err != nil {
+		t.Fatalf("BindSlot 1→a: %v", err)
+	}
+	if err := db.BindSlot(2, "sess-b"); err != nil {
+		t.Fatalf("BindSlot 2→b: %v", err)
+	}
+
+	bindings, _ = db.LoadSlotBindings()
+	if bindings[1] != "sess-a" || bindings[2] != "sess-b" {
+		t.Errorf("unexpected bindings: %v", bindings)
+	}
+
+	// Rebind slot 1 to a different session — old session clears.
+	if err := db.BindSlot(1, "sess-c"); err != nil {
+		t.Fatalf("rebind slot 1: %v", err)
+	}
+	bindings, _ = db.LoadSlotBindings()
+	if bindings[1] != "sess-c" {
+		t.Errorf("slot 1 should be sess-c, got %q", bindings[1])
+	}
+	if _, ok := bindings[2]; !ok || bindings[2] != "sess-b" {
+		t.Errorf("slot 2 should still be sess-b, got %v", bindings)
+	}
+
+	// Move a session to a new slot — old slot clears (uniqueness on session_id).
+	if err := db.BindSlot(5, "sess-b"); err != nil {
+		t.Fatalf("move sess-b to slot 5: %v", err)
+	}
+	bindings, _ = db.LoadSlotBindings()
+	if _, ok := bindings[2]; ok {
+		t.Errorf("slot 2 should be cleared when sess-b moves, got %v", bindings)
+	}
+	if bindings[5] != "sess-b" {
+		t.Errorf("slot 5 should be sess-b, got %q", bindings[5])
+	}
+
+	// Unbind.
+	if err := db.UnbindSlot(1); err != nil {
+		t.Fatalf("UnbindSlot: %v", err)
+	}
+	bindings, _ = db.LoadSlotBindings()
+	if _, ok := bindings[1]; ok {
+		t.Errorf("slot 1 should be unbound")
+	}
+
+	// Out-of-range slot rejected.
+	if err := db.BindSlot(10, "sess-a"); err == nil {
+		t.Error("BindSlot(10) should reject out-of-range slot")
+	}
+	if err := db.BindSlot(-1, "sess-a"); err == nil {
+		t.Error("BindSlot(-1) should reject out-of-range slot")
+	}
+
+	// FK cascade: deleting a session drops its binding.
+	if err := db.BindSlot(3, "sess-a"); err != nil {
+		t.Fatalf("BindSlot 3→a: %v", err)
+	}
+	if err := db.DeleteSession("sess-a"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	bindings, _ = db.LoadSlotBindings()
+	if _, ok := bindings[3]; ok {
+		t.Errorf("slot 3 should be cleared by FK cascade after sess-a delete, got %v", bindings)
+	}
+
+	// Explicit DeleteSlotBindingForSession also works.
+	if err := db.BindSlot(4, "sess-c"); err != nil {
+		t.Fatalf("BindSlot 4→c: %v", err)
+	}
+	if err := db.DeleteSlotBindingForSession("sess-c"); err != nil {
+		t.Fatalf("DeleteSlotBindingForSession: %v", err)
+	}
+	bindings, _ = db.LoadSlotBindings()
+	if _, ok := bindings[4]; ok {
+		t.Errorf("slot 4 should be cleared by explicit delete, got %v", bindings)
+	}
+}

--- a/internal/session/testdata/pane_finished_conversation_whimsical_markers.txt
+++ b/internal/session/testdata/pane_finished_conversation_whimsical_markers.txt
@@ -1,0 +1,36 @@
+[38;5;114m⏺[39m [1mWrite[0m(changelog/unreleased/fix-subagent-up-arrow-running.md)
+[38;5;246m [39m [38;5;246m⎿[39m [38;5;246m [39mWrote [1m4[0m lines to [1mchangelog/unreleased/fix-subagent-up-arrow-running.md[0m
+     [2m[38;5;231m 1[0m [38;5;231m---[39m
+     [2m[38;5;231m 2[0m [38;5;231mtype:[39m [38;5;231mfixed[39m
+     [2m[38;5;231m 3[0m [38;5;231m---[39m
+     [2m[38;5;231m 4[0m [38;5;231mStatus[39m [38;5;231mdetection:[39m [38;5;231msessions[39m [38;5;231mrunning[39m [38;5;231mExplore[39m [38;5;231msub-agents[39m [38;5;231m(with[39m [38;5;231mthe[39m [38;5;231m`·[39m [38;5;231m↑[39m [38;5;231mtokens`[39m [38;5;231moutput[39m [38;5;231mcounter)[39m [38;5;231mstay[39m [38;5;231mmarked[39m [38;5;231mas[39m [38;5;231m"running"[39m [38;5;231minstead[39m [38;5;231mof[39m [38;5;231mcollapsing[39m [38;5;231mto[39m [38;5;231m"idle"[39m [38;5;231mwhen[39m [38;5;231ma[39m [38;5;231mstal[39m
+     [2m[38;5;231m [0m  [38;5;231me[39m [38;5;231mwaiting[39m [38;5;231mhook[39m [38;5;231mis[39m [38;5;231min[39m [38;5;231mplay.[39m
+
+[38;5;114m⏺[39m [1mBash[0m(git add internal/session/session.go internal/session/golden_test.go internal/session/scenario_test.go internal/session/testdata/pane_running_subagent_spelunking…)
+[38;5;246m [39m [38;5;246m⎿[39m [38;5;246m [39mA  changelog/unreleased/fix-subagent-up-arrow-running.md
+     M  internal/session/golden_test.go
+     M  internal/session/scenario_test.go
+     [2m…[0m [2m+2[0m [2mlines[0m [2m(ctrl+o[0m [2mto[0m [2mexpand)[0m
+
+[38;5;114m⏺[39m [1mBash[0m(git commit -m "$(cat <<'EOF'
+      fix(status): detect sub-agent running state via `· ↑ tokens` counter…)
+[38;5;246m [39m [38;5;246m⎿[39m [38;5;246m [39mtrim trailing whitespace.................................................Passed
+     fix end of files.........................................................Passed
+     check yaml...........................................(no files to check)Skipped
+     [2m…[0m [2m+7[0m [2mlines[0m [2m(ctrl+o[0m [2mto[0m [2mexpand)[0m
+
+[38;5;114m⏺[39m [1mBash[0m(git push 2>&1 | tail -5)
+[38;5;246m [39m [38;5;246m⎿[39m [38;5;246m [39mTo github.com:brizzai/brizz-code.git
+        fe2272e..42ec384  session-hotkeys -> session-hotkeys
+
+[38;5;231m⏺[39m Shipped [38;5;153m42ec384[39m. Whimsical check now matches [38;5;153m·[39m [38;5;153m↓[39m [38;5;153mOR[39m [38;5;153m·[39m [38;5;153m↑[39m [38;5;153m+[39m [38;5;153mtokens[39m, new golden fixture + scenario test lock in the sub-agent-spelunking case, memory doc has Known Issue #18,
+  pushed to [38;5;153morigin/session-hotkeys[39m.
+
+[38;5;246m✻[39m [38;5;246mBrewed[39m [38;5;246mfor[39m [38;5;246m4m[39m [38;5;246m21s[39m
+
+[38;5;37m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[38;5;16m[48;5;37m fix-permission-menu-cursor-detection [38;5;37m[49m──
+[39m❯ [7m [0m
+[38;5;37m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m  [36m󰧑[39m [36mOpus[39m [36m4.6[39m [36m(1M[39m [36mcontext)[38;5;246m [90m│[38;5;246m [32m██░░░░░░░░[38;5;246m [90m│[38;5;246m [32m24%[38;5;246m [90m│[38;5;246m [35m󰍛[39m [35m240.0k/1000k[38;5;246m [90m│[38;5;246m [33m[39m [33msession-hotkeys[38;5;246m [90m│[38;5;246m [1m[37m[0m  [1m[37mbrizz-code-session-hotkeys[0m
+  [38;5;147m⏵⏵[39m [38;5;147maccept[39m [38;5;147medits[39m [38;5;147mon[38;5;246m (shift+tab[39m [38;5;246mto[39m [38;5;246mcycle)[39m [38;5;246m·[39m [38;5;246mPR[39m [38;5;220m#52[39m                                                                                      [38;5;246mnew[39m [38;5;246mtask?[39m [38;5;153m/clear[38;5;246m to[39m [38;5;246msave[39m [38;5;153m240.8k[39m [38;5;153mtokens[39m
+

--- a/internal/session/testdata/pane_running_subagent_spelunking_up_arrow.txt
+++ b/internal/session/testdata/pane_running_subagent_spelunking_up_arrow.txt
@@ -1,0 +1,36 @@
+     [2m[38;2;248;248;242m 15[0m [38;2;248;248;242m [39m        [38;2;248;248;242mghost:[39m
+     [2m[38;2;248;248;242m 16[0m [38;2;248;248;242m [39m          [38;2;230;219;116m'bg-transparent[39m [38;2;230;219;116mtext-[var(--ds-btn-text-text-active)][39m [38;2;230;219;116mhover:bg-[var(--ds-btn-text-bg-hover)][39m [38;2;230;219;116mhover:text-[var(--ds-btn-text-text-active)][39m [38;2;230;219;116mactive:bg-[v[39m
+     [2m[38;2;248;248;242m [0m   [38;2;248;248;242m [38;2;230;219;116mar(--ds-btn-text-bg-hover)]/70[39m [38;2;230;219;116mdisabled:text-[var(--ds-btn-text-text-disabled)][39m [38;2;230;219;116m[&_svg]:text-[var(--ds-btn-text-icon-active)][39m [38;2;230;219;116maria-expanded:bg-[var(--ds-btn-te[39m
+     [2m[38;2;248;248;242m [0m   [38;2;248;248;242m [38;2;230;219;116mxt-bg-hover)]'[38;2;248;248;242m,[39m
+
+[38;5;114m⏺[39m [1mUpdate[0m(src/components/ui/button.utils.ts)
+[38;5;246m  ⎿  [39mAdded [1m1[0m line, removed [1m1[0m line
+     [2m[38;2;248;248;242m 13 [0m[38;2;248;248;242m           [38;2;230;219;116m'bg-transparent text-[var(--ds-btn-secondary-text-active)] border-[var(--ds-btn-secondary-border-active)] hover:bg-[var(--ds-blue-700)]/10 hover:bord[39m
+     [2m[38;2;248;248;242m    [0m[38;2;248;248;242m [38;2;230;219;116mer-[var(--ds-btn-secondary-border-hover)] hover:text-[var(--ds-btn-secondary-text-hover)] active:bg-[var(--ds-btn-secondary-bg-pressed)] active:text-[var(--ds-[39m
+     [2m[38;2;248;248;242m    [0m[38;2;248;248;242m [38;2;230;219;116mbtn-secondary-text-pressed)] active:border-[var(--ds-btn-secondary-border-pressed)] disabled:text-[var(--ds-btn-secondary-text-disabled)] disabled:border-[var([39m
+     [2m[38;2;248;248;242m    [0m[38;2;248;248;242m [38;2;230;219;116m--ds-btn-secondary-border-disabled)] [&_svg]:text-[var(--ds-btn-secondary-icon-active)] aria-expanded:bg-[var(--ds-blue-700)]/10'[38;2;248;248;242m,[39m
+     [2m[38;2;248;248;242m 14 [0m[38;2;248;248;242m         secondary: [38;2;230;219;116m'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground'[38;2;248;248;242m,[39m
+     [2m[38;2;248;248;242m 15 [0m[38;2;248;248;242m         ghost:[39m
+     [38;2;220;90;90m[48;2;61;1;0m 16 -[38;2;248;248;242m          'bg-transparent text-[var(--ds-btn-text-text-active)] hover:bg-[var(--ds-[48;2;92;2;0mbtn[48;2;61;1;0m-[48;2;92;2;0mtext-bg-hover[48;2;61;1;0m)] hover:text-[var(--ds-btn-text-text-active)] active:bg-[v[39m[49m
+     [38;2;220;90;90m[48;2;61;1;0m    -[38;2;248;248;242mar(--ds-[48;2;92;2;0mbtn[48;2;61;1;0m-[48;2;92;2;0mtext-bg-hover[48;2;61;1;0m)]/[48;2;92;2;0m70[48;2;61;1;0m disabled:text-[var(--ds-btn-text-text-disabled)] [&_svg]:text-[var(--ds-btn-text-icon-active)] aria-expanded:bg-[var(--ds-[48;2;92;2;0mbtn[48;2;61;1;0m-[48;2;92;2;0mte[39m[49m
+     [38;2;220;90;90m[48;2;61;1;0m    -[38;2;248;248;242m[48;2;92;2;0mxt-bg-hover[48;2;61;1;0m)]',                                                                                                                                                [39m[49m
+     [38;2;80;200;80m[48;2;2;40;0m 16 +[38;2;248;248;242m          [38;2;230;219;116m'bg-transparent text-[var(--ds-btn-text-text-active)] hover:bg-[var(--ds-[48;2;4;71;0mblue[48;2;2;40;0m-[48;2;4;71;0m700[48;2;2;40;0m)][48;2;4;71;0m/10[48;2;2;40;0m hover:text-[var(--ds-btn-text-text-active)] active:bg-[var(--d[39m[49m
+     [38;2;80;200;80m[48;2;2;40;0m    +[38;2;230;219;116ms-[48;2;4;71;0mblue[48;2;2;40;0m-[48;2;4;71;0m700[48;2;2;40;0m)]/[48;2;4;71;0m20[48;2;2;40;0m disabled:text-[var(--ds-btn-text-text-disabled)] [&_svg]:text-[var(--ds-btn-text-icon-active)] aria-expanded:bg-[var(--ds-[48;2;4;71;0mblue[48;2;2;40;0m-[48;2;4;71;0m700[48;2;2;40;0m)][48;2;4;71;0m/10[48;2;2;40;0m'[38;2;248;248;242m,      [39m[49m
+     [2m[38;2;248;248;242m 17[0m [38;2;248;248;242m [39m        [38;2;248;248;242mlink:[39m [38;2;230;219;116m'text-[var(--ds-btn-link-text-active)][39m [38;2;230;219;116munderline-offset-4[39m [38;2;230;219;116mhover:underline[39m [38;2;230;219;116mhover:text-[var(--ds-btn-link-text-hover)][39m [38;2;230;219;116mdisabled:text-[var(--ds-btn-[39m
+     [2m[38;2;248;248;242m [0m   [38;2;248;248;242m [38;2;230;219;116mlink-text-disabled)][39m [38;2;230;219;116m[&_svg]:text-[var(--ds-btn-link-icon-active)]'[38;2;248;248;242m,[39m
+     [2m[38;2;248;248;242m 18[0m [38;2;248;248;242m [39m
+     [2m[38;2;248;248;242m 19[0m [38;2;248;248;242m [39m        [38;2;248;248;242maccent:[39m
+
+[38;5;231m⏺[39m Now auditing the toolbar component sizes you're seeing in the screenshot.
+
+[38;5;246m⏺[39m Searching for [1m1[0m pattern, reading [1m1[0m file… [38;5;246m(ctrl+o to expand)[39m
+[38;5;246m  ⎿  "(Button|ToggleGroup|Toggle|Select|Input)[^a-zA-Z]"[39m
+
+[38;5;174m✳[39m [38;5;174mSpelunking… [38;5;246m(3m 14s · ↑[39m [38;5;246m1.8k tokens)[39m
+
+[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[38;5;246m❯ [7m[39m [0m
+[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m  [36m󰧑 Opus 4.6 (1M context)[38;5;246m [90m│[38;5;246m [32m███░░░░░░░[38;5;246m [90m│[38;5;246m [32m30%[38;5;246m [90m│[38;5;246m [35m󰍛 300.0k/1000k[38;5;246m [90m│[38;5;246m [33m yuval/brz-1232-buttons-figma-thing[38;5;246m [90m│[38;5;246m [1m[37m  anotherbrizzai[0m
+  [38;5;147m⏵⏵[39m [38;5;147maccept[39m [38;5;147medits[39m [38;5;147mon[38;5;246m (shift+tab[39m [38;5;246mto[39m [38;5;246mcycle)[39m
+

--- a/internal/session/testdata/pane_waiting_permission_cursor_opt2.txt
+++ b/internal/session/testdata/pane_waiting_permission_cursor_opt2.txt
@@ -1,0 +1,56 @@
+
+[38;5;231m⏺[39m The pain point we hit: you're in a worktree of repo A ([38;5;153m~/code/morebrizzai[39m), but brz-env uses repo B ([38;5;153m~/code/brizzai[39m) — different clones. Branches in A are invisible to B unless you push + fetch.
+
+  [1mSimplest manual workflow (3 commands)[0m
+
+  From your worktree:
+  git push -u origin HEAD                                                [32m# push your branch[39m
+  [36mcd[39m ~/code/brizzai && git fetch origin <branch>                         [32m# fetch into brz-env's repo[39m
+  brz-env create <name> --branch <branch>                                [32m# create env[39m
+
+  That's it. The "sibling branch in same repo" trick I tried first didn't work because brz-env doesn't know about that repo at all.
+
+  [1mWhat I'd add to brz-env[0m
+
+  Two small features that would have saved us 30 minutes:
+
+  1. [1m[38;5;153mbrz-env create <name> --from-cwd[0m — auto-detects the current branch + commit from [38;5;153m$PWD[39m, handles the push-and-fetch dance, then creates the env from the right ref. One command instead of three.
+  2. [1mSanity check on [38;5;153m--branch[0m — if the branch isn't in the brz-env repo locally, try [38;5;153mgit fetch origin <branch>[39m first (with a "fetching from origin..." message). Currently it silently uses whatever stale local ref exists, which is exactly the bug we hit (it found [38;5;153myuval/brz-checkpoint-cache-test[39m pointing to an old
+  [38;5;153m[BRZ-1153][39m commit).
+
+  (2) is the higher-impact one — it would have surfaced the problem immediately instead of letting us run a brainstorm against the wrong code for 90 seconds.
+
+  Want me to open an issue for these, or just leave it as a note for future-you?
+
+[38;5;246m✻[39m [38;5;246mWorked for 40s[39m
+
+[38;5;239m[48;5;237m❯ [38;5;231mlets do this, create a worktree and workon it[39m
+[49m
+[38;5;114m⏺[39m [1mBash[0m(cd /Users/yuvalhayke/code/morebrizzai && git fetch origin master 2>&1 | tail -3 && git worktree add -b yuval/brz-env-from-cwd ../morebrizzai-brz-env-from-cwd or…)
+[38;5;246m  ⎿  [39mFrom github.com:brizzai/brizzai
+      * branch                master     -> FETCH_HEAD
+     Preparing worktree (new branch 'yuval/brz-env-from-cwd')
+     [2m… +2 lines (ctrl+o to expand)[0m
+[38;5;246m  ⎿  Shell cwd was reset to /Users/yuvalhayke/code/morebrizzai-debug-port-brainstorm[39m
+
+[38;5;231m⏺[39m Worktree created at [38;5;153m/Users/yuvalhayke/code/morebrizzai-brz-env-from-cwd[39m. Let me explore the brz-env code structure there:
+
+  [38;5;246mRead [1m4[0m[38;5;246m files (ctrl+o to expand)[39m
+
+[38;5;231m⏺[39m Now I understand the code. Let me look at tests structure briefly:
+
+[38;5;246m⏺[39m Searching for [1m1[0m pattern… [38;5;246m(ctrl+o to expand)[39m
+[38;5;246m  ⎿  "scripts/brz-env/tests/**/*.py"[39m
+
+[38;5;153m──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m [1m[38;5;153mRead file[0m
+
+  Search(pattern: "scripts/brz-env/tests/**/*.py", path: "~/code/morebrizzai-brz-env-from-cwd")
+
+ Do you want to proceed?
+   [38;5;246m1.[39m Yes
+ [38;5;153m❯[39m [38;5;246m2.[39m [38;5;153mYes, allow reading from [1mmorebrizzai-brz-env-from-cwd/[0m[38;5;153m during this session
+[39m   [38;5;246m3.[39m No
+
+ [38;5;246mEsc[39m [38;5;246mto[39m [38;5;246mcancel[39m
+

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -63,18 +63,20 @@ type (
 		content   string
 	}
 	loadSessionsMsg struct {
-		sessions    []*session.Session
-		ghAvailable bool
-		warning     string
-		err         error
+		sessions     []*session.Session
+		slotBindings map[int]string
+		ghAvailable  bool
+		warning      string
+		err          error
 	}
-	openEditorMsg      struct{ err error }
-	openPRMsg          struct{ err error }
-	quickApproveMsg    struct{ err error }
-	spinnerTickMsg     struct{}
-	previewTickMsg     time.Time
-	focusTickMsg       time.Time
-	reloadAllResultMsg struct {
+	openEditorMsg        struct{ err error }
+	openPRMsg            struct{ err error }
+	quickApproveMsg      struct{ err error }
+	spinnerTickMsg       struct{}
+	previewTickMsg       time.Time
+	focusTickMsg         time.Time
+	slotAssignTimeoutMsg struct{}
+	reloadAllResultMsg   struct {
 		restarted int
 		skipped   int
 		errors    []string
@@ -139,6 +141,13 @@ type Home struct {
 	filterActive bool
 	filterText   string
 
+	// Slot hotkeys (RTS-style quick access: digit=jump, double-digit=attach, alt+digit or =<digit>=bind).
+	slotBindings      map[int]string // slot (0-9) -> session ID
+	lastSlotTapSlot   int            // -1 when no pending tap
+	lastSlotTapAt     time.Time
+	slotAssignPending bool
+	slotAssignExpires time.Time
+
 	// Config.
 	cfg     *config.Config
 	version string
@@ -179,6 +188,8 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string) *Home
 		storage:               storage,
 		sessionByID:           make(map[string]*session.Session),
 		repoExpanded:          make(map[string]bool),
+		slotBindings:          make(map[int]string),
+		lastSlotTapSlot:       -1,
 		newDialog:             NewNewSessionDialog(),
 		confirmDialog:         NewConfirmDialog(),
 		renameDialog:          NewRenameDialog(),
@@ -287,6 +298,12 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sessionCreateResultMsg:
 		return h.handleSessionCreateResult(msg)
+
+	case slotAssignTimeoutMsg:
+		if h.slotAssignPending && !time.Now().Before(h.slotAssignExpires) {
+			h.slotAssignPending = false
+		}
+		return h, nil
 
 	case sessionDeleteMsg:
 		if msg.err != nil {
@@ -608,6 +625,17 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		h.sessions = msg.sessions
 		h.rebuildSessionMap()
+		// Prune slot bindings whose session no longer exists.
+		if msg.slotBindings != nil {
+			h.slotBindings = make(map[int]string, len(msg.slotBindings))
+			for slot, id := range msg.slotBindings {
+				if _, ok := h.sessionByID[id]; ok {
+					h.slotBindings[slot] = id
+				} else {
+					_ = h.storage.UnbindSlot(slot)
+				}
+			}
+		}
 		// Default all repos to expanded on first load.
 		groups := session.GroupByRepo(h.sessions)
 		for repo := range groups {
@@ -717,7 +745,7 @@ func (h *Home) View() string {
 
 	switch h.layoutMode() {
 	case "single":
-		sidebar := RenderSidebar(h.flatItems, h.sessions, h.gitInfoCache, h.cursor, h.viewOffset, h.width, contentHeight)
+		sidebar := RenderSidebar(h.flatItems, h.sessions, h.gitInfoCache, h.slotBindings, h.cursor, h.viewOffset, h.width, contentHeight)
 		b.WriteString(sidebar)
 	case "stacked":
 		sidebarHeight := (contentHeight * 55) / 100
@@ -725,7 +753,7 @@ func (h *Home) View() string {
 			sidebarHeight = 3
 		}
 		previewHeight := contentHeight - sidebarHeight - 1 // 1 for separator
-		sidebar := RenderSidebar(h.flatItems, h.sessions, h.gitInfoCache, h.cursor, h.viewOffset, h.width, sidebarHeight)
+		sidebar := RenderSidebar(h.flatItems, h.sessions, h.gitInfoCache, h.slotBindings, h.cursor, h.viewOffset, h.width, sidebarHeight)
 		b.WriteString(sidebar)
 		b.WriteString("\n")
 		b.WriteString(DimStyle.Render(strings.Repeat("─", h.width)))
@@ -745,7 +773,7 @@ func (h *Home) View() string {
 		if h.focusMode && !h.sidebarDirty && h.cachedSidebar != "" {
 			leftPanel = h.cachedSidebar
 		} else {
-			leftPanel = RenderSidebar(h.flatItems, h.sessions, h.gitInfoCache, h.cursor, h.viewOffset, sidebarWidth, contentHeight)
+			leftPanel = RenderSidebar(h.flatItems, h.sessions, h.gitInfoCache, h.slotBindings, h.cursor, h.viewOffset, sidebarWidth, contentHeight)
 			leftPanel = ensureExactHeight(leftPanel, contentHeight)
 			leftPanel = ensureExactWidth(leftPanel, sidebarWidth)
 			h.cachedSidebar = leftPanel
@@ -1049,12 +1077,36 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.branchDialog.ShowLoading()
 		return h, tea.Batch(h.fetchBranchList(repoPath), spinnerTickCmd)
+	case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
+		digit := int(msg.String()[0] - '0')
+		if h.slotAssignPending {
+			h.slotAssignPending = false
+			h.bindCurrentSessionToSlot(digit)
+			return h, nil
+		}
+		return h.jumpToSlot(digit)
+	case "alt+0", "alt+1", "alt+2", "alt+3", "alt+4", "alt+5", "alt+6", "alt+7", "alt+8", "alt+9":
+		s := msg.String()
+		digit := int(s[len(s)-1] - '0')
+		h.bindCurrentSessionToSlot(digit)
+		return h, nil
+	case "=":
+		h.slotAssignPending = true
+		h.slotAssignExpires = time.Now().Add(2 * time.Second)
+		h.setInfo("Assign slot 0-9 (Esc to cancel)")
+		return h, tea.Tick(2*time.Second, func(time.Time) tea.Msg { return slotAssignTimeoutMsg{} })
 	case "/":
 		h.filterActive = true
 		h.filterInput.Focus()
 		analytics.Track(analytics.EventFilterUsed, nil)
 		return h, nil
 	case "esc":
+		// Cancel pending slot-assign leader.
+		if h.slotAssignPending {
+			h.slotAssignPending = false
+			h.setInfo("Slot assign cancelled")
+			return h, nil
+		}
 		// Clear active filter.
 		if h.filterText != "" {
 			h.filterText = ""
@@ -1683,6 +1735,19 @@ func (h *Home) deleteSession(id string) {
 		debuglog.Logger.Error("failed to delete session from storage", "id", id, "err", err)
 	}
 
+	// Clear any slot binding pointing at this session. FK cascade handles the
+	// DB row, but the in-memory map needs explicit cleanup for the UI.
+	for slot, sid := range h.slotBindings {
+		if sid == id {
+			delete(h.slotBindings, slot)
+		}
+	}
+	if h.lastSlotTapSlot >= 0 {
+		if sid, ok := h.slotBindings[h.lastSlotTapSlot]; !ok || sid == id {
+			h.lastSlotTapSlot = -1
+		}
+	}
+
 	// Remove hook status file.
 	if err := os.Remove(filepath.Join(hooks.GetHooksDir(), id+".json")); err != nil && !os.IsNotExist(err) {
 		debuglog.Logger.Error("failed to remove hook status file", "id", id, "err", err)
@@ -2102,6 +2167,79 @@ func (h *Home) layoutMode() string {
 	return "dual"
 }
 
+// bindCurrentSessionToSlot persists the selected session under the given slot,
+// replacing any prior binding for either the slot or the session.
+func (h *Home) bindCurrentSessionToSlot(slot int) {
+	s := h.selectedSession()
+	if s == nil {
+		h.setError(fmt.Errorf("select a session first"))
+		return
+	}
+	if err := h.storage.BindSlot(slot, s.ID); err != nil {
+		h.setError(fmt.Errorf("bind slot: %w", err))
+		return
+	}
+	for k, v := range h.slotBindings {
+		if v == s.ID {
+			delete(h.slotBindings, k)
+		}
+	}
+	h.slotBindings[slot] = s.ID
+	h.actionLog.Add("bind slot", fmt.Sprintf("%d → %s", slot, s.Title), true)
+	h.setInfo(fmt.Sprintf("Slot %d → %s", slot, s.Title))
+	h.sidebarDirty = true
+}
+
+// jumpToSlot moves the cursor to the session bound at the given slot.
+// A second press of the same slot within 400ms also attaches.
+func (h *Home) jumpToSlot(slot int) (tea.Model, tea.Cmd) {
+	sessID, ok := h.slotBindings[slot]
+	if !ok {
+		h.setInfo(fmt.Sprintf("Slot %d unbound", slot))
+		return h, nil
+	}
+	s, ok := h.sessionByID[sessID]
+	if !ok {
+		delete(h.slotBindings, slot)
+		_ = h.storage.UnbindSlot(slot)
+		h.setError(fmt.Errorf("slot %d was stale, cleared", slot))
+		return h, nil
+	}
+
+	// Expand the repo group if collapsed, so the session is visible and selectable.
+	repo := session.GetRepoRoot(s.ProjectPath)
+	if !h.repoExpanded[repo] {
+		h.repoExpanded[repo] = true
+		h.rebuildFlatItems()
+	}
+
+	idx := -1
+	for i, item := range h.flatItems {
+		if !item.IsRepoHeader && item.Session != nil && item.Session.ID == sessID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		// Likely hidden by an active filter.
+		h.setInfo(fmt.Sprintf("Slot %d hidden by filter", slot))
+		return h, nil
+	}
+
+	isDoubleTap := h.lastSlotTapSlot == slot &&
+		time.Since(h.lastSlotTapAt) < 400*time.Millisecond
+	h.cursor = idx
+	h.syncViewport()
+	if isDoubleTap {
+		h.lastSlotTapSlot = -1
+		h.actionLog.Add("attach via slot", fmt.Sprintf("%d", slot), true)
+		return h, h.attachSelected()
+	}
+	h.lastSlotTapSlot = slot
+	h.lastSlotTapAt = time.Now()
+	return h, h.fetchPreviewForSelected()
+}
+
 func (h *Home) selectedSession() *session.Session {
 	if h.cursor < 0 || h.cursor >= len(h.flatItems) || h.flatItems[h.cursor].IsRepoHeader {
 		return nil
@@ -2202,6 +2340,12 @@ func (h *Home) loadSessions() tea.Msg {
 		sessions = filtered
 	}
 
+	slotBindings, err := h.storage.LoadSlotBindings()
+	if err != nil {
+		debuglog.Logger.Error("failed to load slot bindings", "err", err)
+		slotBindings = map[int]string{}
+	}
+
 	// These block but run in the tea.Cmd goroutine, not Update().
 	configDir := hooks.GetClaudeConfigDir()
 	hooks.InjectClaudeHooks(configDir)
@@ -2214,7 +2358,7 @@ func (h *Home) loadSessions() tea.Msg {
 		warning = "claude CLI not found — install Claude Code to create sessions"
 	}
 
-	return loadSessionsMsg{sessions: sessions, ghAvailable: ghAvailable, warning: warning}
+	return loadSessionsMsg{sessions: sessions, slotBindings: slotBindings, ghAvailable: ghAvailable, warning: warning}
 }
 
 func (h *Home) setError(err error) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -145,7 +145,7 @@ type Home struct {
 	slotBindings      map[int]string // slot (0-9) -> session ID
 	lastSlotTapSlot   int            // -1 when no pending tap
 	lastSlotTapAt     time.Time
-	slotAssignPending bool
+	slotAssignMode    int // 0=off, 1=bind pending (=<digit>), 2=unbind pending (==<digit>)
 	slotAssignExpires time.Time
 
 	// Config.
@@ -300,8 +300,8 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h.handleSessionCreateResult(msg)
 
 	case slotAssignTimeoutMsg:
-		if h.slotAssignPending && !time.Now().Before(h.slotAssignExpires) {
-			h.slotAssignPending = false
+		if h.slotAssignMode != 0 && !time.Now().Before(h.slotAssignExpires) {
+			h.slotAssignMode = 0
 		}
 		return h, nil
 
@@ -1079,9 +1079,14 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, tea.Batch(h.fetchBranchList(repoPath), spinnerTickCmd)
 	case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
 		digit := int(msg.String()[0] - '0')
-		if h.slotAssignPending {
-			h.slotAssignPending = false
+		switch h.slotAssignMode {
+		case 1:
+			h.slotAssignMode = 0
 			h.bindCurrentSessionToSlot(digit)
+			return h, nil
+		case 2:
+			h.slotAssignMode = 0
+			h.unbindSlot(digit)
 			return h, nil
 		}
 		return h.jumpToSlot(digit)
@@ -1091,9 +1096,19 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.bindCurrentSessionToSlot(digit)
 		return h, nil
 	case "=":
-		h.slotAssignPending = true
+		switch h.slotAssignMode {
+		case 0:
+			h.slotAssignMode = 1
+			h.setInfo("Slot: digit=bind · = again=unbind · Esc=cancel")
+		case 1:
+			h.slotAssignMode = 2
+			h.setInfo("Unbind slot: digit=clear · Esc=cancel")
+		default:
+			h.slotAssignMode = 0
+			h.setInfo("Slot assign cancelled")
+			return h, nil
+		}
 		h.slotAssignExpires = time.Now().Add(2 * time.Second)
-		h.setInfo("Assign slot 0-9 (Esc to cancel)")
 		return h, tea.Tick(2*time.Second, func(time.Time) tea.Msg { return slotAssignTimeoutMsg{} })
 	case "/":
 		h.filterActive = true
@@ -1102,8 +1117,8 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 	case "esc":
 		// Cancel pending slot-assign leader.
-		if h.slotAssignPending {
-			h.slotAssignPending = false
+		if h.slotAssignMode != 0 {
+			h.slotAssignMode = 0
 			h.setInfo("Slot assign cancelled")
 			return h, nil
 		}
@@ -2168,11 +2183,16 @@ func (h *Home) layoutMode() string {
 }
 
 // bindCurrentSessionToSlot persists the selected session under the given slot,
-// replacing any prior binding for either the slot or the session.
+// replacing any prior binding for either the slot or the session. Re-binding
+// the same session to its existing slot toggles the binding off (unbind).
 func (h *Home) bindCurrentSessionToSlot(slot int) {
 	s := h.selectedSession()
 	if s == nil {
 		h.setError(fmt.Errorf("select a session first"))
+		return
+	}
+	if existing, ok := h.slotBindings[slot]; ok && existing == s.ID {
+		h.unbindSlot(slot)
 		return
 	}
 	if err := h.storage.BindSlot(slot, s.ID); err != nil {
@@ -2187,6 +2207,30 @@ func (h *Home) bindCurrentSessionToSlot(slot int) {
 	h.slotBindings[slot] = s.ID
 	h.actionLog.Add("bind slot", fmt.Sprintf("%d → %s", slot, s.Title), true)
 	h.setInfo(fmt.Sprintf("Slot %d → %s", slot, s.Title))
+	h.sidebarDirty = true
+}
+
+// unbindSlot clears the given slot's binding, if any.
+func (h *Home) unbindSlot(slot int) {
+	id, ok := h.slotBindings[slot]
+	if !ok {
+		h.setInfo(fmt.Sprintf("Slot %d already unbound", slot))
+		return
+	}
+	title := id
+	if s, ok := h.sessionByID[id]; ok {
+		title = s.Title
+	}
+	if err := h.storage.UnbindSlot(slot); err != nil {
+		h.setError(fmt.Errorf("unbind slot: %w", err))
+		return
+	}
+	delete(h.slotBindings, slot)
+	if h.lastSlotTapSlot == slot {
+		h.lastSlotTapSlot = -1
+	}
+	h.actionLog.Add("unbind slot", fmt.Sprintf("%d (was %s)", slot, title), true)
+	h.setInfo(fmt.Sprintf("Slot %d cleared", slot))
 	h.sidebarDirty = true
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -625,14 +625,16 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		h.sessions = msg.sessions
 		h.rebuildSessionMap()
-		// Prune slot bindings whose session no longer exists.
+		// Keep only bindings whose session is present in the loaded view. Do
+		// NOT delete absent bindings from storage here: BRIZZ_DEMO_PREFIX and
+		// similar filters shrink the session set transiently, and writing back
+		// would permanently destroy real bindings. The FK cascade on session
+		// delete handles the only case where a binding should actually vanish.
 		if msg.slotBindings != nil {
 			h.slotBindings = make(map[int]string, len(msg.slotBindings))
 			for slot, id := range msg.slotBindings {
 				if _, ok := h.sessionByID[id]; ok {
 					h.slotBindings[slot] = id
-				} else {
-					_ = h.storage.UnbindSlot(slot)
 				}
 			}
 		}
@@ -968,6 +970,13 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Snapshot and clear the double-tap window: only a consecutive digit press
+	// should attach, so any other key falling through this switch invalidates
+	// the window for free. The digit case restores the snapshot before jumping.
+	prevSlotTapSlot := h.lastSlotTapSlot
+	prevSlotTapAt := h.lastSlotTapAt
+	h.lastSlotTapSlot = -1
+
 	switch msg.String() {
 	case "j", "down":
 		h.cursor = NextSelectableItem(h.flatItems, h.cursor, 1)
@@ -1089,6 +1098,9 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			h.unbindSlot(digit)
 			return h, nil
 		}
+		// Restore double-tap state so two consecutive digit presses attach.
+		h.lastSlotTapSlot = prevSlotTapSlot
+		h.lastSlotTapAt = prevSlotTapAt
 		return h.jumpToSlot(digit)
 	case "alt+0", "alt+1", "alt+2", "alt+3", "alt+4", "alt+5", "alt+6", "alt+7", "alt+8", "alt+9":
 		s := msg.String()

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	overlay "github.com/rmhubbert/bubbletea-overlay"
 )
 
 const (
@@ -168,6 +169,9 @@ type Home struct {
 	slotAssignMode    int // 0=off, 1=bind pending (=<digit>), 2=unbind pending (==<digit>)
 	slotAssignExpires time.Time
 
+	// Floating toast overlay (bottom-right).
+	toasts *ToastStack
+
 	// Config.
 	cfg     *config.Config
 	version string
@@ -210,6 +214,7 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string) *Home
 		repoExpanded:          make(map[string]bool),
 		slotBindings:          make(map[int]string),
 		lastSlotTapSlot:       -1,
+		toasts:                NewToastStack(),
 		pinnedRepos:           make(map[string]bool),
 		newDialog:             NewNewSessionDialog(),
 		confirmDialog:         NewConfirmDialog(),
@@ -715,7 +720,17 @@ func (h *Home) View() string {
 	if h.width == 0 {
 		return lipgloss.NewStyle().Bold(true).Foreground(ColorAccent).Render("   brizz-code")
 	}
+	base := h.renderBody()
+	toast := h.toasts.View(h.width)
+	if toast == "" {
+		return base
+	}
+	// Bottom-right, with a 1-cell right margin and a 1-row lift so the toast
+	// clears the help-bar baseline.
+	return overlay.Composite(toast, base, overlay.Right, overlay.Bottom, -1, -1)
+}
 
+func (h *Home) renderBody() string {
 	// Modals take priority.
 	if h.helpOverlay.IsVisible() {
 		return h.helpOverlay.View()
@@ -853,19 +868,6 @@ func (h *Home) View() string {
 		b.WriteString("\n")
 		b.WriteString(h.renderHelpBar())
 		lineCount += 2
-	}
-
-	// Info/error flash message (most recent wins, overwrites last line).
-	showInfo := h.infoMsg != "" && time.Since(h.infoTime) < 5*time.Second
-	showErr := h.err != nil && time.Since(h.errTime) < 5*time.Second
-	if showInfo && (!showErr || h.infoTime.After(h.errTime)) {
-		b.WriteString("\n")
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render(" " + h.infoMsg))
-		lineCount++
-	} else if showErr {
-		b.WriteString("\n")
-		b.WriteString(ErrorStyle.Render(" " + h.err.Error()))
-		lineCount++
 	}
 
 	// Track height mismatches (counter for bug report, log only on first occurrence).
@@ -2667,6 +2669,7 @@ func (h *Home) setError(err error) {
 	h.errTime = time.Now()
 	if err != nil {
 		h.errorHistory.Add(err.Error())
+		h.toasts.Add(ToastError, err.Error())
 		analytics.Track(analytics.EventErrorOccurred, map[string]interface{}{
 			"category": strings.SplitN(err.Error(), ":", 2)[0],
 		})
@@ -2676,6 +2679,7 @@ func (h *Home) setError(err error) {
 func (h *Home) setInfo(msg string) {
 	h.infoMsg = msg
 	h.infoTime = time.Now()
+	h.toasts.Add(ToastInfo, msg)
 }
 
 // buildPaletteCommands returns all available commands for the command palette.

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -37,8 +37,9 @@ var allKeyBindings = []KeyBinding{
 	{Key: "b", BarKey: "b", BarDesc: "Branch", Desc: "Switch git branch", Section: "session"},
 	{Key: "/", BarKey: "/", BarDesc: "Filter", Desc: "Filter sessions", Section: "session"},
 	{Key: "0-9", Desc: "Jump to slot (double-tap to attach)", Section: "session"},
-	{Key: "Alt+0-9", Desc: "Bind session to slot", Section: "session"},
+	{Key: "Alt+0-9", Desc: "Bind/unbind slot (re-press same slot clears it)", Section: "session"},
 	{Key: "= then digit", Desc: "Bind slot (fallback if Alt unsupported)", Section: "session"},
+	{Key: "= = then digit", Desc: "Unbind slot", Section: "session"},
 
 	// Global.
 	{Key: ": / Ctrl+P", BarKey: ":", BarDesc: "Cmd", Desc: "Command palette", Section: "global"},

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -36,6 +36,9 @@ var allKeyBindings = []KeyBinding{
 	{Key: "Y", BarKey: "Y", BarDesc: "Approve", Desc: "Quick approve permission", Section: "session"},
 	{Key: "b", BarKey: "b", BarDesc: "Branch", Desc: "Switch git branch", Section: "session"},
 	{Key: "/", BarKey: "/", BarDesc: "Filter", Desc: "Filter sessions", Section: "session"},
+	{Key: "0-9", Desc: "Jump to slot (double-tap to attach)", Section: "session"},
+	{Key: "Alt+0-9", Desc: "Bind session to slot", Section: "session"},
+	{Key: "= then digit", Desc: "Bind slot (fallback if Alt unsupported)", Section: "session"},
 
 	// Global.
 	{Key: ": / Ctrl+P", BarKey: ":", BarDesc: "Cmd", Desc: "Command palette", Section: "global"},

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -132,9 +132,17 @@ func CollectGroupInfo(sessions []*session.Session, repoPath string) RepoGroupInf
 }
 
 // RenderSidebar renders the session list with repo grouping and cursor.
-func RenderSidebar(items []SidebarItem, sessions []*session.Session, gitInfo map[string]*git.RepoInfo, cursor, viewOffset, width, height int) string {
+// slotBindings maps slot number (0-9) to session ID; an inverse lookup
+// decorates bound sessions with a [N] badge.
+func RenderSidebar(items []SidebarItem, sessions []*session.Session, gitInfo map[string]*git.RepoInfo, slotBindings map[int]string, cursor, viewOffset, width, height int) string {
 	if len(items) == 0 {
 		return renderEmptyState(width, height)
+	}
+
+	// Invert bindings: session ID -> slot number.
+	slotBySession := make(map[string]int, len(slotBindings))
+	for slot, id := range slotBindings {
+		slotBySession[id] = slot
 	}
 
 	var b strings.Builder
@@ -185,7 +193,13 @@ func RenderSidebar(items []SidebarItem, sessions []*session.Session, gitInfo map
 		} else if item.Pending != nil {
 			b.WriteString(renderPendingItem(item.Pending, item.IsLast, width, i == cursor))
 		} else {
-			b.WriteString(renderSessionItem(item.Session, item.IsLast, width, i == cursor))
+			slot := -1
+			if item.Session != nil {
+				if n, ok := slotBySession[item.Session.ID]; ok {
+					slot = n
+				}
+			}
+			b.WriteString(renderSessionItem(item.Session, item.IsLast, width, i == cursor, slot))
 		}
 		if i < visibleEnd-1 {
 			b.WriteString("\n")
@@ -371,7 +385,7 @@ func renderPRBadge(pr *github.PR, selected bool) string {
 	return style.Render(result)
 }
 
-func renderSessionItem(s *session.Session, isLast bool, width int, selected bool) string {
+func renderSessionItem(s *session.Session, isLast bool, width int, selected bool, slot int) string {
 	status := s.GetStatus()
 	symbolRaw := StatusSymbolRaw(status)
 	title := s.Title
@@ -382,8 +396,14 @@ func renderSessionItem(s *session.Session, isLast bool, width int, selected bool
 		connector = treeLast
 	}
 
-	// Truncate title if needed.
-	maxTitleLen := width - 10 // account for tree + symbol + spacing
+	// Slot badge: " [N]" (4 cols) when bound, empty otherwise.
+	slotRaw := ""
+	if slot >= 0 && slot <= 9 {
+		slotRaw = fmt.Sprintf(" [%d]", slot)
+	}
+
+	// Truncate title if needed, accounting for the slot badge width.
+	maxTitleLen := width - 10 - len(slotRaw)
 	if maxTitleLen < 10 {
 		maxTitleLen = 10
 	}
@@ -394,20 +414,26 @@ func renderSessionItem(s *session.Session, isLast bool, width int, selected bool
 	// Selection prefix: ▶ when selected, space when not — both 1 char wide.
 	selPrefix := " "
 	treeStyle := DimStyle
-	var styledSymbol, styledTitle string
+	var styledSymbol, styledTitle, styledSlot string
 
 	if selected {
 		selPrefix = SessionSelectionPrefix.Render("▶")
 		treeStyle = TreeConnectorSelStyle
 		styledSymbol = SessionStatusSelStyle.Render(symbolRaw)
 		styledTitle = SessionTitleSelStyle.Render(" " + title + " ")
+		if slotRaw != "" {
+			styledSlot = SessionStatusSelStyle.Render(slotRaw)
+		}
 	} else {
 		styledSymbol = StatusSymbol(status)
 		styledTitle = TitleStyleForStatus(status).Render(title)
+		if slotRaw != "" {
+			styledSlot = SlotBadgeStyle.Render(slotRaw)
+		}
 	}
 
 	styledConnector := treeStyle.Render(connector)
-	return fmt.Sprintf(" %s%s %s %s", selPrefix, styledConnector, styledSymbol, styledTitle)
+	return fmt.Sprintf(" %s%s %s %s%s", selPrefix, styledConnector, styledSymbol, styledTitle, styledSlot)
 }
 
 func renderPendingItem(pw *PendingWorkspace, isLast bool, width int, selected bool) string {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -109,6 +109,9 @@ var (
 	PRFailStyle    = lipgloss.NewStyle().Foreground(ColorRed)
 	PRPendingStyle = lipgloss.NewStyle().Foreground(ColorYellow)
 	PRMergedStyle  = lipgloss.NewStyle().Foreground(ColorPurple)
+
+	// Slot badge style (RTS-style quick-access hotkey).
+	SlotBadgeStyle = lipgloss.NewStyle().Foreground(ColorOrange).Bold(true)
 )
 
 // ApplyPalette reassigns all color vars and rebuilds all style vars from the given palette.
@@ -171,6 +174,8 @@ func ApplyPalette(p Palette) {
 	PRFailStyle = lipgloss.NewStyle().Foreground(ColorRed)
 	PRPendingStyle = lipgloss.NewStyle().Foreground(ColorYellow)
 	PRMergedStyle = lipgloss.NewStyle().Foreground(ColorPurple)
+
+	SlotBadgeStyle = lipgloss.NewStyle().Foreground(ColorOrange).Bold(true)
 }
 
 // RenderPanelTitle renders a panel title with a divider underline.

--- a/internal/ui/toast.go
+++ b/internal/ui/toast.go
@@ -1,0 +1,188 @@
+package ui
+
+import (
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ToastLevel tags a toast's severity, which picks the icon + accent color.
+type ToastLevel int
+
+const (
+	ToastInfo ToastLevel = iota
+	ToastSuccess
+	ToastWarn
+	ToastError
+)
+
+const (
+	toastMaxStack   = 3
+	toastMaxWidth   = 44
+	toastTTLInfo    = 3 * time.Second
+	toastTTLError   = 5 * time.Second
+	toastInnerHPad  = 1
+	toastBorderCols = 2 // left + right border cells
+)
+
+// Toast is a single transient notification.
+type Toast struct {
+	Level     ToastLevel
+	Message   string
+	ExpiresAt time.Time
+}
+
+// ToastStack holds the active toast queue. Expired entries are filtered
+// lazily inside View so callers don't need to pump a separate timer.
+type ToastStack struct {
+	toasts []Toast
+}
+
+func NewToastStack() *ToastStack { return &ToastStack{} }
+
+// Add queues a toast at the given level. When the stack exceeds toastMaxStack
+// the oldest entries drop off.
+func (ts *ToastStack) Add(level ToastLevel, message string) {
+	ttl := toastTTLInfo
+	if level == ToastError {
+		ttl = toastTTLError
+	}
+	ts.toasts = append(ts.toasts, Toast{
+		Level:     level,
+		Message:   message,
+		ExpiresAt: time.Now().Add(ttl),
+	})
+	if len(ts.toasts) > toastMaxStack {
+		ts.toasts = ts.toasts[len(ts.toasts)-toastMaxStack:]
+	}
+}
+
+// View returns the rendered stack of active toasts, newest at the bottom.
+// Returns "" when nothing is active so the caller can skip compositing.
+// maxWidth bounds the toast column to the terminal width.
+func (ts *ToastStack) View(maxWidth int) string {
+	if len(ts.toasts) == 0 {
+		return ""
+	}
+	now := time.Now()
+	active := ts.toasts[:0]
+	for _, t := range ts.toasts {
+		if t.ExpiresAt.After(now) {
+			active = append(active, t)
+		}
+	}
+	ts.toasts = active
+	if len(active) == 0 {
+		return ""
+	}
+
+	width := toastMaxWidth
+	if maxWidth > 0 && maxWidth < width+2 {
+		width = maxWidth - 2
+	}
+	if width < 12 {
+		return ""
+	}
+
+	blocks := make([]string, 0, len(active))
+	for _, t := range active {
+		blocks = append(blocks, renderToast(t, width))
+	}
+	return lipgloss.JoinVertical(lipgloss.Right, blocks...)
+}
+
+// Empty reports whether the stack has any active toasts (ignoring expiry).
+// Callers that care about expiry should call View and compare to "".
+func (ts *ToastStack) Empty() bool { return len(ts.toasts) == 0 }
+
+func renderToast(t Toast, width int) string {
+	color, icon := toastStyle(t.Level)
+
+	// innerWidth is the content area (inside border + padding).
+	// Reserve 2 cells for the "icon " prefix (line 0) or "  " indent (line 1+).
+	innerWidth := width - toastBorderCols - 2*toastInnerHPad
+	if innerWidth < 6 {
+		innerWidth = 6
+	}
+	bodyWidth := innerWidth - 2
+
+	msg := strings.ReplaceAll(t.Message, "\n", " ")
+	lines := wrapToastLine(msg, bodyWidth)
+
+	iconStyle := lipgloss.NewStyle().Foreground(color).Bold(true)
+	msgStyle := lipgloss.NewStyle().Foreground(ColorText)
+
+	var body strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			body.WriteByte('\n')
+		}
+		if i == 0 {
+			body.WriteString(iconStyle.Render(icon) + " " + msgStyle.Render(line))
+		} else {
+			body.WriteString("  " + msgStyle.Render(line))
+		}
+	}
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(color).
+		Padding(0, toastInnerHPad).
+		Width(width - toastBorderCols).
+		Render(body.String())
+}
+
+func toastStyle(level ToastLevel) (lipgloss.TerminalColor, string) {
+	switch level {
+	case ToastSuccess:
+		return ColorGreen, "✓"
+	case ToastWarn:
+		return ColorYellow, "!"
+	case ToastError:
+		return ColorRed, "✕"
+	default:
+		return ColorAccent, "ℹ"
+	}
+}
+
+// wrapToastLine greedy-wraps a plain-text message at space boundaries to at
+// most width cells per line. Words longer than width are hard-split.
+func wrapToastLine(msg string, width int) []string {
+	if width < 1 {
+		return []string{msg}
+	}
+	words := strings.Fields(msg)
+	if len(words) == 0 {
+		return []string{""}
+	}
+	var lines []string
+	var cur string
+	flush := func() {
+		if cur != "" {
+			lines = append(lines, cur)
+			cur = ""
+		}
+	}
+	for _, w := range words {
+		// Hard-split any single word wider than the column.
+		for lipgloss.Width(w) > width {
+			runes := []rune(w)
+			flush()
+			lines = append(lines, string(runes[:width]))
+			w = string(runes[width:])
+		}
+		if cur == "" {
+			cur = w
+			continue
+		}
+		if lipgloss.Width(cur)+1+lipgloss.Width(w) <= width {
+			cur = cur + " " + w
+		} else {
+			flush()
+			cur = w
+		}
+	}
+	flush()
+	return lines
+}


### PR DESCRIPTION
## Summary
- Numbered session slots (0–9) inspired by RTS control groups. Bind with `Alt+<N>` (or `=` then a digit as a portable fallback), jump with plain `<digit>`, double-tap within 400ms to also attach.
- Two unbind paths: re-press `Alt+<N>` on the already-bound session to toggle off, or `==` then a digit to clear any slot.
- Bound sessions show a `[N]` badge in the sidebar; bindings persist in a new `slot_bindings` SQLite table with FK cascade on session delete, and self-heal if a bound session disappears.

## Test plan
- [x] `go test -race ./...` passes (new `TestSlotBindings` covers rebind, move, uniqueness, out-of-range, FK cascade, explicit delete)
- [x] `make build` clean
- [ ] Manual in a real terminal:
  - [ ] `Alt+1` on session A → `[1]` badge appears; flash confirms bind
  - [ ] Navigate away; `1` returns cursor to A; `1` again within 400ms attaches
  - [ ] `Alt+1` on A again → slot 1 clears
  - [ ] `=2` binds slot 2 (fallback path); `==2` clears it
  - [ ] Filter `/` + `1` → filter captures the digit, no slot jump
  - [ ] Delete a bound session → badge gone, `1` shows "Slot 1 unbound"
  - [ ] Restart TUI → slot bindings persist
- [ ] Terminal matrix: Alt+digit works on iTerm2 with "Option as Esc+" on; fallback `=<digit>` works everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)