### PR TITLE
feat(ui): enforce valid git branch names in worktree dialogs

### DIFF
--- a/changelog/unreleased/worktree-branch-name-enforce.md
+++ b/changelog/unreleased/worktree-branch-name-enforce.md
@@ -1,0 +1,4 @@
+---
+type: improved
+---
+Worktree dialogs now guide you toward a valid git branch name as you type: spaces become `-`, and chars git forbids anywhere (`~ ^ : ? * [ \` and control chars) are dropped live. Rules that can't be fixed silently (leading `-`, `..`, trailing `.lock`, etc.) show a friendly inline error on submit instead of a cryptic `git worktree add` failure.

--- a/internal/ui/workspace_create.go
+++ b/internal/ui/workspace_create.go
@@ -184,8 +184,8 @@ func (d *CreateWorkspaceDialog) Update(msg tea.Msg) (*CreateWorkspaceDialog, tea
 		if d.isNative {
 			// Native git mode: branch is the only input.
 			branch := strings.TrimSpace(d.branchInput.Value())
-			if branch == "" {
-				d.err = "Branch cannot be empty"
+			if errMsg := workspace.ValidateBranchName(branch); errMsg != "" {
+				d.err = errMsg
 				return d, nil
 			}
 			d.err = ""
@@ -213,12 +213,21 @@ func (d *CreateWorkspaceDialog) Update(msg tea.Msg) (*CreateWorkspaceDialog, tea
 
 	// Route to focused input.
 	var cmd tea.Cmd
+	branchTouched := false
 	if d.isNative {
 		d.branchInput, cmd = d.branchInput.Update(msg)
+		branchTouched = true
 	} else if d.focusIndex == 0 {
 		d.nameInput, cmd = d.nameInput.Update(msg)
 	} else {
 		d.branchInput, cmd = d.branchInput.Update(msg)
+		branchTouched = true
+	}
+	if branchTouched {
+		if sanitized := workspace.SanitizeBranchInput(d.branchInput.Value()); sanitized != d.branchInput.Value() {
+			d.branchInput.SetValue(sanitized)
+			d.branchInput.CursorEnd()
+		}
 	}
 	return d, cmd
 }

--- a/internal/ui/workspace_create.go
+++ b/internal/ui/workspace_create.go
@@ -224,9 +224,11 @@ func (d *CreateWorkspaceDialog) Update(msg tea.Msg) (*CreateWorkspaceDialog, tea
 		branchTouched = true
 	}
 	if branchTouched {
-		if sanitized := workspace.SanitizeBranchInput(d.branchInput.Value()); sanitized != d.branchInput.Value() {
+		current := d.branchInput.Value()
+		sanitized, newPos := workspace.SanitizeBranchInputWithCursor(current, d.branchInput.Position())
+		if sanitized != current {
 			d.branchInput.SetValue(sanitized)
-			d.branchInput.CursorEnd()
+			d.branchInput.SetCursor(newPos)
 		}
 	}
 	return d, cmd

--- a/internal/ui/workspace_picker.go
+++ b/internal/ui/workspace_picker.go
@@ -202,8 +202,8 @@ func (d *WorktreeDialog) Update(msg tea.Msg) (*WorktreeDialog, tea.Cmd) {
 		}
 		// Create new worktree from inputs.
 		newBranch := strings.TrimSpace(d.newBranchInput.Value())
-		if newBranch == "" {
-			d.err = "Branch name cannot be empty"
+		if errMsg := workspace.ValidateBranchName(newBranch); errMsg != "" {
+			d.err = errMsg
 			return d, nil
 		}
 		baseBranch := strings.TrimSpace(d.baseBranchInput.Value())
@@ -228,6 +228,10 @@ func (d *WorktreeDialog) Update(msg tea.Msg) (*WorktreeDialog, tea.Cmd) {
 		d.baseBranchInput, cmd = d.baseBranchInput.Update(msg)
 	case focusNewBranch:
 		d.newBranchInput, cmd = d.newBranchInput.Update(msg)
+		if sanitized := workspace.SanitizeBranchInput(d.newBranchInput.Value()); sanitized != d.newBranchInput.Value() {
+			d.newBranchInput.SetValue(sanitized)
+			d.newBranchInput.CursorEnd()
+		}
 	}
 	return d, cmd
 }

--- a/internal/ui/workspace_picker.go
+++ b/internal/ui/workspace_picker.go
@@ -228,9 +228,11 @@ func (d *WorktreeDialog) Update(msg tea.Msg) (*WorktreeDialog, tea.Cmd) {
 		d.baseBranchInput, cmd = d.baseBranchInput.Update(msg)
 	case focusNewBranch:
 		d.newBranchInput, cmd = d.newBranchInput.Update(msg)
-		if sanitized := workspace.SanitizeBranchInput(d.newBranchInput.Value()); sanitized != d.newBranchInput.Value() {
+		current := d.newBranchInput.Value()
+		sanitized, newPos := workspace.SanitizeBranchInputWithCursor(current, d.newBranchInput.Position())
+		if sanitized != current {
 			d.newBranchInput.SetValue(sanitized)
-			d.newBranchInput.CursorEnd()
+			d.newBranchInput.SetCursor(newPos)
 		}
 	}
 	return d, cmd

--- a/internal/workspace/provider.go
+++ b/internal/workspace/provider.go
@@ -326,26 +326,48 @@ func SanitizeBranchName(branch string) string {
 }
 
 // SanitizeBranchInput normalizes a partial branch-name input for live display:
-// space becomes '-', and chars git forbids anywhere in a ref (~ ^ : ? * [ \ and
-// ASCII control chars) are dropped. '/' is kept so users can type hierarchical
-// names like "feature/login". Positional rules (leading '-', trailing '.lock',
-// etc.) are left to ValidateBranchName so we don't eat characters mid-type.
+// space becomes '-', and chars git forbids anywhere in a ref (~ ^ : ? * [ \ `
+// and ASCII control chars) are dropped. '/' is kept so users can type
+// hierarchical names like "feature/login". Positional rules (leading '-',
+// per-component leading '.', trailing '.lock', etc.) are left to
+// ValidateBranchName so we don't eat characters mid-type.
 func SanitizeBranchInput(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	for _, r := range s {
+	out, _ := SanitizeBranchInputWithCursor(s, 0)
+	return out
+}
+
+// SanitizeBranchInputWithCursor is SanitizeBranchInput with cursor preservation:
+// it returns the sanitized string and the adjusted rune-position cursor so
+// callers can keep the user's edit point after live sanitation. Cursor units
+// match bubbles/textinput.Position (rune index).
+func SanitizeBranchInputWithCursor(s string, cursor int) (string, int) {
+	runes := []rune(s)
+	newRunes := make([]rune, 0, len(runes))
+	newCursor := cursor
+	for i, r := range runes {
+		keep := true
+		out := r
 		switch {
 		case r == ' ':
-			b.WriteByte('-')
+			out = '-'
 		case r < 0x20 || r == 0x7f:
-			// drop ASCII control chars
-		case r == '~' || r == '^' || r == ':' || r == '?' || r == '*' || r == '[' || r == '\\':
-			// drop chars git forbids anywhere in a ref
-		default:
-			b.WriteRune(r)
+			keep = false
+		case r == '~' || r == '^' || r == ':' || r == '?' || r == '*' || r == '[' || r == '\\' || r == '`':
+			keep = false
+		}
+		if keep {
+			newRunes = append(newRunes, out)
+		} else if i < cursor {
+			newCursor--
 		}
 	}
-	return b.String()
+	if newCursor < 0 {
+		newCursor = 0
+	}
+	if newCursor > len(newRunes) {
+		newCursor = len(newRunes)
+	}
+	return string(newRunes), newCursor
 }
 
 // ValidateBranchName returns a user-friendly error message if branch violates
@@ -363,17 +385,9 @@ func ValidateBranchName(branch string) string {
 		return "Branch name cannot start with '-'"
 	case '/':
 		return "Branch name cannot start with '/'"
-	case '.':
-		return "Branch name cannot start with '.'"
 	}
-	switch branch[len(branch)-1] {
-	case '.':
-		return "Branch name cannot end with '.'"
-	case '/':
+	if branch[len(branch)-1] == '/' {
 		return "Branch name cannot end with '/'"
-	}
-	if strings.HasSuffix(branch, ".lock") {
-		return "Branch name cannot end with '.lock'"
 	}
 	if strings.Contains(branch, "..") {
 		return "Branch name cannot contain '..'"
@@ -383,6 +397,22 @@ func ValidateBranchName(branch string) string {
 	}
 	if strings.Contains(branch, "//") {
 		return "Branch name cannot contain '//'"
+	}
+	// Per-component rules (git check-ref-format applies these to each
+	// '/'-separated component, not just the whole string).
+	for _, comp := range strings.Split(branch, "/") {
+		if comp == "" {
+			continue
+		}
+		if comp[0] == '.' {
+			return "Branch name cannot have a component starting with '.'"
+		}
+		if comp[len(comp)-1] == '.' {
+			return "Branch name cannot have a component ending with '.'"
+		}
+		if strings.HasSuffix(comp, ".lock") {
+			return "Branch name cannot have a component ending with '.lock'"
+		}
 	}
 	return ""
 }

--- a/internal/workspace/provider.go
+++ b/internal/workspace/provider.go
@@ -325,6 +325,68 @@ func SanitizeBranchName(branch string) string {
 	return s
 }
 
+// SanitizeBranchInput normalizes a partial branch-name input for live display:
+// space becomes '-', and chars git forbids anywhere in a ref (~ ^ : ? * [ \ and
+// ASCII control chars) are dropped. '/' is kept so users can type hierarchical
+// names like "feature/login". Positional rules (leading '-', trailing '.lock',
+// etc.) are left to ValidateBranchName so we don't eat characters mid-type.
+func SanitizeBranchInput(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == ' ':
+			b.WriteByte('-')
+		case r < 0x20 || r == 0x7f:
+			// drop ASCII control chars
+		case r == '~' || r == '^' || r == ':' || r == '?' || r == '*' || r == '[' || r == '\\':
+			// drop chars git forbids anywhere in a ref
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// ValidateBranchName returns a user-friendly error message if branch violates
+// git check-ref-format rules that SanitizeBranchInput can't repair live. An
+// empty return value means the branch is acceptable.
+func ValidateBranchName(branch string) string {
+	if branch == "" {
+		return "Branch name cannot be empty"
+	}
+	if branch == "@" {
+		return "Branch name cannot be '@'"
+	}
+	switch branch[0] {
+	case '-':
+		return "Branch name cannot start with '-'"
+	case '/':
+		return "Branch name cannot start with '/'"
+	case '.':
+		return "Branch name cannot start with '.'"
+	}
+	switch branch[len(branch)-1] {
+	case '.':
+		return "Branch name cannot end with '.'"
+	case '/':
+		return "Branch name cannot end with '/'"
+	}
+	if strings.HasSuffix(branch, ".lock") {
+		return "Branch name cannot end with '.lock'"
+	}
+	if strings.Contains(branch, "..") {
+		return "Branch name cannot contain '..'"
+	}
+	if strings.Contains(branch, "@{") {
+		return "Branch name cannot contain '@{'"
+	}
+	if strings.Contains(branch, "//") {
+		return "Branch name cannot contain '//'"
+	}
+	return ""
+}
+
 // deriveWorktreePath computes the sibling worktree path.
 // e.g. repoPath="/code/myrepo", name="feature-login" -> "/code/myrepo-feature-login"
 func deriveWorktreePath(repoPath, name string) string {

--- a/internal/workspace/provider_test.go
+++ b/internal/workspace/provider_test.go
@@ -83,6 +83,7 @@ func TestSanitizeBranchInput(t *testing.T) {
 		{"strip star", "feat*bad", "featbad"},
 		{"strip bracket", "feat[bad", "featbad"},
 		{"strip backslash", "feat\\bad", "featbad"},
+		{"strip backtick", "feat`bad", "featbad"},
 		{"strip tab control", "feat\tbad", "featbad"},
 		{"strip del control", "feat\x7fbad", "featbad"},
 		{"keep slash", "feature/login", "feature/login"},
@@ -106,6 +107,37 @@ func TestSanitizeBranchInput(t *testing.T) {
 	}
 }
 
+func TestSanitizeBranchInputWithCursor(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		cursor     int
+		wantOut    string
+		wantCursor int
+	}{
+		{"no change", "feat", 2, "feat", 2},
+		{"space before cursor replaced (cursor unchanged)", "a b", 3, "a-b", 3},
+		{"drop char before cursor", "a~bc", 4, "abc", 3},
+		{"drop char after cursor", "ab~c", 2, "abc", 2},
+		{"drop char at cursor", "ab~c", 3, "abc", 2},
+		{"multiple drops before cursor", "~a~b~c", 6, "abc", 3},
+		{"cursor past end clamps", "abc", 10, "abc", 3},
+		{"negative cursor clamps to 0", "~abc", -1, "abc", 0},
+		{"empty string", "", 0, "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOut, gotCursor := SanitizeBranchInputWithCursor(tt.input, tt.cursor)
+			if gotOut != tt.wantOut {
+				t.Errorf("out = %q, want %q", gotOut, tt.wantOut)
+			}
+			if gotCursor != tt.wantCursor {
+				t.Errorf("cursor = %d, want %d", gotCursor, tt.wantCursor)
+			}
+		})
+	}
+}
+
 func TestValidateBranchName(t *testing.T) {
 	invalid := []struct {
 		name  string
@@ -116,9 +148,12 @@ func TestValidateBranchName(t *testing.T) {
 		{"leading dash", "-bad"},
 		{"leading slash", "/bad"},
 		{"leading dot", ".bad"},
+		{"component leading dot", "feature/.bad"},
 		{"trailing dot", "bad."},
+		{"component trailing dot", "a./b"},
 		{"trailing slash", "bad/"},
 		{"trailing .lock", "feature.lock"},
+		{"component .lock", "a.lock/b"},
 		{"double dot", "a..b"},
 		{"at brace", "a@{b"},
 		{"double slash", "a//b"},

--- a/internal/workspace/provider_test.go
+++ b/internal/workspace/provider_test.go
@@ -68,6 +68,86 @@ func TestParseWorktreePorcelain(t *testing.T) {
 	}
 }
 
+func TestSanitizeBranchInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"space becomes dash", "my branch", "my-branch"},
+		{"multiple spaces", "a b c d", "a-b-c-d"},
+		{"strip tilde", "feat~bad", "featbad"},
+		{"strip caret", "feat^bad", "featbad"},
+		{"strip colon", "feat:bad", "featbad"},
+		{"strip question", "feat?bad", "featbad"},
+		{"strip star", "feat*bad", "featbad"},
+		{"strip bracket", "feat[bad", "featbad"},
+		{"strip backslash", "feat\\bad", "featbad"},
+		{"strip tab control", "feat\tbad", "featbad"},
+		{"strip del control", "feat\x7fbad", "featbad"},
+		{"keep slash", "feature/login", "feature/login"},
+		{"keep dots", "v1.2.3", "v1.2.3"},
+		{"keep underscore", "fix_bug_123", "fix_bug_123"},
+		{"empty stays empty", "", ""},
+		{"mixed", "my cool~branch/v2 ", "my-coolbranch/v2-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeBranchInput(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitizeBranchInput(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+			// Idempotence.
+			if twice := SanitizeBranchInput(got); twice != got {
+				t.Errorf("SanitizeBranchInput not idempotent: %q -> %q -> %q", tt.input, got, twice)
+			}
+		})
+	}
+}
+
+func TestValidateBranchName(t *testing.T) {
+	invalid := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"at sign alone", "@"},
+		{"leading dash", "-bad"},
+		{"leading slash", "/bad"},
+		{"leading dot", ".bad"},
+		{"trailing dot", "bad."},
+		{"trailing slash", "bad/"},
+		{"trailing .lock", "feature.lock"},
+		{"double dot", "a..b"},
+		{"at brace", "a@{b"},
+		{"double slash", "a//b"},
+	}
+	for _, tt := range invalid {
+		t.Run("invalid/"+tt.name, func(t *testing.T) {
+			if got := ValidateBranchName(tt.input); got == "" {
+				t.Errorf("ValidateBranchName(%q) = \"\", want error message", tt.input)
+			}
+		})
+	}
+
+	valid := []string{
+		"feature-login",
+		"feature/login",
+		"fix-bug-123",
+		"v1.2.3",
+		"release/2026-04-16",
+		"a",
+	}
+	for _, v := range valid {
+		t.Run("valid/"+v, func(t *testing.T) {
+			if got := ValidateBranchName(v); got != "" {
+				t.Errorf("ValidateBranchName(%q) = %q, want \"\"", v, got)
+			}
+		})
+	}
+}
+
 func TestSanitizeBranchName(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary
- Worktree dialogs (`w` key and the native-git create-workspace sub-dialog) now guide the user toward a valid git branch name as they type: spaces become `-`, and chars git forbids anywhere in a ref (`~ ^ : ? * [ \` and ASCII control chars) are dropped live. `/` stays legal.
- Rules that can't be fixed silently (empty, leading `-/./`, trailing `./lock/`, `..`, `@{`, `//`, lone `@`) are checked on submit and surface as a friendly inline error in the dialog instead of a cryptic `git worktree add` failure.
- Two new helpers in `internal/workspace/provider.go`: `SanitizeBranchInput` (live-transform) and `ValidateBranchName` (submit-check), with full test coverage.

## Test plan
- [x] `make build`
- [x] `go test -race ./internal/ui/... ./internal/workspace/...`
- [ ] Manual TUI smoke test — press `w` on a worktree-enabled repo and try:
  - `my cool branch` → shows `my-cool-branch` live
  - `feat~evil` → tilde dropped as typed
  - `feature/login` → slash preserved; path preview shows `feature-login` dir
  - `-bad` + Enter → inline red error, no dispatch
  - `a..b` + Enter → inline red error
  - valid name + Enter → worktree created as before
- [ ] Repeat the same typing checks in the native-git create-workspace sub-dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live branch-name sanitization while typing (spaces -> dashes, disallowed chars removed) and improved inline validation to prevent cryptic git errors on submit.
* **Tests**
  * Added tests covering input sanitization, cursor behavior during edits, and branch-name validation for various edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->