### PR TITLE
feat(ui): undo delete + sticky pinned repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,10 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Sessions grouped by git repo root in sidebar with tree lines (├─/└─)
 - Status: Running, Waiting, Finished, Idle, Error, Starting
 - Status icons: ● (running/finished), ◐ (waiting), ○ (idle/starting), ✕ (error)
-- Keybindings: j/k nav, Enter attach, Space jump to next waiting/finished, a new session (instant, repo-scoped), n new session (any repo, path autocomplete), w new worktree session (base branch + new branch), d delete (Y to also destroy workspace), r restart, R rename, e editor, p open PR in browser, Y quick approve (waiting sessions), / filter, : or Ctrl+P command palette, S settings, ! bug report/diagnostics, ? help, q quit
+- Keybindings: j/k nav, Enter attach, Space jump to next waiting/finished, a new session (instant, repo-scoped), n new session (any repo, path autocomplete), w new worktree session (base branch + new branch), d delete (Y to also destroy workspace, D to also remove repo), z undo delete (5s window), r restart, R rename, e editor, p open PR in browser, Y quick approve (waiting sessions), / filter, : or Ctrl+P command palette, S settings, ! bug report/diagnostics, ? help, q quit
 - Command palette (: / Ctrl+P): fuzzy-searchable list of all actions; palette-only commands include "Reload All Sessions" (restarts all dead/error sessions)
+- Undo delete: `z` key restores last deleted session within 5s window (stacked — multiple deletes each undoable). Tmux kept alive during window for full restore.
+- Pinned repos: repos auto-pinned on session creation, persist in SQLite. Empty repos show dimmed with "(empty)". `d` on empty repo header unpins it. `D` in delete dialog also removes repo.
 - Tmux status bar configured per session with detach hint (ctrl+q)
 - Attach uses PTY with Ctrl+Q intercept for clean detach (creack/pty + golang.org/x/term)
 - Repo headers show branch name (), dirty indicator (*), and PR badge (#N)

--- a/changelog/unreleased/undo-delete-sticky-repos.md
+++ b/changelog/unreleased/undo-delete-sticky-repos.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+Undo delete (z key): restore deleted sessions within 5 seconds. Sticky repos: empty repo groups persist in sidebar until dismissed.

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -152,6 +152,13 @@ func (s *StateDB) migrate() error {
 		}
 	}
 
+	// Pinned repos table for sticky repo headers.
+	_, err = s.db.Exec(`CREATE TABLE IF NOT EXISTS pinned_repos (repo_path TEXT PRIMARY KEY)`)
+	if err != nil {
+		debuglog.Logger.Error("migration failed: create pinned_repos table", "error", err)
+		return err
+	}
+
 	return nil
 }
 
