### PR TITLE
fix(status): cut hook→TUI latency and stop stale-hook oscillation

### DIFF
--- a/changelog/unreleased/fix-hook-status-latency.md
+++ b/changelog/unreleased/fix-hook-status-latency.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Status detection: hook events now reflect in the TUI within ~100ms (was 4–6s, waiting on the worker's round-robin). Stale "running" hooks no longer oscillate between idle/running/finished on pane-content changes (survey popups, cursor blinks, scrollback redraws).

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -232,6 +232,32 @@ func TestScenarioSubAgentPermission(t *testing.T) {
 	})
 }
 
+// TestScenarioStaleRunningHookMemoizesOverride reproduces the "merge-master"
+// oscillation bug: a running hook that's hours stale (no Stop ever fired
+// because the user only ran slash commands), combined with periodic pane
+// content changes (survey popup, cursor blink, scrollback redraws) would
+// flip Status back to Running every time the hash changed, then 10s+ later
+// flip back to Finished. The fix memoizes the stability override via
+// hookOverriddenAt, so subsequent pane changes don't re-oscillate until a
+// fresh hook lands.
+func TestScenarioStaleRunningHookMemoizesOverride(t *testing.T) {
+	runScenario(t, Scenario{
+		Name: "stale running hook: hash change after override does not flip back to running",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "running", Pane: "line1\n❯ \n"},
+			// Simulate pane content change after the override has fired
+			// (e.g. session-rating popup appears, or scrollback redraws).
+			// The hook is still the stale "running" from t=0.
+			{At: 13 * time.Second, Pane: "line1\nDifferent content appeared\n❯ \n"},
+		},
+		Checks: []ScenarioCheck{
+			{At: 2 * time.Second, Expected: StatusRunning},   // baseline: first tick sets lastContentHash
+			{At: 11 * time.Second, Expected: StatusFinished}, // stability override fires, memoizes via hookOverriddenAt
+			{At: 13 * time.Second, Expected: StatusFinished}, // without fix: oscillates back to Running on hash change
+		},
+	})
+}
+
 func TestScenarioAcknowledgedPreventsOscillation(t *testing.T) {
 	runScenario(t, Scenario{
 		Name: "acknowledged idle stays idle when hook says waiting + pane idle",

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -258,6 +258,34 @@ func TestScenarioStaleRunningHookMemoizesOverride(t *testing.T) {
 	})
 }
 
+// TestScenarioStaleRunningResumesThenReIdles covers the escape path in
+// applyHookRunning's override guard: after an override has memoized
+// Status=Finished on a stale running hook, if the pane shows running (genuine
+// resume — e.g. sub-agent burst without a new hook), the guard must clear the
+// override so subsequent ticks can re-engage the stability heuristic when
+// Claude stops again. Otherwise the session is stuck at Running forever.
+func TestScenarioStaleRunningResumesThenReIdles(t *testing.T) {
+	runScenario(t, Scenario{
+		Name: "stale running hook: override → resume (pane running) → re-idle must re-override",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "running", Pane: "line1\n❯ \n"},
+			// Pane flips to active running (sub-agent burst before any new hook lands).
+			{At: 12 * time.Second, Pane: "⠋ Working on your request...\nctrl+c to interrupt\n"},
+			// Pane flips back to idle — Claude stopped again, still no new hook.
+			{At: 14 * time.Second, Pane: "line1\n❯ \n"},
+		},
+		Checks: []ScenarioCheck{
+			{At: 2 * time.Second, Expected: StatusRunning},   // baseline
+			{At: 11 * time.Second, Expected: StatusFinished}, // override memoizes
+			{At: 12 * time.Second, Expected: StatusRunning},  // escape path: resume detected, override cleared
+			// At t=14 pane flipped back to idle. Run an UpdateStatus at t=15 to lock
+			// in the new hash baseline, then verify stability re-engages by t=26.
+			{At: 15 * time.Second, Expected: StatusRunning},  // new idle pane, hash baseline being set
+			{At: 26 * time.Second, Expected: StatusFinished}, // >10s stable on new idle pane → re-override
+		},
+	})
+}
+
 func TestScenarioAcknowledgedPreventsOscillation(t *testing.T) {
 	runScenario(t, Scenario{
 		Name: "acknowledged idle stays idle when hook says waiting + pane idle",

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -207,14 +207,17 @@ type HookStatus struct {
 }
 
 // UpdateHookStatus updates the session's hook-based status.
-func (s *Session) UpdateHookStatus(hs *HookStatus) {
+// Returns true if the hook meaningfully changed (new status or new timestamp),
+// so callers can prioritize an immediate status recomputation.
+func (s *Session) UpdateHookStatus(hs *HookStatus) bool {
 	if hs == nil {
-		return
+		return false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	changed := s.hookStatus != hs.Status || s.hookUpdatedAt != hs.UpdatedAt
 	// Reset tracking when hook genuinely changes (new event or new status).
-	if s.hookStatus != hs.Status || s.hookUpdatedAt != hs.UpdatedAt {
+	if changed {
 		s.lastContentHash = ""
 		s.lastContentChangeAt = time.Time{}
 		s.hookOverriddenAt = time.Time{} // allow fresh evaluation of new hook
@@ -233,6 +236,7 @@ func (s *Session) UpdateHookStatus(hs *HookStatus) {
 	} else if hs.UserPrompt != "" && s.FirstPrompt == "" {
 		s.FirstPrompt = hs.UserPrompt
 	}
+	return changed
 }
 
 // Restart kills and recreates the tmux session with the same config.
@@ -361,6 +365,29 @@ func (s *Session) updateStatusFromHook(oldStatus Status, hookStatus string, hook
 // applyHookRunning handles hook status "running" with content stability detection.
 // Must be called with s.mu held.
 func (s *Session) applyHookRunning(oldStatus Status, paneContent string, paneStatus Status, log *slog.Logger) {
+	// If this stale "running" hook was already overridden to finished/idle,
+	// preserve that decision. A new hook (different timestamp) resets the flag
+	// via UpdateHookStatus, allowing fresh evaluation.
+	//
+	// Without this guard, every pane-content change (survey popups, cursor
+	// blinks, scrollback redraws) resets Status=Running at the top of this
+	// function and clears Acknowledged, causing idle ↔ running ↔ finished
+	// oscillation on stale hooks where no Stop event ever fires (e.g. slash
+	// commands, session survey popup).
+	//
+	// Escape: if pane shows an active running indicator, Claude genuinely
+	// resumed (sub-agent output burst, or user-initiated work before a new
+	// hook landed) — break out and let the normal path resume.
+	if !s.hookOverriddenAt.IsZero() && s.hookOverriddenAt.Equal(s.hookUpdatedAt) {
+		if paneStatus == StatusRunning {
+			s.Status = StatusRunning
+			s.Acknowledged = false
+			log.Info("overridden running hook but pane shows running, resuming")
+			return
+		}
+		return // preserve whatever state the stability override concluded
+	}
+
 	s.Status = StatusRunning
 	s.Acknowledged = false
 
@@ -404,6 +431,9 @@ func (s *Session) applyHookRunning(oldStatus Status, paneContent string, paneSta
 		} else {
 			s.Status = StatusFinished
 		}
+		// Memoize the override so subsequent ticks don't re-run this logic and
+		// reset Status=Running at the top on every pane-content change.
+		s.hookOverriddenAt = s.hookUpdatedAt
 		log.Info("content stable >10s, hook says running, assuming finished",
 			"stableSince", s.lastContentChangeAt.Format(time.TimeOnly))
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -377,15 +377,19 @@ func (s *Session) applyHookRunning(oldStatus Status, paneContent string, paneSta
 	//
 	// Escape: if pane shows an active running indicator, Claude genuinely
 	// resumed (sub-agent output burst, or user-initiated work before a new
-	// hook landed) — break out and let the normal path resume.
+	// hook landed). Clear the override and fall through to the normal path so
+	// the stability heuristic can re-engage if Claude stops again — otherwise
+	// the session would be stuck at Running forever until the next hook.
 	if !s.hookOverriddenAt.IsZero() && s.hookOverriddenAt.Equal(s.hookUpdatedAt) {
 		if paneStatus == StatusRunning {
-			s.Status = StatusRunning
-			s.Acknowledged = false
+			s.hookOverriddenAt = time.Time{}
+			s.lastContentHash = ""
+			s.lastContentChangeAt = time.Time{}
 			log.Info("overridden running hook but pane shows running, resuming")
-			return
+			// fall through to normal running path
+		} else {
+			return // preserve whatever state the stability override concluded
 		}
-		return // preserve whatever state the stability override concluded
 	}
 
 	s.Status = StatusRunning

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -182,11 +182,12 @@ type Home struct {
 	bugReport    *BugReportDialog
 
 	// Background worker for async status/git/PR updates.
-	statusTrigger chan struct{} // buffered(1), triggers worker
-	workerMu      sync.Mutex    // protects sessions/gitInfoCache from concurrent worker access
-	ctx           context.Context
-	cancel        context.CancelFunc
-	workerStarted bool
+	statusTrigger         chan struct{} // buffered(1), triggers worker
+	priorityStatusUpdates chan string   // buffered, session IDs with fresh hook changes — drained before round-robin
+	workerMu              sync.Mutex    // protects sessions/gitInfoCache from concurrent worker access
+	ctx                   context.Context
+	cancel                context.CancelFunc
+	workerStarted         bool
 
 	startTime time.Time // app start time for uptime tracking
 
@@ -235,6 +236,7 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string) *Home
 		errorHistory:          NewErrorHistory(50),
 		actionLog:             NewActionLog(100),
 		statusTrigger:         make(chan struct{}, 1),
+		priorityStatusUpdates: make(chan string, 256),
 		ctx:                   ctx,
 		cancel:                cancel,
 		startTime:             time.Now(),
@@ -286,11 +288,14 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h.handleTick()
 
 	case hookChangedMsg:
-		// HookWatcher detected a status file change. Do immediate hook-only sync.
+		// HookWatcher detected a status file change. Do immediate hook-only sync,
+		// then hand sessions whose hook changed to the worker via the priority queue
+		// so they get a full UpdateStatus() within ~100ms instead of waiting for round-robin.
 		h.workerMu.Lock()
-		h.syncHookStatuses(h.sessions)
+		changed := h.syncHookStatuses(h.sessions)
 		h.rebuildFlatItems()
 		h.workerMu.Unlock()
+		h.enqueuePriorityUpdates(changed)
 		return h, h.listenForHookChanges
 
 	case statusUpdateMsg:
@@ -298,9 +303,10 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.isAttaching.Store(false)
 		// Immediate hook sync (data already in HookWatcher from hooks that fired during attach).
 		h.workerMu.Lock()
-		h.syncHookStatuses(h.sessions)
+		changed := h.syncHookStatuses(h.sessions)
 		h.rebuildFlatItems()
 		h.workerMu.Unlock()
+		h.enqueuePriorityUpdates(changed)
 		// Also trigger full background refresh for pane captures, git, etc.
 		select {
 		case h.statusTrigger <- struct{}{}:
@@ -2129,23 +2135,28 @@ func (h *Home) statusWorker() {
 
 // syncHookStatuses reads the latest hook statuses from the HookWatcher and applies
 // them to the given sessions. Caller must ensure thread-safe access to sessions.
-func (h *Home) syncHookStatuses(sessions []*session.Session) {
+// Returns the IDs of sessions whose hook meaningfully changed (new status or timestamp);
+// callers can forward these to priorityStatusUpdates for immediate UpdateStatus().
+func (h *Home) syncHookStatuses(sessions []*session.Session) []string {
 	if h.hookWatcher == nil {
-		return
+		return nil
 	}
+	var changed []string
 	for _, s := range sessions {
 		hs := h.hookWatcher.GetStatus(s.ID)
 		if hs != nil {
 			oldClaudeSessionID := s.ClaudeSessionID
 			oldFirstPrompt := s.FirstPrompt
 			oldPromptCount := s.PromptCount
-			s.UpdateHookStatus(&session.HookStatus{
+			if s.UpdateHookStatus(&session.HookStatus{
 				Status:      hs.Status,
 				SessionID:   hs.SessionID,
 				UpdatedAt:   hs.UpdatedAt,
 				UserPrompt:  hs.UserPrompt,
 				PromptCount: hs.PromptCount,
-			})
+			}) {
+				changed = append(changed, s.ID)
+			}
 			// Persist new Claude session ID if it changed.
 			if s.ClaudeSessionID != oldClaudeSessionID && s.ClaudeSessionID != "" {
 				if err := h.storage.UpdateClaudeSessionID(s.ID, s.ClaudeSessionID); err != nil {
@@ -2172,6 +2183,39 @@ func (h *Home) syncHookStatuses(sessions []*session.Session) {
 				}
 			}
 		}
+	}
+	return changed
+}
+
+// updateAndPersistStatus runs a full UpdateStatus() on the session and persists
+// the result to storage if the status changed. Called from the worker goroutine.
+func (h *Home) updateAndPersistStatus(s *session.Session) {
+	oldStatus := s.GetStatus()
+	s.UpdateStatus()
+	newStatus := s.GetStatus()
+	if oldStatus != newStatus {
+		if err := h.storage.UpdateStatus(s.ID, string(newStatus)); err != nil {
+			debuglog.Logger.Error("storage: UpdateStatus", "id", s.ID, "status", newStatus, "err", err)
+		}
+	}
+}
+
+// enqueuePriorityUpdates pushes session IDs into the worker's priority queue
+// and kicks the worker to drain them immediately. Safe to call from any goroutine.
+func (h *Home) enqueuePriorityUpdates(ids []string) {
+	if len(ids) == 0 {
+		return
+	}
+	for _, id := range ids {
+		select {
+		case h.priorityStatusUpdates <- id:
+		default:
+			// Queue full — next worker cycle's round-robin will still catch it.
+		}
+	}
+	select {
+	case h.statusTrigger <- struct{}{}:
+	default:
 	}
 }
 
@@ -2245,7 +2289,29 @@ func (h *Home) statusWorkerCycle() {
 		}
 	}
 
-	// 4. Round-robin status updates (pane capture — blocking).
+	// 4. Priority updates first — sessions whose hook file just changed.
+	// These bypass round-robin so the UI reflects fresh hook status within
+	// ~100ms of the hook firing (vs. up to (N/statusRoundRobin)*tickInterval seconds).
+	priorityIDs := make(map[string]bool)
+drainPriority:
+	for {
+		select {
+		case id := <-h.priorityStatusUpdates:
+			priorityIDs[id] = true
+		default:
+			break drainPriority
+		}
+	}
+	processed := make(map[string]bool, len(priorityIDs))
+	for _, s := range sessions {
+		if !priorityIDs[s.ID] {
+			continue
+		}
+		h.updateAndPersistStatus(s)
+		processed[s.ID] = true
+	}
+
+	// 5. Round-robin status updates (pane capture — blocking), skipping already-processed.
 	count := statusRoundRobin
 	if count > len(sessions) {
 		count = len(sessions)
@@ -2253,14 +2319,10 @@ func (h *Home) statusWorkerCycle() {
 	for i := 0; i < count; i++ {
 		idx := (h.statusRRIndex + i) % len(sessions)
 		s := sessions[idx]
-		oldStatus := s.GetStatus()
-		s.UpdateStatus()
-		newStatus := s.GetStatus()
-		if oldStatus != newStatus {
-			if err := h.storage.UpdateStatus(s.ID, string(newStatus)); err != nil {
-				debuglog.Logger.Error("storage: UpdateStatus", "id", s.ID, "status", newStatus, "err", err)
-			}
+		if processed[s.ID] {
+			continue
 		}
+		h.updateAndPersistStatus(s)
 	}
 	h.statusRRIndex = (h.statusRRIndex + count) % len(sessions)
 


### PR DESCRIPTION
## Summary

Two independent status-detection fixes, bundled because they surfaced together while debugging a snapshot and share test scaffolding.

### 1. Hook → TUI latency (4–6s → ~100ms)

`syncHookStatuses` was updating the session's hook tracking fields (`hookStatus`, `hookUpdatedAt`) in the Update loop, but `s.Status` was only recomputed by `s.UpdateStatus()` inside the worker's round-robin scan (5 sessions per 2s tick). With ~15 sessions, a hook-triggered status change could lag 4–6s before the TUI reflected it.

- `Session.UpdateHookStatus` now returns `bool` (hook meaningfully changed).
- `syncHookStatuses` collects changed session IDs and returns them.
- New `priorityStatusUpdates` channel + `enqueuePriorityUpdates` helper on `Home`.
- `hookChangedMsg` / `statusUpdateMsg` handlers forward changed IDs to the priority queue and kick the worker.
- `statusWorkerCycle` drains the priority queue first and runs full `UpdateStatus()` on those sessions, then the round-robin skips anything already processed.

All blocking I/O stays in the worker goroutine; the Update loop is never stalled.

### 2. Stale-hook oscillation in `applyHookRunning`

Discovered while investigating a snapshot where a 13-hour-stale `running` hook kept flipping `idle → running → finished` whenever the pane content changed (session-rating popup animation, cursor blinks, scrollback). The debug log showed the "content stable >10s, assuming finished" override firing ~100 times in 3.5 hours instead of sticking.

Root cause: `applyHookRunning` unconditionally reset `s.Status = StatusRunning; s.Acknowledged = false` at the top of every call and never memoized its stability-override conclusion. `applyHookWaiting` and `applyHookFinished` both have guards (`hookOverriddenAt`, `Acknowledged`) — `applyHookRunning` was the odd one out.

- Added top-of-function guard mirroring `applyHookWaiting:423-430`: if `hookOverriddenAt == hookUpdatedAt`, preserve the overridden state. Escape branch triggers only when `paneStatus == StatusRunning` (genuine resume from sub-agent burst before a new hook lands).
- Set `s.hookOverriddenAt = s.hookUpdatedAt` at the stability-override point so the decision sticks across ticks.
- A fresh hook event still clears `hookOverriddenAt` via existing `UpdateHookStatus` logic.

## Test plan

- [x] `TestScenarioStaleRunningHookMemoizesOverride` — new scenario test; verified to FAIL without the `hookOverriddenAt` memoization (got `running`, expected `finished` at t=13s) and PASS with it.
- [x] Existing test suite green: `go test -race ./internal/session/ ./internal/ui/ ./internal/hooks/`
- [x] `make build` passes.
- [ ] Test-drive on actual running TUI to confirm ≤100ms perceived latency on hook events.
- [ ] Confirm the stale-hook session in the original snapshot no longer oscillates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hook status detection now updates in the TUI within ~100ms (previously 4–6s).
  * Stale "running" hooks no longer oscillate between idle/running/finished during pane-content changes (e.g., survey popups, cursor blinks, scrollback redraws).

* **Tests**
  * Added scenario tests to verify stale-running hook overrides, resumption on real activity, and stable final states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->