### PR TITLE
ci: add CodeRabbit AI reviewer config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: go
+early_access: false
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - master
+  path_filters:
+    - "!**/*.pb.go"
+    - "!**/mocks/**"
+    - "!build/**"
+    - "!vendor/**"
+    - "!chrome-extension/icons/**"
+  path_instructions:
+    - path: "internal/ui/**"
+      instructions: |
+        Bubble Tea conventions: no blocking I/O in Update() — all tmux/git/gh
+        calls must be dispatched via the worker goroutine. Flag anything that
+        calls tmux/git/exec directly inside a message handler.
+    - path: "internal/hooks/**"
+      instructions: |
+        Status files live under ~/.config/brizz-code/hooks/<session_id>.json.
+        Hooks are authoritative: never override hook=running with pane=waiting.
+    - path: ".github/workflows/**"
+      instructions: |
+        Public repo — flag any use of pull_request_target that also checks out
+        the PR head SHA with secrets in env. Flag missing minimal permissions
+        blocks and any secret echoed to logs.
+tools:
+  golangci-lint:
+    enabled: true
+  gitleaks:
+    enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-language: go
+language: en-US
 early_access: false
 reviews:
   profile: chill

--- a/changelog/unreleased/coderabbit.md
+++ b/changelog/unreleased/coderabbit.md
@@ -1,4 +1,4 @@
 ---
 type: added
 ---
-AI-powered PR reviews via CodeRabbit: every pull request now gets an auto-generated walkthrough and inline review comments. Config lives at `.coderabbit.yaml` (Go-aware, `chill` tone, golangci-lint + gitleaks wired in, path instructions that flag Bubble Tea anti-patterns and public-repo workflow hazards). Free for public repos — contributors don't need anything set up on their side.
+AI-powered PR review config via CodeRabbit: `.coderabbit.yaml` tunes the reviewer for Go (chill tone, golangci-lint + gitleaks wired in, path instructions that flag Bubble Tea anti-patterns and public-repo workflow hazards). Once the CodeRabbit GitHub App is installed on the repo, every PR gets an auto-generated walkthrough and inline review comments. Free for public repos — contributors don't need anything set up on their side.

--- a/changelog/unreleased/coderabbit.md
+++ b/changelog/unreleased/coderabbit.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+AI-powered PR reviews via CodeRabbit: every pull request now gets an auto-generated walkthrough and inline review comments. Config lives at `.coderabbit.yaml` (Go-aware, `chill` tone, golangci-lint + gitleaks wired in, path instructions that flag Bubble Tea anti-patterns and public-repo workflow hazards). Free for public repos — contributors don't need anything set up on their side.


### PR DESCRIPTION
## Summary
- Adds `.coderabbit.yaml` to enable CodeRabbit AI review on PRs (free for public repos, no secrets required — GitHub App auth only)
- Config tuned for brizz-code: Go language, `chill` profile, poem off, drafts skipped, golangci-lint + gitleaks enabled
- Path instructions flag Bubble Tea anti-patterns (blocking I/O in `Update()`), hook-precedence rules in `internal/hooks/**`, and public-repo workflow safety (e.g. `pull_request_target` + PR-head checkout + secrets)

## Next steps (not in this PR)
- Install the CodeRabbit GitHub App on the repo (one-click at https://app.coderabbit.ai/login) — required for the config to take effect
- Optional follow-ups: GitHub Copilot code review, Qodo PR-Agent (Gemini), CodeQL on public repo, Codecov

## Test plan
- [ ] Install CodeRabbit GitHub App on `brizzai/brizz-code`
- [ ] Confirm first PR (this one) gets an auto-generated walkthrough + review
- [ ] Verify `chill` profile tone matches repo vibe (adjust to `assertive` if too soft)
- [ ] Comment `/no-changelog` if CI blocks on missing changelog fragment (tooling-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository configuration to enable automated, Go-aware PR reviews with a relaxed "chill" review profile, path-specific guidance for common patterns (UI, hooks, workflows), and auto-reviews for non-draft PRs; enabled linting and secret-scanning tools for improved quality and security checks.

* **Documentation**
  * Added a changelog entry describing the rollout, behavior, and configuration surface of the automated review integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->