@@ -324,6 +331,45 @@ func (s *StateDB) ResetTitleGenerated(id string) error {
 func (s *StateDB) UpdatePromptCount(id string, count int) error {
 	_, err := s.db.Exec("UPDATE sessions SET prompt_count = ? WHERE id = ?", count, id)
 	return err
+}
+
+// PinRepo adds a repo to the pinned set (idempotent).
+func (s *StateDB) PinRepo(repoPath string) error {
+	_, err := s.db.Exec("INSERT OR IGNORE INTO pinned_repos (repo_path) VALUES (?)", repoPath)
+	if err != nil {
+		debuglog.Logger.Error("failed to pin repo", "repo", repoPath, "error", err)
+	}
+	return err
+}
+
+// UnpinRepo removes a repo from the pinned set.
+func (s *StateDB) UnpinRepo(repoPath string) error {
+	_, err := s.db.Exec("DELETE FROM pinned_repos WHERE repo_path = ?", repoPath)
+	if err != nil {
+		debuglog.Logger.Error("failed to unpin repo", "repo", repoPath, "error", err)
+	}
+	return err
+}
+
+// LoadPinnedRepos returns all pinned repo paths.
+func (s *StateDB) LoadPinnedRepos() ([]string, error) {
+	rows, err := s.db.Query("SELECT repo_path FROM pinned_repos ORDER BY repo_path")
+	if err != nil {
+		debuglog.Logger.Error("failed to load pinned repos", "error", err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	var repos []string
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			debuglog.Logger.Error("failed to scan pinned repo row", "error", err)
+			return nil, err
+		}
+		repos = append(repos, path)
+	}
+	return repos, rows.Err()
 }
 
 func boolToInt(b bool) int {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2,8 +2,6 @@ package ui
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -1279,8 +1277,7 @@ func (h *Home) confirmDeleteSelected() tea.Cmd {
 	}
 
 	details := []string{
-		"tmux session terminated",
-		"Terminal history lost",
+		"Press z to undo within 5s",
 	}
 	if isLastInRepo {
 		details = append(details, "Last session in this repo")
@@ -1780,9 +1777,7 @@ func (h *Home) deferDelete(msg sessionDeleteMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Generate nonce for timer matching.
-	nonceBytes := make([]byte, 8)
-	_, _ = rand.Read(nonceBytes)
-	nonce := hex.EncodeToString(nonceBytes)
+	nonce := fmt.Sprintf("%s-%d", msg.id, time.Now().UnixNano())
 
 	// Push onto undo stack.
 	h.pendingDeletes = append(h.pendingDeletes, PendingDelete{
@@ -1920,7 +1915,15 @@ func (h *Home) finalizeAllPendingDeletes() {
 		if err := os.Remove(filepath.Join(hooks.GetHooksDir(), pd.Session.ID+".json")); err != nil && !os.IsNotExist(err) {
 			debuglog.Logger.Error("failed to remove hook status file on quit", "id", pd.Session.ID, "err", err)
 		}
-		// Note: workspace destruction skipped on quit (async operation, app is exiting).
+		// Best-effort workspace destruction on quit.
+		if pd.DestroyWS && pd.WorkspaceName != "" {
+			provider := workspace.ResolveProvider(pd.RepoPath)
+			if provider != nil && provider.CanDestroy() {
+				if err := provider.Destroy(pd.RepoPath, pd.WorkspaceName); err != nil {
+					debuglog.Logger.Error("failed to destroy workspace on quit", "id", pd.Session.ID, "workspace", pd.WorkspaceName, "err", err)
+				}
+			}
+		}
 	}
 	h.pendingDeletes = nil
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -44,8 +44,8 @@ const (
 
 // PendingDelete holds state for a deferred session deletion (undo window).
 type PendingDelete struct {
-	Nonce         string             // unique ID for timer matching
-	Session       *session.Session   // kept alive (tmux still running)
+	Nonce         string              // unique ID for timer matching
+	Session       *session.Session    // kept alive (tmux still running)
 	Row           *session.SessionRow // DB snapshot for re-insert
 	RepoPath      string
 	DestroyWS     bool

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -37,7 +39,20 @@ const (
 	layoutBreakpointDual   = 80
 	helpBarHeight          = 2 // border line + shortcuts
 	statusRoundRobin       = 5 // sessions per tick
+	undoDeleteTimeout      = 5 * time.Second
 )
+
+// PendingDelete holds state for a deferred session deletion (undo window).
+type PendingDelete struct {
+	Nonce         string             // unique ID for timer matching
+	Session       *session.Session   // kept alive (tmux still running)
+	Row           *session.SessionRow // DB snapshot for re-insert
+	RepoPath      string
+	DestroyWS     bool
+	WorkspaceName string
+	UnpinRepo     bool // true if user chose D +Remove Repo
+	DeletedAt     time.Time
+}
 
 // Message types.
 type (
@@ -49,6 +64,11 @@ type (
 		err              error
 		destroyWorkspace bool
 		workspaceName    string
+		unpinRepo        bool
+		repoPath         string
+	}
+	pendingDeleteExpireMsg struct {
+		nonce string
 	}
 	sessionRestartMsg struct {
 		id  string
@@ -116,6 +136,8 @@ type Home struct {
 	commandPalette        *CommandPaletteDialog
 
 	pendingWorkspaces []*PendingWorkspace // in-flight workspace creations
+	pendingDeletes    []PendingDelete     // undo stack for deferred deletions
+	pinnedRepos       map[string]bool     // pinned repo paths (persist in SQLite)
 
 	repoExpanded     map[string]bool // repo path -> expanded state
 	previewCache     map[string]string
@@ -179,6 +201,7 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string) *Home
 		storage:               storage,
 		sessionByID:           make(map[string]*session.Session),
 		repoExpanded:          make(map[string]bool),
+		pinnedRepos:           make(map[string]bool),
 		newDialog:             NewNewSessionDialog(),
 		confirmDialog:         NewConfirmDialog(),
 		renameDialog:          NewRenameDialog(),
@@ -291,30 +314,13 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sessionDeleteMsg:
 		if msg.err != nil {
 			h.setError(msg.err)
-		} else {
-			analytics.Track(analytics.EventSessionDeleted, nil)
-			// Resolve provider before deleting session (need project path).
-			var destroyProvider workspace.Provider
-			var destroyRepoPath string
-			if msg.destroyWorkspace && msg.workspaceName != "" {
-				if s, ok := h.sessionByID[msg.id]; ok {
-					destroyRepoPath = session.GetRepoRoot(s.ProjectPath)
-					destroyProvider = workspace.ResolveProvider(destroyRepoPath)
-				}
-			}
-			h.deleteSession(msg.id)
-			// If workspace destroy requested, do it async.
-			if destroyProvider != nil && destroyProvider.CanDestroy() {
-				wsName := msg.workspaceName
-				repoPath := destroyRepoPath
-				sid := msg.id
-				return h, func() tea.Msg {
-					err := destroyProvider.Destroy(repoPath, wsName)
-					return workspaceDestroyResultMsg{sessionID: sid, err: err}
-				}
-			}
+			return h, nil
 		}
-		return h, nil
+		analytics.Track(analytics.EventSessionDeleted, nil)
+		return h.deferDelete(msg)
+
+	case pendingDeleteExpireMsg:
+		return h.handlePendingDeleteExpire(msg)
 
 	case sessionRestartMsg:
 		if msg.err != nil {
@@ -608,9 +614,21 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		h.sessions = msg.sessions
 		h.rebuildSessionMap()
+		// Load pinned repos from storage.
+		if pinnedPaths, err := h.storage.LoadPinnedRepos(); err == nil {
+			for _, p := range pinnedPaths {
+				h.pinnedRepos[p] = true
+			}
+		}
 		// Default all repos to expanded on first load.
 		groups := session.GroupByRepo(h.sessions)
 		for repo := range groups {
+			if _, exists := h.repoExpanded[repo]; !exists {
+				h.repoExpanded[repo] = true
+			}
+		}
+		// Also expand pinned repos that have no sessions.
+		for repo := range h.pinnedRepos {
 			if _, exists := h.repoExpanded[repo]; !exists {
 				h.repoExpanded[repo] = true
 			}
@@ -1014,10 +1032,33 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "f":
 		return h, h.forkSelected()
 	case "d":
+		// Handle d on empty pinned repo header: unpin directly.
+		if h.cursor >= 0 && h.cursor < len(h.flatItems) && h.flatItems[h.cursor].IsRepoHeader {
+			item := h.flatItems[h.cursor]
+			if h.countSessionsForRepo(item.RepoPath) == 0 && h.pinnedRepos[item.RepoPath] {
+				delete(h.pinnedRepos, item.RepoPath)
+				if err := h.storage.UnpinRepo(item.RepoPath); err != nil {
+					debuglog.Logger.Error("failed to unpin repo", "repo", item.RepoPath, "err", err)
+				}
+				h.actionLog.Add("unpin repo", filepath.Base(item.RepoPath), true)
+				h.rebuildFlatItems()
+				// Fix cursor if it's now out of bounds.
+				if h.cursor >= len(h.flatItems) {
+					h.cursor = len(h.flatItems) - 1
+				}
+				if h.cursor < 0 {
+					h.cursor = 0
+				}
+				return h, nil
+			}
+			return h, nil // non-empty repo header, ignore
+		}
 		if s := h.selectedSession(); s != nil {
 			h.actionLog.Add("delete session", s.Title, true)
 		}
 		return h, h.confirmDeleteSelected()
+	case "z":
+		return h.undoDelete()
 	case "r":
 		if s := h.selectedSession(); s != nil {
 			h.actionLog.Add("restart session", s.Title, true)
@@ -1100,6 +1141,8 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.controlClient != nil {
 			h.controlClient.Close()
 		}
+		// Finalize all pending deletes before quitting.
+		h.finalizeAllPendingDeletes()
 		analytics.Track(analytics.EventAppQuit, map[string]interface{}{
 			"uptime_seconds": int(time.Since(h.startTime).Seconds()),
 		})
@@ -1187,9 +1230,15 @@ func (h *Home) handleSessionCreateResult(msg sessionCreateResultMsg) (tea.Model,
 	h.rebuildSessionMap()
 	h.workerMu.Unlock()
 
-	// Ensure the repo group is expanded for the new session.
+	// Ensure the repo group is expanded for the new session and pin it.
 	repo := session.GetRepoRoot(s.ProjectPath)
 	h.repoExpanded[repo] = true
+	if !h.pinnedRepos[repo] {
+		h.pinnedRepos[repo] = true
+		if err := h.storage.PinRepo(repo); err != nil {
+			debuglog.Logger.Error("failed to pin repo", "repo", repo, "err", err)
+		}
+	}
 	h.rebuildFlatItems()
 
 	// Save to storage.
@@ -1220,28 +1269,46 @@ func (h *Home) confirmDeleteSelected() tea.Cmd {
 
 	id := s.ID
 	wsName := s.WorkspaceName
+	repoPath := session.GetRepoRoot(s.ProjectPath)
+	isLastInRepo := h.countSessionsForRepo(repoPath) == 1 && h.pinnedRepos[repoPath]
+	hasDestroyableWorkspace := false
 
 	if wsName != "" {
-		repoPath := session.GetRepoRoot(s.ProjectPath)
 		provider := workspace.ResolveProvider(repoPath)
-		if provider.CanDestroy() {
-			h.confirmDialog.ShowDangerWithWorkspace("Delete Session?", s.Title, []string{
-				"tmux session terminated",
-				"Terminal history lost",
-			}, wsName, func() tea.Msg {
-				return sessionDeleteMsg{id: id}
-			}, func() tea.Msg {
-				return sessionDeleteMsg{id: id, destroyWorkspace: true, workspaceName: wsName}
-			})
-			return nil
-		}
+		hasDestroyableWorkspace = provider.CanDestroy()
 	}
-	h.confirmDialog.ShowDanger("Delete Session?", s.Title, []string{
+
+	details := []string{
 		"tmux session terminated",
 		"Terminal history lost",
-	}, func() tea.Msg {
+	}
+	if isLastInRepo {
+		details = append(details, "Last session in this repo")
+	}
+
+	onYes := func() tea.Msg {
 		return sessionDeleteMsg{id: id}
-	})
+	}
+	onRemoveRepo := func() tea.Msg {
+		return sessionDeleteMsg{id: id, unpinRepo: true, repoPath: repoPath}
+	}
+
+	switch {
+	case hasDestroyableWorkspace && isLastInRepo:
+		onYesWS := func() tea.Msg {
+			return sessionDeleteMsg{id: id, destroyWorkspace: true, workspaceName: wsName}
+		}
+		h.confirmDialog.ShowDangerLastInRepoWithWorkspace("Delete Session?", s.Title, details, wsName, onYes, onYesWS, onRemoveRepo)
+	case hasDestroyableWorkspace:
+		onYesWS := func() tea.Msg {
+			return sessionDeleteMsg{id: id, destroyWorkspace: true, workspaceName: wsName}
+		}
+		h.confirmDialog.ShowDangerWithWorkspace("Delete Session?", s.Title, details, wsName, onYes, onYesWS)
+	case isLastInRepo:
+		h.confirmDialog.ShowDangerLastInRepo("Delete Session?", s.Title, details, onYes, onRemoveRepo)
+	default:
+		h.confirmDialog.ShowDanger("Delete Session?", s.Title, details, onYes)
+	}
 	return nil
 }
 
@@ -1663,35 +1730,37 @@ func (h *Home) openPRInBrowser() tea.Cmd {
 	}
 }
 
-func (h *Home) deleteSession(id string) {
-	s, ok := h.sessionByID[id]
+// deferDelete removes a session from the UI and DB but defers tmux/hook/workspace
+// cleanup for the undo window. Returns a tick command for expiry.
+func (h *Home) deferDelete(msg sessionDeleteMsg) (tea.Model, tea.Cmd) {
+	s, ok := h.sessionByID[msg.id]
 	if !ok {
-		return
+		return h, nil
 	}
 
-	debuglog.Logger.Info("deleting session", "id", id, "title", s.Title)
+	debuglog.Logger.Info("deferred delete", "id", msg.id, "title", s.Title)
 
-	// Kill tmux session if alive.
-	if s.IsAlive() {
-		if err := s.Kill(); err != nil {
-			debuglog.Logger.Error("failed to kill tmux session", "id", id, "err", err)
+	// Snapshot DB row before deleting.
+	row := s.ToRow()
+	repoPath := session.GetRepoRoot(s.ProjectPath)
+
+	// Delete from SQLite immediately (crash-safe).
+	if err := h.storage.DeleteSession(msg.id); err != nil {
+		debuglog.Logger.Error("failed to delete session from storage", "id", msg.id, "err", err)
+	}
+
+	// Handle repo unpin if requested.
+	if msg.unpinRepo {
+		delete(h.pinnedRepos, msg.repoPath)
+		if err := h.storage.UnpinRepo(msg.repoPath); err != nil {
+			debuglog.Logger.Error("failed to unpin repo", "repo", msg.repoPath, "err", err)
 		}
 	}
 
-	// Remove from storage.
-	if err := h.storage.DeleteSession(id); err != nil {
-		debuglog.Logger.Error("failed to delete session from storage", "id", id, "err", err)
-	}
-
-	// Remove hook status file.
-	if err := os.Remove(filepath.Join(hooks.GetHooksDir(), id+".json")); err != nil && !os.IsNotExist(err) {
-		debuglog.Logger.Error("failed to remove hook status file", "id", id, "err", err)
-	}
-
-	// Remove from list.
+	// Remove from in-memory session list.
 	var remaining []*session.Session
 	for _, sess := range h.sessions {
-		if sess.ID != id {
+		if sess.ID != msg.id {
 			remaining = append(remaining, sess)
 		}
 	}
@@ -1709,6 +1778,176 @@ func (h *Home) deleteSession(id string) {
 	if len(h.flatItems) > 0 && h.flatItems[h.cursor].IsRepoHeader {
 		h.cursor = NextSelectableItem(h.flatItems, h.cursor, 1)
 	}
+
+	// Generate nonce for timer matching.
+	nonceBytes := make([]byte, 8)
+	_, _ = rand.Read(nonceBytes)
+	nonce := hex.EncodeToString(nonceBytes)
+
+	// Push onto undo stack.
+	h.pendingDeletes = append(h.pendingDeletes, PendingDelete{
+		Nonce:         nonce,
+		Session:       s,
+		Row:           row,
+		RepoPath:      repoPath,
+		DestroyWS:     msg.destroyWorkspace,
+		WorkspaceName: msg.workspaceName,
+		UnpinRepo:     msg.unpinRepo,
+		DeletedAt:     time.Now(),
+	})
+
+	// Show undo flash.
+	h.setInfo(h.buildUndoFlashMessage())
+
+	// Start expiry timer.
+	return h, tea.Tick(undoDeleteTimeout, func(t time.Time) tea.Msg {
+		return pendingDeleteExpireMsg{nonce: nonce}
+	})
+}
+
+// undoDelete restores the most recent pending delete.
+func (h *Home) undoDelete() (tea.Model, tea.Cmd) {
+	if len(h.pendingDeletes) == 0 {
+		return h, nil
+	}
+
+	// Pop most recent.
+	pd := h.pendingDeletes[len(h.pendingDeletes)-1]
+	h.pendingDeletes = h.pendingDeletes[:len(h.pendingDeletes)-1]
+
+	debuglog.Logger.Info("undo delete", "id", pd.Session.ID, "title", pd.Session.Title)
+
+	// Re-insert into SQLite.
+	if err := h.storage.SaveSession(pd.Row); err != nil {
+		h.setError(fmt.Errorf("undo failed: %w", err))
+		return h, nil
+	}
+
+	// Re-pin repo if it was unpinned.
+	if pd.UnpinRepo {
+		h.pinnedRepos[pd.RepoPath] = true
+		if err := h.storage.PinRepo(pd.RepoPath); err != nil {
+			debuglog.Logger.Error("failed to re-pin repo on undo", "repo", pd.RepoPath, "err", err)
+		}
+	}
+
+	// Re-add to session list (tmux is still alive).
+	h.workerMu.Lock()
+	h.sessions = append(h.sessions, pd.Session)
+	h.rebuildSessionMap()
+	h.workerMu.Unlock()
+
+	// Expand repo group and rebuild sidebar.
+	h.repoExpanded[pd.RepoPath] = true
+	h.rebuildFlatItems()
+
+	// Move cursor to restored session.
+	for i, item := range h.flatItems {
+		if !item.IsRepoHeader && item.Session != nil && item.Session.ID == pd.Session.ID {
+			h.cursor = i
+			h.syncViewport()
+			break
+		}
+	}
+
+	h.actionLog.Add("undo delete", pd.Session.Title, true)
+	h.setInfo(fmt.Sprintf("Restored %q", pd.Session.Title))
+	return h, nil
+}
+
+// handlePendingDeleteExpire finalizes a deferred delete after the undo window.
+func (h *Home) handlePendingDeleteExpire(msg pendingDeleteExpireMsg) (tea.Model, tea.Cmd) {
+	// Find by nonce.
+	idx := -1
+	for i, pd := range h.pendingDeletes {
+		if pd.Nonce == msg.nonce {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return h, nil // already undone
+	}
+
+	pd := h.pendingDeletes[idx]
+	h.pendingDeletes = append(h.pendingDeletes[:idx], h.pendingDeletes[idx+1:]...)
+
+	return h, h.finalizeDelete(pd)
+}
+
+// finalizeDelete performs the actual cleanup (tmux kill, hook removal, workspace destruction).
+func (h *Home) finalizeDelete(pd PendingDelete) tea.Cmd {
+	debuglog.Logger.Info("finalizing delete", "id", pd.Session.ID, "title", pd.Session.Title)
+
+	// Kill tmux session if alive.
+	if pd.Session.IsAlive() {
+		if err := pd.Session.Kill(); err != nil {
+			debuglog.Logger.Error("failed to kill tmux session", "id", pd.Session.ID, "err", err)
+		}
+	}
+
+	// Remove hook status file.
+	if err := os.Remove(filepath.Join(hooks.GetHooksDir(), pd.Session.ID+".json")); err != nil && !os.IsNotExist(err) {
+		debuglog.Logger.Error("failed to remove hook status file", "id", pd.Session.ID, "err", err)
+	}
+
+	// If workspace destroy requested, do it async.
+	if pd.DestroyWS && pd.WorkspaceName != "" {
+		repoPath := pd.RepoPath
+		wsName := pd.WorkspaceName
+		sid := pd.Session.ID
+		provider := workspace.ResolveProvider(repoPath)
+		if provider != nil && provider.CanDestroy() {
+			return func() tea.Msg {
+				err := provider.Destroy(repoPath, wsName)
+				return workspaceDestroyResultMsg{sessionID: sid, err: err}
+			}
+		}
+	}
+
+	return nil
+}
+
+// finalizeAllPendingDeletes cleans up all pending deletes synchronously (called on quit).
+func (h *Home) finalizeAllPendingDeletes() {
+	for _, pd := range h.pendingDeletes {
+		debuglog.Logger.Info("finalizing pending delete on quit", "id", pd.Session.ID, "title", pd.Session.Title)
+		if pd.Session.IsAlive() {
+			if err := pd.Session.Kill(); err != nil {
+				debuglog.Logger.Error("failed to kill tmux session on quit", "id", pd.Session.ID, "err", err)
+			}
+		}
+		if err := os.Remove(filepath.Join(hooks.GetHooksDir(), pd.Session.ID+".json")); err != nil && !os.IsNotExist(err) {
+			debuglog.Logger.Error("failed to remove hook status file on quit", "id", pd.Session.ID, "err", err)
+		}
+		// Note: workspace destruction skipped on quit (async operation, app is exiting).
+	}
+	h.pendingDeletes = nil
+}
+
+// buildUndoFlashMessage builds the flash message for the undo prompt.
+func (h *Home) buildUndoFlashMessage() string {
+	n := len(h.pendingDeletes)
+	if n == 0 {
+		return ""
+	}
+	last := h.pendingDeletes[n-1]
+	title := last.Session.Title
+	if n == 1 {
+		return fmt.Sprintf("Deleted %q. z to undo", title)
+	}
+	return fmt.Sprintf("Deleted %q. z to undo (%d pending)", title, n)
+}
+
+// countSessionsForRepo counts live sessions for a given repo path.
+func (h *Home) countSessionsForRepo(repoPath string) int {
+	count := 0
+	for _, s := range h.sessions {
+		if session.GetRepoRoot(s.ProjectPath) == repoPath {
+			count++
+		}
+	}
+	return count
 }
 
 // --- Tick / status ---
@@ -2130,7 +2369,7 @@ func (h *Home) selectedRepoInfo() *git.RepoInfo {
 // --- Internal helpers ---
 
 func (h *Home) rebuildFlatItems() {
-	h.flatItems = BuildFlatItems(h.sessions, h.pendingWorkspaces, h.repoExpanded, h.filterText)
+	h.flatItems = BuildFlatItems(h.sessions, h.pendingWorkspaces, h.repoExpanded, h.filterText, h.pinnedRepos)
 	h.sidebarDirty = true
 }
 

--- a/internal/ui/dialogs.go
+++ b/internal/ui/dialogs.go
@@ -390,11 +390,13 @@ type ConfirmDialog struct {
 	height         int
 	onYes          func() tea.Msg
 	onYesWorkspace func() tea.Msg
+	onRemoveRepo   func() tea.Msg
 	dialogType     string // "danger", "warning", "info"
 	title          string
 	subject        string
 	details        []string
 	hasWorkspace   bool
+	hasRemoveRepo  bool
 	workspaceName  string
 }
 
@@ -413,6 +415,8 @@ func (d *ConfirmDialog) ShowDanger(title, subject string, details []string, onYe
 	d.onYes = onYes
 	d.hasWorkspace = false
 	d.onYesWorkspace = nil
+	d.hasRemoveRepo = false
+	d.onRemoveRepo = nil
 	d.workspaceName = ""
 }
 
@@ -427,6 +431,38 @@ func (d *ConfirmDialog) ShowDangerWithWorkspace(title, subject string, details [
 	d.hasWorkspace = true
 	d.workspaceName = workspaceName
 	d.onYesWorkspace = onYesWorkspace
+	d.hasRemoveRepo = false
+	d.onRemoveRepo = nil
+}
+
+// ShowDangerLastInRepo shows a danger dialog with the "D +Remove Repo" option for the last session in a pinned repo.
+func (d *ConfirmDialog) ShowDangerLastInRepo(title, subject string, details []string, onYes func() tea.Msg, onRemoveRepo func() tea.Msg) {
+	d.visible = true
+	d.dialogType = "danger"
+	d.title = title
+	d.subject = subject
+	d.details = details
+	d.onYes = onYes
+	d.hasWorkspace = false
+	d.onYesWorkspace = nil
+	d.hasRemoveRepo = true
+	d.onRemoveRepo = onRemoveRepo
+	d.workspaceName = ""
+}
+
+// ShowDangerLastInRepoWithWorkspace shows a danger dialog with both workspace destroy and remove repo options.
+func (d *ConfirmDialog) ShowDangerLastInRepoWithWorkspace(title, subject string, details []string, workspaceName string, onYes func() tea.Msg, onYesWorkspace func() tea.Msg, onRemoveRepo func() tea.Msg) {
+	d.visible = true
+	d.dialogType = "danger"
+	d.title = title
+	d.subject = subject
+	d.details = details
+	d.onYes = onYes
+	d.hasWorkspace = true
+	d.workspaceName = workspaceName
+	d.onYesWorkspace = onYesWorkspace
+	d.hasRemoveRepo = true
+	d.onRemoveRepo = onRemoveRepo
 }
 
 // Show shows a basic info-style confirmation dialog (backward compatible).
@@ -449,6 +485,13 @@ func (d *ConfirmDialog) SetSize(w, h int) {
 func (d *ConfirmDialog) Update(msg tea.Msg) (*ConfirmDialog, tea.Cmd) {
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		switch keyMsg.String() {
+		case "D":
+			if d.hasRemoveRepo && d.onRemoveRepo != nil {
+				cb := d.onRemoveRepo
+				d.Hide()
+				return d, func() tea.Msg { return cb() }
+			}
+			return d, nil
 		case "Y":
 			if d.hasWorkspace && d.onYesWorkspace != nil {
 				cb := d.onYesWorkspace
@@ -537,12 +580,22 @@ func (d *ConfirmDialog) View() string {
 			Render("Y +Workspace") + "  "
 	}
 
+	var repoBtn string
+	if d.hasRemoveRepo {
+		repoBtn = lipgloss.NewStyle().
+			Background(ColorOrange).
+			Foreground(ColorBg).
+			Bold(true).
+			Padding(0, 1).
+			Render("D +Remove Repo") + "  "
+	}
+
 	cancelBtn := lipgloss.NewStyle().
 		Background(ColorBorder).
 		Foreground(ColorText).
 		Padding(0, 1).
 		Render("n Cancel")
-	b.WriteString(actionBtn + "  " + wsBtn + cancelBtn)
+	b.WriteString(actionBtn + "  " + wsBtn + repoBtn + cancelBtn)
 
 	boxStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -29,6 +29,7 @@ var allKeyBindings = []KeyBinding{
 	{Key: "w", BarKey: "w", BarDesc: "Wktree", Desc: "New worktree session", Section: "session"},
 	{Key: "f", Desc: "Fork session", Section: "session"},
 	{Key: "d", BarKey: "d", BarDesc: "Del", Desc: "Delete session", Section: "session"},
+	{Key: "z", Desc: "Undo delete", Section: "session"},
 	{Key: "r", BarKey: "r", BarDesc: "Restart", Desc: "Restart session", Section: "session"},
 	{Key: "R", Desc: "Rename session", Section: "session"},
 	{Key: "e", Desc: "Open in editor", Section: "session"},

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -40,13 +40,21 @@ type RepoGroupInfo struct {
 // expanded maps repo path -> whether the group is expanded.
 // filter, when non-empty, only includes sessions whose title contains the filter string.
 // pending workspaces are injected as phantom entries under their repo group.
-func BuildFlatItems(sessions []*session.Session, pending []*PendingWorkspace, expanded map[string]bool, filter string) []SidebarItem {
+// pinnedRepos includes repos that should appear even with no sessions.
+func BuildFlatItems(sessions []*session.Session, pending []*PendingWorkspace, expanded map[string]bool, filter string, pinnedRepos map[string]bool) []SidebarItem {
 	groups := session.GroupByRepo(sessions)
 
 	// Include repos that only have pending workspaces (no sessions yet).
 	for _, pw := range pending {
 		if _, exists := groups[pw.RepoPath]; !exists {
 			groups[pw.RepoPath] = nil
+		}
+	}
+
+	// Include pinned repos even if they have no sessions or pending workspaces.
+	for repo := range pinnedRepos {
+		if _, exists := groups[repo]; !exists {
+			groups[repo] = nil
 		}
 	}
 
@@ -300,13 +308,22 @@ func renderRepoHeader(repoPath string, expanded bool, info RepoGroupInfo, repoIn
 		prStr = " " + renderPRBadge(repoInfo.PR, selected)
 	}
 
+	isEmpty := info.SessionCount == 0
+
 	if selected {
 		icon := SessionSelectionPrefix.Render(expandIcon)
 		styledName := SessionTitleSelStyle.Render(" " + name + " ")
+		if isEmpty {
+			emptyLabel := SessionStatusSelStyle.Render("(empty)")
+			return fmt.Sprintf(" %s %s %s", icon, styledName, emptyLabel) + prStr
+		}
 		styledCount := SessionStatusSelStyle.Render(fmt.Sprintf("(%d)", info.SessionCount))
 		return fmt.Sprintf(" %s %s%s%s %s", icon, styledName, branchStr, dirtyStr, styledCount) + statsStr + prStr
 	}
 	icon := DimStyle.Render(expandIcon)
+	if isEmpty {
+		return fmt.Sprintf(" %s %s %s", icon, DimStyle.Render(name), DimStyle.Render("(empty)")) + prStr
+	}
 	return fmt.Sprintf(" %s %s%s%s %s", icon, RepoHeaderStyle.Render(name), branchStr, dirtyStr, countStr) + statsStr + prStr
 }
 


### PR DESCRIPTION
## Summary
- **Undo delete** (`z` key): session deletion deferred 5s — tmux kept alive, press `z` to fully restore. Stack-based (multiple deletes each undoable, LIFO). All pending deletes finalized on quit.
- **Sticky repos**: repos auto-pinned in SQLite on session creation. Empty repos persist in sidebar (dimmed, "(empty)" label) until dismissed with `d` on header. `D` in delete dialog also removes repo when it's the last session.

Closes #43

## Test plan
- [ ] Create session → delete → press `z` within 5s → session restored with live tmux
- [ ] Delete last session in repo → repo header stays (dimmed, empty) → `a` creates new session there
- [ ] Delete last session with `D +Remove Repo` → repo header removed
- [ ] Delete 3 sessions quickly → `z` restores most recent first
- [ ] Quit during undo window → tmux sessions cleaned up
- [ ] Restart app → pinned empty repos still visible
- [ ] `d` on empty repo header → repo removed from sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)