### PR TITLE
fix(tmux): detect CSI-u encoded Ctrl+Q for detach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ var/
 
 # Claude Code local settings (may contain personal paths)
 .claude/settings.local.json
+
+# macOS
+.DS_Store

--- a/changelog/unreleased/ctrl-q-extended-keys.md
+++ b/changelog/unreleased/ctrl-q-extended-keys.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+Ctrl+Q detach now works when the host tmux config enables `extended-keys` (common in oh-my-tmux / iTerm2 setups). Previously the terminal encoded Ctrl+Q as `CSI 113;5 u` or `CSI 27;5;113 ~` instead of byte 17, so the interceptor missed it and the keystroke was forwarded to the pane.

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -20,6 +20,34 @@ import (
 
 const terminalStyleReset = "\x1b]8;;\x1b\\\x1b[0m\x1b[24m\x1b[39m\x1b[49m"
 
+// ctrlQSequences enumerates every byte pattern a terminal may emit for Ctrl+Q.
+// The bare control byte is the common case; the CSI variants appear when the
+// terminal has switched to CSI-u or xterm's modifyOtherKeys reporting (tmux
+// enables this via `extended-keys on`, which oh-my-tmux turns on for
+// iTerm2/mintty/xterm).
+var ctrlQSequences = [][]byte{
+	{17},                     // plain Ctrl+Q (ASCII DC1)
+	[]byte("\x1b[113;5u"),    // CSI-u / libtickit / kitty keyboard
+	[]byte("\x1b[27;5;113~"), // xterm modifyOtherKeys
+}
+
+// findCtrlQ returns the byte offset of the earliest Ctrl+Q sequence in buf
+// and the length of that sequence. Returns (-1, 0) when none is present.
+func findCtrlQ(buf []byte) (int, int) {
+	idx, length := -1, 0
+	for _, seq := range ctrlQSequences {
+		i := bytes.Index(buf, seq)
+		if i < 0 {
+			continue
+		}
+		if idx < 0 || i < idx {
+			idx = i
+			length = len(seq)
+		}
+	}
+	return idx, length
+}
+
 // Attach attaches to the tmux session with full PTY support.
 // Ctrl+Q detaches and returns to the caller. Ctrl+b d also works (tmux native).
 func (s *Session) Attach(ctx context.Context) error {
@@ -97,7 +125,7 @@ func (s *Session) Attach(ctx context.Context) error {
 		}
 	}()
 
-	// Goroutine: read stdin, intercept Ctrl+Q (ASCII 17), forward rest to PTY.
+	// Goroutine: read stdin, intercept Ctrl+Q (raw ASCII 17 or CSI-u / modifyOtherKeys encodings), forward rest to PTY.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -148,8 +176,8 @@ func forwardStdinToPTY(ptmx *os.File, startTime time.Time, controlSeqTimeout tim
 			continue
 		}
 
-		// Check for Ctrl+Q (ASCII 17).
-		if idx := bytes.IndexByte(buf[:n], 17); idx >= 0 {
+		// Check for Ctrl+Q in any encoding the terminal might use.
+		if idx, _ := findCtrlQ(buf[:n]); idx >= 0 {
 			if idx > 0 {
 				if _, werr := ptmx.Write(buf[:idx]); werr != nil {
 					select {

--- a/internal/tmux/pty_test.go
+++ b/internal/tmux/pty_test.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package tmux
+
+import "testing"
+
+func TestFindCtrlQ(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         []byte
+		wantIdx    int
+		wantLength int
+	}{
+		{"plain byte 17", []byte{17}, 0, 1},
+		{"byte 17 after payload", []byte{'h', 'i', 17}, 2, 1},
+		{"csi-u kitty format", []byte("\x1b[113;5u"), 0, 8},
+		{"csi-u after payload", append([]byte("hi"), []byte("\x1b[113;5u")...), 2, 8},
+		{"xterm modifyOtherKeys", []byte("\x1b[27;5;113~"), 0, 11},
+		{"modifyOtherKeys after payload", append([]byte("ab"), []byte("\x1b[27;5;113~")...), 2, 11},
+		{"not present", []byte("hello"), -1, 0},
+		{"empty", []byte{}, -1, 0},
+		{"unrelated csi", []byte("\x1b[A"), -1, 0},
+		{"earliest wins", append([]byte{17}, []byte("\x1b[113;5u")...), 0, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIdx, gotLength := findCtrlQ(tt.in)
+			if gotIdx != tt.wantIdx || gotLength != tt.wantLength {
+				t.Errorf("findCtrlQ(%q) = (%d, %d), want (%d, %d)",
+					tt.in, gotIdx, gotLength, tt.wantIdx, tt.wantLength)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `Ctrl+Q` detach was silently broken for anyone whose tmux config enables `extended-keys` (oh-my-tmux turns this on by default for iTerm2 / mintty / xterm).
- With extended-keys on, the terminal emits `Ctrl+Q` as a CSI sequence — either `\x1b[113;5u` (kitty/libtickit) or `\x1b[27;5;113~` (xterm modifyOtherKeys) — instead of bare byte 17. The interceptor in `internal/tmux/pty.go` only matched byte 17, so the keystroke was forwarded to the pane and tmux swallowed it.
- Extend the matcher to recognise all three encodings; the bare byte-17 path still works for terminals without extended-keys. Full extended-keys support inside the pane (Ctrl+Shift+H/L, etc.) is preserved.

## Test plan

- [x] `go test -race ./internal/tmux/...` — 31 passed (10 new `TestFindCtrlQ` cases covering each encoding, mixed payloads, and the earliest-match rule)
- [x] `go build ./...`
- [ ] Manual: attach to a session on a machine with `set -g extended-keys on`, press `Ctrl+Q`, confirm clean detach
- [ ] Manual: same on a machine without extended-keys, confirm Ctrl+Q still detaches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ctrl+Q detach now works reliably when terminals send alternative escape-sequence encodings (extended-keys).
* **Tests**
  * Added tests covering multiple Ctrl+Q encodings and detection scenarios to prevent regressions.
* **Documentation**
  * Added an unreleased changelog entry documenting the Ctrl+Q behavior and fix.
* **Chores**
  * Ignore macOS .DS_Store files in repository metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brizzai/fleet/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->