### PR TITLE
feat(perfwatch): Update() loop instrumentation + first stall fix

### DIFF
--- a/.claude/skills/debug-perf/SKILL.md
+++ b/.claude/skills/debug-perf/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: debug-perf
+description: >
+  Debug fleet TUI performance issues — UI loop stalls, frozen sidebar, sluggish
+  attach, or background CPU spikes. Reads perfwatch stall dumps and the debug.log
+  heartbeat to identify what blocked the Bubble Tea Update() loop or stole cycles
+  from the PTY. Trigger on: "TUI is stuck/frozen/laggy", "UI hangs", "everything
+  froze", "attach feels slow", "what blocked the loop", "perfwatch", "stall dump",
+  "Bubble Tea slow", or any complaint that fleet became unresponsive even briefly.
+allowed-tools: Read, Grep, Glob, Bash
+user-invocable: true
+---
+
+# Debug Performance / UI Stalls
+
+Diagnose why the fleet TUI froze, stuttered, or felt laggy by reading the artifacts the `perfwatch` package writes when `FLEET_DEBUG=1` is set. Read-only — report findings and recommend fixes, never edit code.
+
+## What perfwatch records
+
+When `FLEET_DEBUG=1`, `internal/perfwatch` instruments every `Update()` call and continuously samples runtime state:
+
+- **Stall dumps** — `~/.config/fleet/stalls/<ts>_update_stall_<msgType>_<ms>ms.txt` written automatically when `Update()` runs longer than 500ms. Re-dumps every 1.5s while still stuck. Contains: in-flight message, recent message ring buffer (last 32 with durations), full goroutine stacks (`debug=2`), block profile, mutex profile, GC stats.
+- **Heartbeat** — every 5s in `~/.config/fleet/debug.log`: goroutine count, process CPU%, heap KB, total/slow update counts, max update duration. Keeps logging during attach (when the Bubble Tea loop is suspended) so background-worker CPU usage is visible even when the TUI itself isn't running.
+- **Slow Update warnings** — any `Update()` ≥100ms gets a `perfwatch: slow Update msg=… duration_ms=…` WARN line in debug.log even if it didn't trigger a stall dump.
+- **SIGUSR1** — `kill -USR1 $(pgrep -f 'fleet$')` forces a snapshot on demand. Filename ends in `_manual_sigusr1`.
+
+## Step 0: Verify perfwatch is enabled
+
+If the user hasn't set `FLEET_DEBUG`, no dumps exist and you can't help. Check:
+
+```bash
+grep "perfwatch: enabled" ~/.config/fleet/debug.log | tail -1
+```
+
+If empty, instruct the user:
+```
+Re-launch with: FLEET_DEBUG=1 ./build/fleet
+Reproduce the freeze, then run /debug-perf again.
+```
+
+If the user reports laggy attach but no TUI stall, also tell them: while attach feels laggy, run `kill -USR1 $(pgrep -f 'fleet$')` from another terminal to force a snapshot of background goroutines. Stalls during attach won't trigger the watchdog (Bubble Tea loop is suspended), so manual snapshots are the only signal.
+
+## Step 1: Find the relevant dump
+
+```bash
+ls -lt ~/.config/fleet/stalls/ | head -20
+```
+
+Pick the dump whose timestamp matches the freeze the user described. Filename encodes the trigger:
+- `*_update_stall_<msgType>_<ms>ms.txt` — automatic, fired by the watchdog. `<msgType>` is the Bubble Tea message type that was blocking (e.g., `ui.tickMsg`, `tea.KeyMsg`, `ui.statusUpdateMsg`).
+- `*_manual_sigusr1.txt` — user-triggered snapshot, typically captured during attach lag.
+
+If multiple consecutive dumps exist within ~2s of each other, the freeze lasted long enough that the watchdog re-fired. Use the **earliest** — it captures the first moment of the stall before goroutines piled up.
+
+## Step 2: Read the dump header
+
+```bash
+head -60 ~/.config/fleet/stalls/<file>
+```
+
+Key fields:
+- **Update() IN FLIGHT: msg=… elapsed=…** — this is the message type that was blocking when the dump fired. The biggest single clue.
+- **Goroutines: N** — baseline is ~20-30. >100 = goroutine leak suspect.
+- **HeapAlloc / NumGC** — sudden GC pressure or huge heap can starve goroutines.
+- **Counters: total / slow / max_ms** — context for severity.
+
+## Step 3: Read the recent message ring
+
+```bash
+sed -n '/Recent Update/,/Goroutine stacks/p' ~/.config/fleet/stalls/<file>
+```
+
+The ring shows up to 32 prior `Update()` calls with durations. Look for:
+- A pattern of slow updates leading up to the stall (gradual degradation vs. sudden spike).
+- Repeated handling of the same message type (e.g., 30× `ui.tickMsg`) — suggests a tea.Cmd loop misfiring.
+- A single recent message with abnormal duration matching the stall msg — confirms the blocking call is reproducible per-message-type.
+
+## Step 4: Read the goroutine stacks
+
+```bash
+sed -n '/Goroutine stacks/,/Block profile/p' ~/.config/fleet/stalls/<file>
+```
+
+Find the goroutine running `Home.Update`. Its stack tells you exactly what blocked:
+
+**Common blocking patterns in fleet:**
+
+- `sync.(*Mutex).Lock` → `internal/ui/app.go` referencing `workerMu` — Update is waiting on the status worker. Look at the goroutine running `Home.statusWorkerCycle` or `Home.statusWorker` — what is *it* blocked on? Usually:
+  - `os/exec.(*Cmd).Wait` on `git`, `gh`, or `tmux` → external process is slow. Fix: timeout or move off Update path.
+  - `bufio.(*Reader).ReadBytes` on tmux pane capture → tmux is unresponsive.
+
+- `os/exec.(*Cmd).Run/Output/Wait` directly in the Update goroutine → blocking I/O leaked into Update. Per CLAUDE.md this is forbidden — find the call site and move it to a tea.Cmd closure or the worker.
+
+- `database/sql.(*DB).Exec/Query` in Update goroutine → SQLite write contention. Look for `storage.UpdateStatus`, `storage.SetAcknowledged`, etc., called synchronously.
+
+- `chan send` blocked on a full channel → look at which channel (`statusTrigger`, `priorityStatusUpdates`, hook watcher channel) and who is supposed to be draining it. Receiver may be stuck.
+
+- `runtime.gopark` / `select` with no obvious culprit → goroutine is idle. Not the cause; look elsewhere.
+
+- `syscall.read` / `syscall.write` on PTY fds → the PTY io.Copy goroutine. During attach this is normal.
+
+## Step 5: Read the block & mutex profiles
+
+```bash
+sed -n '/Block profile/,/Mutex profile/p' ~/.config/fleet/stalls/<file>
+sed -n '/Mutex profile/,$p' ~/.config/fleet/stalls/<file>
+```
+
+These are cumulative since process start (>1ms blocks recorded). The function showing the most time at the top is the dominant contention point across the whole run, not just this stall. Useful to confirm what Step 4 found and to spot chronic contenders even when individual stalls don't reach 500ms.
+
+## Step 6: Cross-reference with heartbeat
+
+```bash
+grep "perfwatch heartbeat" ~/.config/fleet/debug.log | tail -50
+```
+
+For each heartbeat near the stall timestamp, check:
+- **goroutines spike** — leak suspicion. Trace which subsystem started spawning goroutines (compare to baseline before the spike).
+- **cpu_pct spike** — busy loop or expensive work. If `cpu_pct > 50%` while the user reports attach is laggy, fleet's own goroutines are starving the PTY.
+- **heap_kb growth without GC** — possible memory pressure causing GC pauses (which look like UI stalls).
+- **updates_slow climbing fast** — many Updates went over 100ms even without hitting the 500ms stall threshold. Look for the WARN lines: `grep "perfwatch: slow Update" ~/.config/fleet/debug.log | tail -30`.
+
+## Step 7: For attach-specific lag
+
+If the user reports lag *inside* the attached tmux session (typing/output sluggish, not TUI freeze), the watchdog won't catch it (Bubble Tea is suspended during `tea.Exec`). Use:
+
+1. **Heartbeats during attach** — fleet keeps logging while attached. Find the attach window:
+   ```bash
+   grep -E "attach|perfwatch heartbeat" ~/.config/fleet/debug.log | tail -100
+   ```
+   If `cpu_pct` is high (>30%) while attached, a fleet background goroutine is competing with the PTY. Look at goroutine count trend — leaking workers will show.
+
+2. **Manual snapshot during lag** — instruct user:
+   ```bash
+   # In another terminal while attach feels laggy:
+   kill -USR1 $(pgrep -f 'fleet$')
+   ```
+   Then read the resulting `*_manual_sigusr1.txt` and look at goroutine stacks. Common attach-lag culprits:
+   - `Home.statusWorkerCycle` doing pane captures on a large session list every 2s → slows everything.
+   - `hooks.HookWatcher` fsnotify storm if many hook files change rapidly.
+   - `git.RepoInfoCache` refresh hitting many repos at once.
+   - PTY `io.Copy` not the issue itself, but check if it's blocked on `syscall.write` to stdout for unusually long.
+
+## Step 8: Report
+
+Lead with the in-flight message and the blocking syscall/lock. Then explain the chain.
+
+Format:
+1. **Symptom**: stall duration, message type, what the user saw.
+2. **Blocking call**: function + file:line that was on top of the Update goroutine's stack.
+3. **Why it blocked**: held by which other goroutine, waiting on what (process, lock, channel).
+4. **Chronic vs. one-off**: does the block/mutex profile confirm this is a recurring pattern?
+5. **Recommended fix**: which of these applies?
+   - Move blocking I/O off the Update goroutine into a tea.Cmd closure (per CLAUDE.md "All blocking I/O … runs in background worker goroutine, never in Bubble Tea Update()").
+   - Add a timeout to an external command (`exec.CommandContext` with a deadline).
+   - Reduce lock scope: hold `workerMu` only for in-memory state mutation, not for I/O.
+   - Add backpressure to a channel (drop on full) instead of blocking sends.
+   - Cache an expensive computation behind a TTL.
+6. **Regression signal**: a heartbeat threshold (e.g., "alert if cpu_pct >50 sustained" or "alert if max_update_ms >1000") that would have caught this earlier.
+
+Do not modify code unless the user explicitly asks. The job ends at the recommendation.

--- a/.claude/skills/debug-perf/SKILL.md
+++ b/.claude/skills/debug-perf/SKILL.md
@@ -33,7 +33,7 @@ grep "perfwatch: enabled" ~/.config/fleet/debug.log | tail -1
 ```
 
 If empty, instruct the user:
-```
+```text
 Re-launch with: FLEET_DEBUG=1 ./build/fleet
 Reproduce the freeze, then run /debug-perf again.
 ```

--- a/changelog/unreleased/crash-dump-on-session-death.md
+++ b/changelog/unreleased/crash-dump-on-session-death.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+Crash dumps for dying sessions: when a session transitions to `error`, fleet writes a forensic snapshot to `~/.config/fleet/crashes/<id>_<ts>.txt` containing the tmux exit status/signal (with human-readable annotation — e.g. `9 (SIGKILL — likely OOM/Jetsam or external kill)`), last 200 lines of pane content (raw ANSI), the SessionEnd hook reason from Claude Code, and the last 6 perfwatch heartbeats — enough to tell a kernel kill from a panic from a clean exit at a glance. Tmux now uses `remain-on-exit on` so dead panes can be inspected before fleet cleans them up. Perfwatch heartbeats also gained a `sys_free_mb` field (system-wide free memory) so the heartbeat trail records memory-pressure collapse leading up to a crash.

--- a/changelog/unreleased/env-disable-auto-update.md
+++ b/changelog/unreleased/env-disable-auto-update.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+`FLEET_AUTO_UPDATE_DISABLED=1` env var to skip the auto-updater on a per-launch basis (handy when running a local dev build you don't want overwritten by the latest release)

--- a/changelog/unreleased/fix-askuserquestion-status.md
+++ b/changelog/unreleased/fix-askuserquestion-status.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Status flickering between `waiting` and `running` while navigating Claude's AskUserQuestion dialog

--- a/changelog/unreleased/fix-stale-hook-after-restart.md
+++ b/changelog/unreleased/fix-stale-hook-after-restart.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Restarting a dead session no longer briefly flashes back to `error` (with a misleading crash dump) before the new Claude process fires its first hook. Restart now clears the previous Claude's hook state — both in memory and the on-disk status file — so the worker doesn't trust an 8-minute-old `status=dead` during the relaunch window. The crash-dump quota also re-arms when a fresh hook reports the session is alive again, so a real death following a false-positive flash still produces a dump.

--- a/changelog/unreleased/fix-undo-delete-stall.md
+++ b/changelog/unreleased/fix-undo-delete-stall.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+TUI freezing for ~500ms when the 5-second undo-delete window expired while scrolling — the tmux kill now runs off the Update loop

--- a/changelog/unreleased/perfwatch-storm-detector.md
+++ b/changelog/unreleased/perfwatch-storm-detector.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+Storm detector in perfwatch: dumps a snapshot when sustained Update() throughput exceeds 200/s, catching tea.Cmd loops that flood the loop without any single Update going slow (the stall watchdog can't see those)

--- a/cmd/fleet/hook_handler.go
+++ b/cmd/fleet/hook_handler.go
@@ -19,6 +19,8 @@ type hookPayload struct {
 	Source        string          `json:"source"`
 	Matcher       json.RawMessage `json:"matcher,omitempty"`
 	Prompt        string          `json:"prompt,omitempty"`
+	// Reason is set on SessionEnd: "clear", "logout", "prompt_input_exit", "other".
+	Reason string `json:"reason,omitempty"`
 }
 
 // mapEventToStatus maps a Claude Code hook event to a fleet status string.
@@ -132,6 +134,7 @@ func handleHookHandler() {
 		Timestamp:   time.Now().Unix(),
 		UserPrompt:  userPrompt,
 		PromptCount: promptCount,
+		Reason:      payload.Reason,
 	}
 
 	if err := hooks.WriteStatusFile(hooksDir, instanceID, sf); err != nil {

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brizzai/fleet/internal/config"
 	"github.com/brizzai/fleet/internal/debuglog"
 	"github.com/brizzai/fleet/internal/migration"
+	"github.com/brizzai/fleet/internal/perfwatch"
 	"github.com/brizzai/fleet/internal/session"
 	"github.com/brizzai/fleet/internal/tmux"
 	"github.com/brizzai/fleet/internal/ui"
@@ -84,6 +85,7 @@ func runTUI() {
 
 	debuglog.Init()
 	defer debuglog.Close()
+	perfwatch.Init()
 	debuglog.Logger.Info("fleet TUI starting", "version", version)
 
 	if err := tmux.IsTmuxAvailable(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/brizzai/fleet/internal/debuglog"
 )
@@ -30,11 +31,27 @@ func (c *Config) IsAutoNameEnabled() bool {
 }
 
 // IsAutoUpdateEnabled returns whether auto-update is enabled (default: true).
+// FLEET_AUTO_UPDATE_DISABLED takes precedence over the config file when truthy
+// (1/true/yes/y/on) — useful for running a local dev build without the
+// auto-updater overwriting it with the latest release.
 func (c *Config) IsAutoUpdateEnabled() bool {
+	if isTruthyEnv(os.Getenv("FLEET_AUTO_UPDATE_DISABLED")) {
+		return false
+	}
 	if c.AutoUpdate == nil {
 		return true
 	}
 	return *c.AutoUpdate
+}
+
+// isTruthyEnv returns true for common truthy values (1, true, yes, y, on).
+func isTruthyEnv(v string) bool {
+	switch strings.TrimSpace(strings.ToLower(v)) {
+	case "1", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 // DefaultConfigPath returns the default config file path.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,35 @@ func TestIsAutoUpdateEnabled(t *testing.T) {
 			t.Error("expected false")
 		}
 	})
+
+	t.Run("FLEET_AUTO_UPDATE_DISABLED overrides config=true", func(t *testing.T) {
+		t.Setenv("FLEET_AUTO_UPDATE_DISABLED", "1")
+		v := true
+		cfg := &Config{AutoUpdate: &v}
+		if cfg.IsAutoUpdateEnabled() {
+			t.Error("env var should override config=true")
+		}
+	})
+
+	t.Run("FLEET_AUTO_UPDATE_DISABLED accepts truthy values", func(t *testing.T) {
+		for _, val := range []string{"1", "true", "TRUE", "yes", "y", "on"} {
+			t.Setenv("FLEET_AUTO_UPDATE_DISABLED", val)
+			cfg := &Config{}
+			if cfg.IsAutoUpdateEnabled() {
+				t.Errorf("value %q should disable auto-update", val)
+			}
+		}
+	})
+
+	t.Run("FLEET_AUTO_UPDATE_DISABLED ignores non-truthy values", func(t *testing.T) {
+		for _, val := range []string{"", "0", "false", "no", "off", "garbage"} {
+			t.Setenv("FLEET_AUTO_UPDATE_DISABLED", val)
+			cfg := &Config{} // default true
+			if !cfg.IsAutoUpdateEnabled() {
+				t.Errorf("value %q should NOT disable auto-update (default true)", val)
+			}
+		}
+	})
 }
 
 func TestGetEditor(t *testing.T) {

--- a/internal/hooks/status_file.go
+++ b/internal/hooks/status_file.go
@@ -14,6 +14,10 @@ type StatusFile struct {
 	Timestamp   int64  `json:"ts"`
 	UserPrompt  string `json:"user_prompt,omitempty"`
 	PromptCount int    `json:"prompt_count,omitempty"`
+	// Reason is forwarded from Claude Code's SessionEnd hook payload
+	// ("clear", "logout", "prompt_input_exit", "other"). "other" combined with
+	// no exit info typically means the process was killed externally.
+	Reason string `json:"reason,omitempty"`
 }
 
 // WriteStatusFile atomically writes a status file to the hooks directory.

--- a/internal/perfwatch/perfwatch.go
+++ b/internal/perfwatch/perfwatch.go
@@ -1,0 +1,333 @@
+// Package perfwatch instruments the Bubble Tea Update() loop to detect and
+// post-mortem-debug stalls. When FLEET_DEBUG is set:
+//
+//   - Every Update() is wrapped via MarkUpdateStart/MarkUpdateEnd. The last 32
+//     messages and their durations are kept in a ring buffer.
+//   - A watchdog goroutine ticks every 100ms; if Update() has been running
+//     longer than stallThreshold, it writes a dump to ~/.config/fleet/stalls/
+//     containing goroutine stacks, block + mutex profiles, recent message ring,
+//     and counters.
+//   - A heartbeat logs goroutine count and process CPU% every 5s — keeps
+//     running during attach so background-worker CPU use shows up in debug.log
+//     even when the TUI loop is suspended.
+//   - SIGUSR1 forces a snapshot on demand.
+//
+// When FLEET_DEBUG is unset, all entry points short-circuit and the package
+// adds no measurable overhead.
+package perfwatch
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"runtime/metrics"
+	"runtime/pprof"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/brizzai/fleet/internal/debuglog"
+)
+
+const (
+	stallThreshold     = 500 * time.Millisecond
+	slowLogThreshold   = 100 * time.Millisecond
+	watchdogInterval   = 100 * time.Millisecond
+	heartbeatInterval  = 5 * time.Second
+	minDumpGap         = 1500 * time.Millisecond
+	recentMsgRing      = 32
+	blockProfileRateNs = int64(time.Millisecond) // record blocks >= 1ms
+)
+
+var (
+	enabled atomic.Bool
+
+	updateStartUnixNano atomic.Int64
+	updateMsgType       atomic.Pointer[string]
+
+	totalUpdates atomic.Int64
+	slowUpdates  atomic.Int64
+	maxUpdateMs  atomic.Int64
+
+	recentMu   sync.Mutex
+	recentBuf  [recentMsgRing]recentEntry
+	recentNext int
+
+	dumpMu     sync.Mutex
+	lastDumpAt time.Time
+
+	stallDir string
+)
+
+type recentEntry struct {
+	when     time.Time
+	msgType  string
+	duration time.Duration
+}
+
+// UpdateToken carries the start state for a single Update() invocation.
+// Returned by MarkUpdateStart and consumed by MarkUpdateEnd.
+type UpdateToken struct {
+	start   time.Time
+	msgType string
+}
+
+// Enabled reports whether perfwatch instrumentation is active.
+func Enabled() bool { return enabled.Load() }
+
+// Init starts perfwatch if FLEET_DEBUG is set. Otherwise it is a no-op and
+// all hot paths short-circuit.
+func Init() {
+	if os.Getenv("FLEET_DEBUG") == "" {
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		debuglog.Logger.Error("perfwatch: UserHomeDir failed", "err", err)
+		return
+	}
+	stallDir = filepath.Join(home, ".config", "fleet", "stalls")
+	if err := os.MkdirAll(stallDir, 0755); err != nil {
+		debuglog.Logger.Error("perfwatch: mkdir stalls", "err", err)
+		return
+	}
+
+	runtime.SetBlockProfileRate(int(blockProfileRateNs))
+	runtime.SetMutexProfileFraction(1)
+
+	enabled.Store(true)
+	debuglog.Logger.Info("perfwatch: enabled",
+		"stall_dir", stallDir,
+		"stall_threshold_ms", stallThreshold.Milliseconds(),
+	)
+
+	go watchdogLoop()
+	go heartbeatLoop()
+	go signalLoop()
+}
+
+// MarkUpdateStart records the entry to a Bubble Tea Update() call. Call as the
+// first statement of Update; the returned token must be passed to MarkUpdateEnd
+// (typically via defer).
+func MarkUpdateStart(msgType string) UpdateToken {
+	if !enabled.Load() {
+		return UpdateToken{}
+	}
+	now := time.Now()
+	updateStartUnixNano.Store(now.UnixNano())
+	mt := msgType
+	updateMsgType.Store(&mt)
+	return UpdateToken{start: now, msgType: msgType}
+}
+
+// MarkUpdateEnd records the exit from a Bubble Tea Update() call.
+func MarkUpdateEnd(t UpdateToken) {
+	if !enabled.Load() || t.start.IsZero() {
+		return
+	}
+	dur := time.Since(t.start)
+	updateStartUnixNano.Store(0)
+	updateMsgType.Store(nil)
+	totalUpdates.Add(1)
+
+	if ms := dur.Milliseconds(); ms > maxUpdateMs.Load() {
+		maxUpdateMs.Store(ms)
+	}
+	if dur >= stallThreshold {
+		slowUpdates.Add(1)
+	}
+
+	recentMu.Lock()
+	recentBuf[recentNext] = recentEntry{when: t.start, msgType: t.msgType, duration: dur}
+	recentNext = (recentNext + 1) % recentMsgRing
+	recentMu.Unlock()
+
+	if dur >= slowLogThreshold {
+		debuglog.Logger.Warn("perfwatch: slow Update",
+			"msg", t.msgType,
+			"duration_ms", dur.Milliseconds(),
+		)
+	}
+}
+
+// Snapshot writes a stall dump to the stalls directory and returns its path.
+// Safe to call from any goroutine. Returns "" if perfwatch is disabled.
+func Snapshot(reason string) string {
+	if !enabled.Load() {
+		return ""
+	}
+	ts := time.Now().Format("20060102-150405.000")
+	safe := sanitizeFilename(reason)
+	path := filepath.Join(stallDir, ts+"_"+safe+".txt")
+
+	f, err := os.Create(path)
+	if err != nil {
+		debuglog.Logger.Error("perfwatch: create snapshot", "err", err, "path", path)
+		return ""
+	}
+	defer f.Close()
+
+	writeSnapshot(f, reason)
+	debuglog.Logger.Warn("perfwatch: snapshot written", "path", path, "reason", reason)
+	return path
+}
+
+func writeSnapshot(f *os.File, reason string) {
+	fmt.Fprintf(f, "=== perfwatch snapshot ===\n")
+	fmt.Fprintf(f, "Reason:     %s\n", reason)
+	fmt.Fprintf(f, "Time:       %s\n", time.Now().Format(time.RFC3339Nano))
+	fmt.Fprintf(f, "Goroutines: %d\n", runtime.NumGoroutine())
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	fmt.Fprintf(f, "HeapAlloc:  %d KB\n", ms.HeapAlloc/1024)
+	fmt.Fprintf(f, "Sys:        %d KB\n", ms.Sys/1024)
+	fmt.Fprintf(f, "NumGC:      %d\n", ms.NumGC)
+
+	if startNs := updateStartUnixNano.Load(); startNs != 0 {
+		elapsed := time.Since(time.Unix(0, startNs))
+		msg := "(unknown)"
+		if p := updateMsgType.Load(); p != nil {
+			msg = *p
+		}
+		fmt.Fprintf(f, "\nUpdate() IN FLIGHT: msg=%s elapsed=%s\n", msg, elapsed)
+	} else {
+		fmt.Fprintf(f, "\nUpdate() not in flight at snapshot time\n")
+	}
+
+	fmt.Fprintf(f, "Counters: total=%d slow=%d max_ms=%d\n",
+		totalUpdates.Load(), slowUpdates.Load(), maxUpdateMs.Load())
+
+	fmt.Fprintf(f, "\n=== Recent Update() messages (oldest -> newest) ===\n")
+	recentMu.Lock()
+	for i := range recentMsgRing {
+		idx := (recentNext + i) % recentMsgRing
+		e := recentBuf[idx]
+		if e.when.IsZero() {
+			continue
+		}
+		fmt.Fprintf(f, "%s  %-40s  %s\n",
+			e.when.Format("15:04:05.000"), e.msgType, e.duration)
+	}
+	recentMu.Unlock()
+
+	fmt.Fprintf(f, "\n=== Goroutine stacks (debug=2) ===\n")
+	if p := pprof.Lookup("goroutine"); p != nil {
+		if err := p.WriteTo(f, 2); err != nil {
+			fmt.Fprintf(f, "(goroutine profile error: %v)\n", err)
+		}
+	}
+
+	fmt.Fprintf(f, "\n=== Block profile ===\n")
+	if p := pprof.Lookup("block"); p != nil {
+		if err := p.WriteTo(f, 1); err != nil {
+			fmt.Fprintf(f, "(block profile error: %v)\n", err)
+		}
+	}
+
+	fmt.Fprintf(f, "\n=== Mutex profile ===\n")
+	if p := pprof.Lookup("mutex"); p != nil {
+		if err := p.WriteTo(f, 1); err != nil {
+			fmt.Fprintf(f, "(mutex profile error: %v)\n", err)
+		}
+	}
+}
+
+func watchdogLoop() {
+	t := time.NewTicker(watchdogInterval)
+	defer t.Stop()
+	for range t.C {
+		startNs := updateStartUnixNano.Load()
+		if startNs == 0 {
+			continue
+		}
+		elapsed := time.Since(time.Unix(0, startNs))
+		if elapsed < stallThreshold {
+			continue
+		}
+
+		dumpMu.Lock()
+		if time.Since(lastDumpAt) < minDumpGap {
+			dumpMu.Unlock()
+			continue
+		}
+		lastDumpAt = time.Now()
+		dumpMu.Unlock()
+
+		msg := "unknown"
+		if p := updateMsgType.Load(); p != nil {
+			msg = *p
+		}
+		Snapshot(fmt.Sprintf("update_stall_%s_%dms", msg, elapsed.Milliseconds()))
+	}
+}
+
+func heartbeatLoop() {
+	// /cpu/classes/total reports CPU resources *available* (wall × NumCPU),
+	// not consumed. Subtract idle to get actual fleet CPU usage. Reported as
+	// multi-core %: 100% = one full core busy, 250% = 2.5 cores busy.
+	samples := []metrics.Sample{
+		{Name: "/cpu/classes/total:cpu-seconds"},
+		{Name: "/cpu/classes/idle:cpu-seconds"},
+	}
+	metrics.Read(samples)
+	lastTotal := samples[0].Value.Float64()
+	lastIdle := samples[1].Value.Float64()
+	lastWall := time.Now()
+
+	t := time.NewTicker(heartbeatInterval)
+	defer t.Stop()
+	for now := range t.C {
+		metrics.Read(samples)
+		total := samples[0].Value.Float64()
+		idle := samples[1].Value.Float64()
+		wall := now.Sub(lastWall).Seconds()
+		var pct float64
+		if wall > 0 {
+			pct = ((total - lastTotal) - (idle - lastIdle)) / wall * 100
+		}
+		lastTotal = total
+		lastIdle = idle
+		lastWall = now
+
+		var ms runtime.MemStats
+		runtime.ReadMemStats(&ms)
+
+		debuglog.Logger.Debug("perfwatch heartbeat",
+			"goroutines", runtime.NumGoroutine(),
+			"cpu_pct", fmt.Sprintf("%.1f", pct),
+			"heap_kb", ms.HeapAlloc/1024,
+			"updates_total", totalUpdates.Load(),
+			"updates_slow", slowUpdates.Load(),
+			"max_update_ms", maxUpdateMs.Load(),
+		)
+	}
+}
+
+func signalLoop() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGUSR1)
+	for range ch {
+		Snapshot("manual_sigusr1")
+	}
+}
+
+func sanitizeFilename(s string) string {
+	if len(s) > 80 {
+		s = s[:80]
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, s)
+}

--- a/internal/perfwatch/perfwatch.go
+++ b/internal/perfwatch/perfwatch.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
@@ -42,6 +43,11 @@ const (
 	minDumpGap         = 1500 * time.Millisecond
 	recentMsgRing      = 32
 	blockProfileRateNs = int64(time.Millisecond) // record blocks >= 1ms
+	// updateStormRate triggers a snapshot when sustained Update() throughput
+	// over one heartbeat interval exceeds this (msgs/sec). Catches tea.Cmd
+	// loops that flood the loop without any single Update going slow — the
+	// watchdog can't see those because elapsed never crosses stallThreshold.
+	updateStormRate = 200
 )
 
 var (
@@ -252,14 +258,9 @@ func watchdogLoop() {
 		if elapsed < stallThreshold {
 			continue
 		}
-
-		dumpMu.Lock()
-		if time.Since(lastDumpAt) < minDumpGap {
-			dumpMu.Unlock()
+		if !claimDump() {
 			continue
 		}
-		lastDumpAt = time.Now()
-		dumpMu.Unlock()
 
 		msg := "unknown"
 		if p := updateMsgType.Load(); p != nil {
@@ -267,6 +268,19 @@ func watchdogLoop() {
 		}
 		Snapshot(fmt.Sprintf("update_stall_%s_%dms", msg, elapsed.Milliseconds()))
 	}
+}
+
+// claimDump returns true if no other dump fired within the last minDumpGap.
+// Shared by the stall watchdog and the heartbeat storm detector so concurrent
+// failure modes don't pile up dumps on disk.
+func claimDump() bool {
+	dumpMu.Lock()
+	defer dumpMu.Unlock()
+	if time.Since(lastDumpAt) < minDumpGap {
+		return false
+	}
+	lastDumpAt = time.Now()
+	return true
 }
 
 func heartbeatLoop() {
@@ -280,6 +294,7 @@ func heartbeatLoop() {
 	metrics.Read(samples)
 	lastTotal, lastIdle, cpuOK := readCPUSamples(samples)
 	lastWall := time.Now()
+	lastUpdateCount := totalUpdates.Load()
 
 	t := time.NewTicker(heartbeatInterval)
 	defer t.Stop()
@@ -294,6 +309,13 @@ func heartbeatLoop() {
 		lastTotal, lastIdle, cpuOK = total, idle, ok
 		lastWall = now
 
+		updateCount := totalUpdates.Load()
+		updateRate := 0.0
+		if wall > 0 {
+			updateRate = float64(updateCount-lastUpdateCount) / wall
+		}
+		lastUpdateCount = updateCount
+
 		var ms runtime.MemStats
 		runtime.ReadMemStats(&ms)
 
@@ -301,10 +323,19 @@ func heartbeatLoop() {
 			"goroutines", runtime.NumGoroutine(),
 			"cpu_pct", math.Round(pct*10)/10, // numeric float64 (sentinel -1.0 = unavailable) so structured-log filtering can compare against thresholds
 			"heap_kb", ms.HeapAlloc/1024,
-			"updates_total", totalUpdates.Load(),
+			"sys_free_mb", systemFreeMB(), // -1 if vm_stat unavailable; near-zero = imminent Jetsam OOM kill
+			"updates_total", updateCount,
+			"updates_per_sec", math.Round(updateRate*10)/10,
 			"updates_slow", slowUpdates.Load(),
 			"max_update_ms", maxUpdateMs.Load(),
 		)
+
+		// Storm detector: a tea.Cmd that re-arms without throttling can flood
+		// the loop without any single Update going slow, so the watchdog never
+		// fires. Snapshot once so the recent-message ring captures the culprit.
+		if updateRate > updateStormRate && claimDump() {
+			Snapshot(fmt.Sprintf("update_storm_%dpersec", int(updateRate)))
+		}
 	}
 }
 
@@ -327,6 +358,47 @@ func signalLoop() {
 	for range ch {
 		Snapshot("manual_sigusr1")
 	}
+}
+
+// systemFreeMB returns macOS-wide free memory in MB. Returns -1 on any error.
+// Implementation shells out to vm_stat once per heartbeat (~5ms) and parses
+// the page size from its header line + the "Pages free" field. Fleet is
+// macOS-only; on other platforms this still works if vm_stat is shimmed,
+// otherwise returns -1.
+//
+// Why this matters: when this drops toward 0, macOS Jetsam will start killing
+// user processes — Claude Code child processes are prime targets due to their
+// large in-memory KV cache. Crash dumps cross-reference this trail to confirm
+// OOM-kill diagnoses.
+func systemFreeMB() int64 {
+	out, err := exec.Command("vm_stat").Output()
+	if err != nil {
+		return -1
+	}
+	pageSize := int64(4096) // x86 default
+	var freePages int64 = -1
+	for _, line := range strings.Split(string(out), "\n") {
+		if i := strings.Index(line, "page size of "); i >= 0 {
+			rest := line[i+len("page size of "):]
+			var n int64
+			if _, err := fmt.Sscanf(rest, "%d", &n); err == nil && n > 0 {
+				pageSize = n
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "Pages free:") {
+			rest := strings.TrimSpace(strings.TrimPrefix(line, "Pages free:"))
+			rest = strings.TrimSuffix(rest, ".")
+			var n int64
+			if _, err := fmt.Sscanf(rest, "%d", &n); err == nil {
+				freePages = n
+			}
+		}
+	}
+	if freePages < 0 {
+		return -1
+	}
+	return freePages * pageSize / (1024 * 1024)
 }
 
 func sanitizeFilename(s string) string {

--- a/internal/perfwatch/perfwatch.go
+++ b/internal/perfwatch/perfwatch.go
@@ -137,7 +137,9 @@ func MarkUpdateEnd(t UpdateToken) {
 	if ms := dur.Milliseconds(); ms > maxUpdateMs.Load() {
 		maxUpdateMs.Store(ms)
 	}
-	if dur >= stallThreshold {
+	// Counter mirrors the WARN log threshold (≥100ms), not the stall-dump
+	// threshold (≥500ms). The skill surfaces this as "Updates >100ms".
+	if dur >= slowLogThreshold {
 		slowUpdates.Add(1)
 	}
 
@@ -275,23 +277,20 @@ func heartbeatLoop() {
 		{Name: "/cpu/classes/idle:cpu-seconds"},
 	}
 	metrics.Read(samples)
-	lastTotal := samples[0].Value.Float64()
-	lastIdle := samples[1].Value.Float64()
+	lastTotal, lastIdle, cpuOK := readCPUSamples(samples)
 	lastWall := time.Now()
 
 	t := time.NewTicker(heartbeatInterval)
 	defer t.Stop()
 	for now := range t.C {
 		metrics.Read(samples)
-		total := samples[0].Value.Float64()
-		idle := samples[1].Value.Float64()
+		total, idle, ok := readCPUSamples(samples)
 		wall := now.Sub(lastWall).Seconds()
-		var pct float64
-		if wall > 0 {
+		pct := -1.0 // sentinel: CPU metric unavailable on this runtime
+		if ok && cpuOK && wall > 0 {
 			pct = ((total - lastTotal) - (idle - lastIdle)) / wall * 100
 		}
-		lastTotal = total
-		lastIdle = idle
+		lastTotal, lastIdle, cpuOK = total, idle, ok
 		lastWall = now
 
 		var ms runtime.MemStats
@@ -306,6 +305,19 @@ func heartbeatLoop() {
 			"max_update_ms", maxUpdateMs.Load(),
 		)
 	}
+}
+
+// readCPUSamples returns total/idle CPU seconds, or ok=false when the runtime
+// doesn't expose these metrics as Float64 (e.g. metric removed or renamed in a
+// future Go release). Calling Float64() on a non-Float64 sample panics.
+func readCPUSamples(samples []metrics.Sample) (total, idle float64, ok bool) {
+	if len(samples) < 2 {
+		return 0, 0, false
+	}
+	if samples[0].Value.Kind() != metrics.KindFloat64 || samples[1].Value.Kind() != metrics.KindFloat64 {
+		return 0, 0, false
+	}
+	return samples[0].Value.Float64(), samples[1].Value.Float64(), true
 }
 
 func signalLoop() {

--- a/internal/perfwatch/perfwatch.go
+++ b/internal/perfwatch/perfwatch.go
@@ -18,6 +18,7 @@ package perfwatch
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -298,7 +299,7 @@ func heartbeatLoop() {
 
 		debuglog.Logger.Debug("perfwatch heartbeat",
 			"goroutines", runtime.NumGoroutine(),
-			"cpu_pct", fmt.Sprintf("%.1f", pct),
+			"cpu_pct", math.Round(pct*10)/10, // numeric float64 (sentinel -1.0 = unavailable) so structured-log filtering can compare against thresholds
 			"heap_kb", ms.HeapAlloc/1024,
 			"updates_total", totalUpdates.Load(),
 			"updates_slow", slowUpdates.Load(),

--- a/internal/perfwatch/perfwatch.go
+++ b/internal/perfwatch/perfwatch.go
@@ -98,7 +98,8 @@ func Init() {
 		return
 	}
 	stallDir = filepath.Join(home, ".config", "fleet", "stalls")
-	if err := os.MkdirAll(stallDir, 0755); err != nil {
+	// 0700: snapshots include goroutine stacks + block/mutex profiles.
+	if err := os.MkdirAll(stallDir, 0700); err != nil {
 		debuglog.Logger.Error("perfwatch: mkdir stalls", "err", err)
 		return
 	}
@@ -173,7 +174,8 @@ func Snapshot(reason string) string {
 	safe := sanitizeFilename(reason)
 	path := filepath.Join(stallDir, ts+"_"+safe+".txt")
 
-	f, err := os.Create(path)
+	// 0600: snapshot contents are user-private (goroutine stacks etc.).
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		debuglog.Logger.Error("perfwatch: create snapshot", "err", err, "path", path)
 		return ""

--- a/internal/session/crashdump.go
+++ b/internal/session/crashdump.go
@@ -1,0 +1,231 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/brizzai/fleet/internal/debuglog"
+	"github.com/brizzai/fleet/internal/hooks"
+)
+
+// triggerCrashDump captures forensic state for a session that just died and
+// writes it to ~/.config/fleet/crashes/. Called once per death — guarded by
+// the deathRecorded flag so subsequent UpdateStatus ticks are no-ops.
+//
+// The dump itself runs in a goroutine so the worker can move on to other
+// sessions. Captures:
+//   - tmux pane_dead/exit-status/exit-signal (only present with remain-on-exit on)
+//   - last 200 lines of pane content (raw ANSI, copy-paste-friendly), with
+//     fallback to the most recent pane capture cached by tmux.Session — vital
+//     when the tmux session is GC'd before the dump runs (pane was the only
+//     window, claude was the only command, exit closes the lot)
+//   - hook status file (SessionEnd reason if Claude reported one)
+//   - last 6 perfwatch heartbeats from debug.log (~30s of system context)
+//
+// reason is a fleet-side label ("tmux_gone", "pane_dead", "hook_dead") that
+// indicates which detection path fired.
+func (s *Session) triggerCrashDump(reason string) {
+	s.mu.Lock()
+	if s.deathRecorded {
+		s.mu.Unlock()
+		return
+	}
+	s.deathRecorded = true
+	tmuxName := s.TmuxSessionName
+	id := s.ID
+	title := s.Title
+	s.mu.Unlock()
+
+	// Snapshot the cached pane content NOW (before the goroutine fires) — by
+	// the time the goroutine runs, tmux may already have GC'd the session and
+	// the cache reflects the moment of death.
+	var cachedPane string
+	if s.tmuxSession != nil {
+		cachedPane = s.tmuxSession.CachedPane()
+	}
+
+	go writeCrashDump(id, title, tmuxName, reason, cachedPane)
+}
+
+func writeCrashDump(sessionID, title, tmuxName, reason, cachedPane string) {
+	defer func() {
+		if r := recover(); r != nil {
+			debuglog.Logger.Error("crashdump: panic", "id", sessionID, "recover", r)
+		}
+	}()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		debuglog.Logger.Error("crashdump: UserHomeDir failed", "err", err)
+		return
+	}
+	dir := filepath.Join(home, ".config", "fleet", "crashes")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		debuglog.Logger.Error("crashdump: mkdir failed", "dir", dir, "err", err)
+		return
+	}
+
+	now := time.Now()
+	path := filepath.Join(dir, fmt.Sprintf("%s_%s.txt", sessionID, now.Format("20060102-150405")))
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "=== fleet session crash dump ===\n")
+	fmt.Fprintf(&buf, "session_id:     %s\n", sessionID)
+	fmt.Fprintf(&buf, "title:          %s\n", title)
+	fmt.Fprintf(&buf, "tmux_session:   %s\n", tmuxName)
+	fmt.Fprintf(&buf, "detected_via:   %s\n", reason)
+	fmt.Fprintf(&buf, "captured_at:    %s\n", now.Format(time.RFC3339))
+
+	// Tmux exit info — only meaningful with remain-on-exit on.
+	if dead, status, signal, ok := tmuxPaneDeadInfo(tmuxName); ok {
+		fmt.Fprintf(&buf, "tmux_dead:      %t\n", dead)
+		fmt.Fprintf(&buf, "exit_status:    %s\n", emptyDash(status))
+		fmt.Fprintf(&buf, "exit_signal:    %s%s\n", emptyDash(signal), signalNote(signal))
+	} else {
+		fmt.Fprintf(&buf, "tmux_dead:      tmux session no longer exists (GC'd before dump)\n")
+	}
+
+	// Hook file — Claude Code's SessionEnd payload.
+	if hf, err := readHookFile(home, sessionID); err == nil {
+		fmt.Fprintf(&buf, "hook_event:     %s\n", hf.Event)
+		fmt.Fprintf(&buf, "hook_reason:    %s\n", emptyDash(hf.Reason))
+		fmt.Fprintf(&buf, "hook_status:    %s\n", hf.Status)
+		fmt.Fprintf(&buf, "hook_ts:        %s\n", time.Unix(hf.Timestamp, 0).Format(time.RFC3339))
+	} else {
+		fmt.Fprintf(&buf, "hook_file:      not readable (%v)\n", err)
+	}
+
+	// Last 200 lines of pane (raw ANSI preserved — paste straight into a
+	// terminal to view colored, or strip with `sed 's/\x1b\[[0-9;]*m//g'`).
+	// Try live capture first (most recent), fall back to fleet's cached capture
+	// (last successful poll before the death) if tmux session is already gone.
+	fmt.Fprintf(&buf, "\n=== pane (last 200 lines, raw ANSI) ===\n")
+	if pane, err := capturePaneRaw(tmuxName, 200); err == nil {
+		buf.WriteString(pane)
+		if !strings.HasSuffix(pane, "\n") {
+			buf.WriteByte('\n')
+		}
+	} else if cachedPane != "" {
+		fmt.Fprintf(&buf, "(live capture failed: %v — falling back to fleet's cached pane from last successful poll)\n", err)
+		buf.WriteString(cachedPane)
+		if !strings.HasSuffix(cachedPane, "\n") {
+			buf.WriteByte('\n')
+		}
+	} else {
+		fmt.Fprintf(&buf, "(capture failed: %v; no cached content available)\n", err)
+	}
+
+	// Last 6 perfwatch heartbeats from debug.log (~30s of system context).
+	fmt.Fprintf(&buf, "\n=== recent perfwatch heartbeats (system context) ===\n")
+	if hb := tailPerfwatchHeartbeats(6); hb != "" {
+		buf.WriteString(hb)
+	} else {
+		fmt.Fprintf(&buf, "(no heartbeats found — perfwatch may be disabled; relaunch with FLEET_DEBUG=1)\n")
+	}
+
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		debuglog.Logger.Error("crashdump: write failed", "path", path, "err", err)
+		return
+	}
+	debuglog.Logger.Warn("crashdump: written", "path", path, "id", sessionID, "reason", reason)
+}
+
+func tmuxPaneDeadInfo(tmuxName string) (dead bool, status, signal string, ok bool) {
+	out, err := exec.Command("tmux", "list-panes", "-t", tmuxName+":0.0",
+		"-F", "#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}").Output()
+	if err != nil {
+		return false, "", "", false
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(out)), "|", 3)
+	if len(parts) != 3 {
+		return false, "", "", false
+	}
+	return parts[0] == "1", parts[1], parts[2], true
+}
+
+func capturePaneRaw(tmuxName string, lines int) (string, error) {
+	// -e preserves ANSI; -S -N starts N lines back from the bottom of history.
+	out, err := exec.Command("tmux", "capture-pane", "-t", tmuxName, "-p", "-e",
+		"-S", fmt.Sprintf("-%d", lines)).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func readHookFile(home, sessionID string) (*hooks.StatusFile, error) {
+	path := filepath.Join(home, ".config", "fleet", "hooks", sessionID+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var hf hooks.StatusFile
+	if err := json.Unmarshal(data, &hf); err != nil {
+		return nil, err
+	}
+	return &hf, nil
+}
+
+// tailPerfwatchHeartbeats returns the last n "perfwatch heartbeat" lines from
+// the debug log, oldest first. Returns "" if the log can't be read or no
+// heartbeats are present.
+func tailPerfwatchHeartbeats(n int) string {
+	data, err := os.ReadFile(debuglog.LogPath())
+	if err != nil {
+		return ""
+	}
+	// Walk lines from the end, picking the last n that contain "perfwatch heartbeat".
+	all := bytes.Split(data, []byte("\n"))
+	var picked []string
+	for i := len(all) - 1; i >= 0 && len(picked) < n; i-- {
+		line := string(all[i])
+		if strings.Contains(line, "perfwatch heartbeat") {
+			picked = append(picked, line)
+		}
+	}
+	if len(picked) == 0 {
+		return ""
+	}
+	// Reverse to oldest-first.
+	for i, j := 0, len(picked)-1; i < j; i, j = i+1, j-1 {
+		picked[i], picked[j] = picked[j], picked[i]
+	}
+	return strings.Join(picked, "\n") + "\n"
+}
+
+func emptyDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// signalNote annotates a tmux #{pane_dead_signal} value with what the signal
+// number means, when recognized. Returns "" for unknown/empty values.
+func signalNote(sig string) string {
+	switch strings.TrimSpace(sig) {
+	case "":
+		return ""
+	case "0":
+		return " (no signal — clean exit)"
+	case "1":
+		return " (SIGHUP)"
+	case "2":
+		return " (SIGINT — Ctrl+C)"
+	case "6":
+		return " (SIGABRT — panic/abort)"
+	case "9":
+		return " (SIGKILL — likely OOM/Jetsam or external kill)"
+	case "11":
+		return " (SIGSEGV — segfault)"
+	case "15":
+		return " (SIGTERM — graceful kill)"
+	}
+	return ""
+}

--- a/internal/session/crashdump.go
+++ b/internal/session/crashdump.go
@@ -2,8 +2,10 @@ package session
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +15,11 @@ import (
 	"github.com/brizzai/fleet/internal/debuglog"
 	"github.com/brizzai/fleet/internal/hooks"
 )
+
+// crashdumpTmuxTimeout caps any tmux shell-out from the crash-dump path. A
+// hung tmux during repeated crashes would otherwise pile up stuck goroutines.
+// Mirrors the captureTimeout pattern in tmux.Session.CapturePane.
+const crashdumpTmuxTimeout = 3 * time.Second
 
 // triggerCrashDump captures forensic state for a session that just died and
 // writes it to ~/.config/fleet/crashes/. Called once per death — guarded by
@@ -40,14 +47,19 @@ func (s *Session) triggerCrashDump(reason string) {
 	tmuxName := s.TmuxSessionName
 	id := s.ID
 	title := s.Title
+	// Snapshot the *tmux.Session pointer under the lock — Restart() swaps
+	// s.tmuxSession concurrently (with s.mu held during the swap), so reading
+	// it after Unlock would race with subsequent restarts and could capture
+	// the replacement session's cached pane instead of the dead one.
+	tmuxSession := s.tmuxSession
 	s.mu.Unlock()
 
 	// Snapshot the cached pane content NOW (before the goroutine fires) — by
 	// the time the goroutine runs, tmux may already have GC'd the session and
 	// the cache reflects the moment of death.
 	var cachedPane string
-	if s.tmuxSession != nil {
-		cachedPane = s.tmuxSession.CachedPane()
+	if tmuxSession != nil {
+		cachedPane = tmuxSession.CachedPane()
 	}
 
 	go writeCrashDump(id, title, tmuxName, reason, cachedPane)
@@ -66,7 +78,8 @@ func writeCrashDump(sessionID, title, tmuxName, reason, cachedPane string) {
 		return
 	}
 	dir := filepath.Join(home, ".config", "fleet", "crashes")
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	// 0700: dumps include raw pane content (code, prompts, occasional secrets).
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		debuglog.Logger.Error("crashdump: mkdir failed", "dir", dir, "err", err)
 		return
 	}
@@ -83,12 +96,16 @@ func writeCrashDump(sessionID, title, tmuxName, reason, cachedPane string) {
 	fmt.Fprintf(&buf, "captured_at:    %s\n", now.Format(time.RFC3339))
 
 	// Tmux exit info — only meaningful with remain-on-exit on.
-	if dead, status, signal, ok := tmuxPaneDeadInfo(tmuxName); ok {
+	if dead, status, signal, infoErr := tmuxPaneDeadInfo(tmuxName); infoErr == nil {
 		fmt.Fprintf(&buf, "tmux_dead:      %t\n", dead)
 		fmt.Fprintf(&buf, "exit_status:    %s\n", emptyDash(status))
 		fmt.Fprintf(&buf, "exit_signal:    %s%s\n", emptyDash(signal), signalNote(signal))
 	} else {
-		fmt.Fprintf(&buf, "tmux_dead:      tmux session no longer exists (GC'd before dump)\n")
+		// Most common cause is the tmux session being GC'd before the dump
+		// runs (only window, only command exited). Other causes: tmux not on
+		// PATH, transient tmux server failure, or list-panes output that
+		// doesn't match the expected 3-field format.
+		fmt.Fprintf(&buf, "tmux_dead:      unavailable (%v)\n", infoErr)
 	}
 
 	// Hook file — Claude Code's SessionEnd payload.
@@ -129,29 +146,36 @@ func writeCrashDump(sessionID, title, tmuxName, reason, cachedPane string) {
 		fmt.Fprintf(&buf, "(no heartbeats found — perfwatch may be disabled; relaunch with FLEET_DEBUG=1)\n")
 	}
 
-	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+	// 0600: contents are user-private (pane raw text + hook context).
+	if err := os.WriteFile(path, buf.Bytes(), 0600); err != nil {
 		debuglog.Logger.Error("crashdump: write failed", "path", path, "err", err)
 		return
 	}
 	debuglog.Logger.Warn("crashdump: written", "path", path, "id", sessionID, "reason", reason)
 }
 
-func tmuxPaneDeadInfo(tmuxName string) (dead bool, status, signal string, ok bool) {
+// tmuxPaneDeadInfo queries tmux for pane death info. Returns an error rather
+// than a bool ok so writeCrashDump can surface the *cause* of failure (tmux
+// missing, server gone, malformed output) instead of a one-size-fits-all
+// "session GC'd" message.
+func tmuxPaneDeadInfo(tmuxName string) (dead bool, status, signal string, err error) {
 	out, err := exec.Command("tmux", "list-panes", "-t", tmuxName+":0.0",
 		"-F", "#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}").Output()
 	if err != nil {
-		return false, "", "", false
+		return false, "", "", fmt.Errorf("tmux list-panes: %w", err)
 	}
 	parts := strings.SplitN(strings.TrimSpace(string(out)), "|", 3)
 	if len(parts) != 3 {
-		return false, "", "", false
+		return false, "", "", fmt.Errorf("unexpected list-panes output: %q", string(out))
 	}
-	return parts[0] == "1", parts[1], parts[2], true
+	return parts[0] == "1", parts[1], parts[2], nil
 }
 
 func capturePaneRaw(tmuxName string, lines int) (string, error) {
 	// -e preserves ANSI; -S -N starts N lines back from the bottom of history.
-	out, err := exec.Command("tmux", "capture-pane", "-t", tmuxName, "-p", "-e",
+	ctx, cancel := context.WithTimeout(context.Background(), crashdumpTmuxTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "tmux", "capture-pane", "-t", tmuxName, "-p", "-e",
 		"-S", fmt.Sprintf("-%d", lines)).Output()
 	if err != nil {
 		return "", err
@@ -172,16 +196,49 @@ func readHookFile(home, sessionID string) (*hooks.StatusFile, error) {
 	return &hf, nil
 }
 
+// heartbeatTailWindow caps how many bytes we read from the end of debug.log
+// when extracting the last few heartbeat lines. With FLEET_DEBUG=1 the log
+// can grow to MBs; allocating that just to find ~6 short lines is wasteful,
+// especially since crash dumps tend to fire under memory pressure. 64KB
+// comfortably covers ~6 heartbeats * ~300 bytes each plus headroom.
+const heartbeatTailWindow = 64 * 1024
+
 // tailPerfwatchHeartbeats returns the last n "perfwatch heartbeat" lines from
 // the debug log, oldest first. Returns "" if the log can't be read or no
-// heartbeats are present.
+// heartbeats are present. Reads only the trailing heartbeatTailWindow bytes
+// of the log to avoid loading multi-MB logs into memory.
 func tailPerfwatchHeartbeats(n int) string {
-	data, err := os.ReadFile(debuglog.LogPath())
+	f, err := os.Open(debuglog.LogPath())
 	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	stat, err := f.Stat()
+	if err != nil {
+		return ""
+	}
+	size := stat.Size()
+	readLen := int64(heartbeatTailWindow)
+	var seekedIntoLine bool
+	if size > readLen {
+		if _, err := f.Seek(-readLen, io.SeekEnd); err != nil {
+			return ""
+		}
+		seekedIntoLine = true
+	} else {
+		readLen = size
+	}
+	data := make([]byte, readLen)
+	if _, err := io.ReadFull(f, data); err != nil {
 		return ""
 	}
 	// Walk lines from the end, picking the last n that contain "perfwatch heartbeat".
 	all := bytes.Split(data, []byte("\n"))
+	// If we seeked into the middle of a line, the first element is a partial —
+	// drop it so we don't match against truncated content.
+	if seekedIntoLine && len(all) > 0 {
+		all = all[1:]
+	}
 	var picked []string
 	for i := len(all) - 1; i >= 0 && len(picked) < n; i-- {
 		line := string(all[i])

--- a/internal/session/golden_test.go
+++ b/internal/session/golden_test.go
@@ -32,6 +32,7 @@ var goldenTests = []struct {
 	{"pane_running_stale_waiting_spinner.txt", StatusRunning, "active spinner (✳) with idle prompt — Claude running after permission approved"},
 	{"pane_finished_cli_spinners_in_scrollback.txt", StatusFinished, "idle prompt with braille spinner chars from CLI tool output in scrollback"},
 	{"pane_running_plan_checklist_deep.txt", StatusRunning, "plan execution with whimsical activity line pushed deep by expanding checklist"},
+	{"pane_waiting_askuserquestion_checkbox_focus.txt", StatusWaiting, "AskUserQuestion dialog with focus on checkbox question header (no `❯ N.` cursor in numbered options)"},
 }
 
 func TestGoldenDetection(t *testing.T) {

--- a/internal/session/golden_test.go
+++ b/internal/session/golden_test.go
@@ -32,6 +32,7 @@ var goldenTests = []struct {
 	{"pane_running_stale_waiting_spinner.txt", StatusRunning, "active spinner (✳) with idle prompt — Claude running after permission approved"},
 	{"pane_finished_cli_spinners_in_scrollback.txt", StatusFinished, "idle prompt with braille spinner chars from CLI tool output in scrollback"},
 	{"pane_running_plan_checklist_deep.txt", StatusRunning, "plan execution with whimsical activity line pushed deep by expanding checklist"},
+	{"pane_finished_quoted_crashdump_whimsical.txt", StatusFinished, "idle prompt with embedded crash-dump example containing a whimsical activity line in scrollback (~30 lines from bottom)"},
 	{"pane_waiting_askuserquestion_checkbox_focus.txt", StatusWaiting, "AskUserQuestion dialog with focus on checkbox question header (no `❯ N.` cursor in numbered options)"},
 }
 

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -553,6 +553,49 @@ func TestScenarioWaitingFirstTickPaneRunning(t *testing.T) {
 	})
 }
 
+func TestScenarioAskUserQuestionNavigationStaysWaiting(t *testing.T) {
+	// Regression: Claude's AskUserQuestion tool keeps the prompt open while the
+	// user navigates with Tab/arrow keys. Each keystroke mutates pane content
+	// (cursor moves, checkbox toggles), so the hash drifts on every tick.
+	// Before the fix, applyHookWaiting's "content changed → assume running"
+	// override fired on each drift, flipping status to running for ≥15s. The
+	// user only saw "waiting" again once they paused for the full cooldown.
+	//
+	// Fix: detectWaiting matches the AskUserQuestion footer ("Tab to switch
+	// questions" + "Esc to cancel"), so paneStatus=Waiting through navigation.
+	// applyHookWaiting suppresses the running override when paneStatus=Waiting
+	// because the prompt is clearly still on screen.
+	// Captured from snapshot 2026-05-05T15-38-57_lets-start-brainstorming-ideas.
+	fixture := "pane_waiting_askuserquestion_checkbox_focus.txt"
+	if _, err := os.Stat(filepath.Join("testdata", fixture)); err != nil {
+		t.Skipf("fixture %s not available", fixture)
+	}
+
+	// Plain-text variants that share the AskUserQuestion footer but differ in
+	// the checkbox row above it — simulates the user pressing Tab to toggle
+	// which question is selected. Both must be detected as waiting; only the
+	// hash changes.
+	stackFocus := "Round 3: Architecture\n☒ Stack  ☐ Process model  ☐ V1 scope\nEnter to select · ↑/↓ to navigate · n to add notes · Tab to switch questions · Esc to cancel\n"
+	processFocus := "Round 3: Architecture\n☐ Stack  ☒ Process model  ☐ V1 scope\nEnter to select · ↑/↓ to navigate · n to add notes · Tab to switch questions · Esc to cancel\n"
+
+	runScenario(t, Scenario{
+		Name: "AskUserQuestion navigation: hook=waiting + drifting hash → stays waiting",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "waiting", Pane: "@fixture:" + fixture}, // real ANSI capture
+			{At: 3 * time.Second, Pane: stackFocus},               // first plain-text view
+			{At: 6 * time.Second, Pane: processFocus},             // user Tab'd to next question, hash drifts
+			{At: 9 * time.Second, Pane: stackFocus},               // Tab'd back, hash drifts again
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusWaiting},
+			{At: 3 * time.Second, Expected: StatusWaiting},  // before fix: flipped to running on hash drift
+			{At: 6 * time.Second, Expected: StatusWaiting},  // before fix: still running (15s cooldown)
+			{At: 9 * time.Second, Expected: StatusWaiting},  // before fix: still running
+			{At: 25 * time.Second, Expected: StatusWaiting}, // long after any cooldown
+		},
+	})
+}
+
 func TestScenarioStaleWaitingWithActiveSpinner(t *testing.T) {
 	// Regression: user approves a PermissionRequest and Claude starts working.
 	// No UserPromptSubmit fires for permission grants, so the hook stays "waiting".

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/brizzai/fleet/internal/debuglog"
+	"github.com/brizzai/fleet/internal/hooks"
 	"github.com/brizzai/fleet/internal/tmux"
 )
 
@@ -59,6 +61,8 @@ type Session struct {
 
 	lastContentHash     string
 	lastContentChangeAt time.Time
+
+	deathRecorded bool // crash dump already written for the current life of this session; reset by Restart
 
 	tmuxSession  *tmux.Session
 	paneCapturer PaneCapturer // optional override for testing; if nil, uses tmuxSession
@@ -221,6 +225,13 @@ func (s *Session) UpdateHookStatus(hs *HookStatus) bool {
 		s.lastContentHash = ""
 		s.lastContentChangeAt = time.Time{}
 		s.hookOverriddenAt = time.Time{} // allow fresh evaluation of new hook
+		// A non-dead hook means Claude is alive again. Re-arm the crash-dump
+		// trigger so the NEXT real death gets a dump even if a prior false
+		// transition (e.g. brief stale-hook flash before this fresh hook
+		// landed) already consumed the once-per-life dump quota.
+		if hs.Status != "" && hs.Status != "dead" {
+			s.deathRecorded = false
+		}
 	}
 	s.hookStatus = hs.Status
 	s.hookUpdatedAt = hs.UpdatedAt
@@ -247,11 +258,18 @@ func (s *Session) Restart() error {
 		_ = s.tmuxSession.Kill()
 	}
 
+	// Drop the previous Claude's hook state. Without this, fleet's status worker
+	// can read the old file's status=dead before the new Claude has fired any
+	// hook event, which flips the freshly-restarted session straight back to
+	// error and triggers a misleading crash dump.
+	s.clearHookState()
+
 	// Recreate tmux session with same config.
 	s.tmuxSession = tmux.NewSession(s.Title, s.ProjectPath)
 	s.mu.Lock()
 	s.TmuxSessionName = s.tmuxSession.Name
 	s.Status = StatusStarting
+	s.deathRecorded = false
 	s.mu.Unlock()
 
 	cmd := s.buildClaudeCmd()
@@ -274,8 +292,10 @@ func (s *Session) Restart() error {
 func (s *Session) RespawnClaude() error {
 	resuming := s.ClaudeSessionID != ""
 	debuglog.Logger.Info("session respawn", "id", s.ID, "title", s.Title, "resuming", resuming)
+	s.clearHookState()
 	s.mu.Lock()
 	s.Status = StatusStarting
+	s.deathRecorded = false
 	s.mu.Unlock()
 
 	cmd := s.buildClaudeCmd()
@@ -297,6 +317,23 @@ func (s *Session) RespawnClaude() error {
 	return nil
 }
 
+// clearHookState drops the previous Claude process's hook state — both the
+// in-memory cache and the on-disk status file at
+// ~/.config/fleet/hooks/<id>.json. Called before relaunching Claude so the
+// worker doesn't trust the dead Claude's last hook ("dead", "waiting", etc.)
+// during the gap between tmux respawn and the new Claude's first hook event.
+func (s *Session) clearHookState() {
+	s.mu.Lock()
+	s.hookStatus = ""
+	s.hookUpdatedAt = time.Time{}
+	s.hookOverriddenAt = time.Time{}
+	s.mu.Unlock()
+	hookFile := filepath.Join(hooks.GetHooksDir(), s.ID+".json")
+	if err := os.Remove(hookFile); err != nil && !os.IsNotExist(err) {
+		debuglog.Logger.Warn("session: clear hook file failed", "id", s.ID, "path", hookFile, "err", err)
+	}
+}
+
 // UpdateStatus detects the session status from pane content.
 func (s *Session) UpdateStatus() {
 	log := debuglog.Logger.With("session", s.ID, "title", s.Title)
@@ -305,6 +342,7 @@ func (s *Session) UpdateStatus() {
 	if !s.IsAlive() {
 		s.SetStatus(StatusError)
 		log.Debug("status: not alive", "old", oldStatus, "new", StatusError)
+		s.triggerCrashDump("tmux_gone")
 		return
 	}
 
@@ -312,6 +350,7 @@ func (s *Session) UpdateStatus() {
 	if s.getCapturer().IsPaneDead() {
 		s.SetStatus(StatusError)
 		log.Debug("status: pane dead", "old", oldStatus, "new", StatusError)
+		s.triggerCrashDump("pane_dead")
 		return
 	}
 
@@ -341,24 +380,32 @@ func (s *Session) updateStatusFromHook(oldStatus Status, hookStatus string, hook
 		paneStatus = detectStatus(paneContent, log)
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	hookSaysDead := false
+	func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
 
-	switch hookStatus {
-	case "running":
-		s.applyHookRunning(oldStatus, paneContent, paneStatus, log)
-	case "waiting":
-		s.applyHookWaiting(paneContent, paneStatus, log)
-	case "finished":
-		s.applyHookFinished(paneStatus, log)
-	case "dead":
-		s.lastContentHash = ""
-		s.lastContentChangeAt = time.Time{}
-		s.Status = StatusError
-	}
+		switch hookStatus {
+		case "running":
+			s.applyHookRunning(oldStatus, paneContent, paneStatus, log)
+		case "waiting":
+			s.applyHookWaiting(paneContent, paneStatus, log)
+		case "finished":
+			s.applyHookFinished(paneStatus, log)
+		case "dead":
+			s.lastContentHash = ""
+			s.lastContentChangeAt = time.Time{}
+			s.Status = StatusError
+			hookSaysDead = true
+		}
 
-	if s.Status != oldStatus {
-		log.Info("status changed (hook)", "old", oldStatus, "new", s.Status, "hookStatus", hookStatus, "hookAge", hookAge.Round(time.Millisecond))
+		if s.Status != oldStatus {
+			log.Info("status changed (hook)", "old", oldStatus, "new", s.Status, "hookStatus", hookStatus, "hookAge", hookAge.Round(time.Millisecond))
+		}
+	}()
+
+	if hookSaysDead {
+		s.triggerCrashDump("hook_dead")
 	}
 }
 
@@ -836,12 +883,17 @@ func detectRunning(recentLines []string, _ string, log *slog.Logger) Status {
 	//   "· Clauding… (53s · ↓ 749 tokens)"                                    — standard
 	//   "· Gesticulating… (5m 42s · ↓ 4.2k tokens · thinking with high effort)" — extended thinking
 	// Both contain `tokens` and `· ↓`/`· ↑` inside a trailing ")".
-	// The `)` suffix + `tokens` + arrow marker combo is specific enough to avoid
-	// false-positives from conversation text — safe to scan all 50 recent lines.
-	// (Unlike raw spinner chars, which false-positive on CLI tool output.)
-	// Scanning all lines is important because plan execution pushes the activity
-	// line far from the bottom as checklist items expand below it.
-	for _, line := range recentLines {
+	//
+	// Scanned in the bottom 20 lines (not all 50): plan execution can push the
+	// activity line down via checklist items rendered below it (deepest known
+	// case lands at recentLines[14]), so the limit accommodates that with
+	// headroom. Scanning all 50 false-positives on quoted activity lines that
+	// can land in scrollback when Claude's prior response embeds an example
+	// pane capture or crash-dump snippet — those satisfy every textual guard
+	// (`)` suffix, `tokens`, `· ↓`/`· ↑`, real duration string) but are not
+	// live indicators.
+	whimsicalN := min(20, len(recentLines))
+	for _, line := range recentLines[:whimsicalN] {
 		if isWhimsicalActivity(line) {
 			log.Debug("detectStatus: matched whimsical activity pattern", "line", strings.TrimRight(line, " \t"))
 			return StatusRunning

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -513,10 +513,21 @@ func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, log *s
 			s.lastContentChangeAt = time.Now()
 		}
 	} else if hash != s.lastContentHash {
-		// Content changed — user acted on the prompt.
+		// Content changed — refresh hash so the next tick measures from the new baseline.
+		s.lastContentHash = hash
+		// If pane still structurally shows a waiting prompt (e.g. the user is
+		// navigating Claude's AskUserQuestion dialog with arrow/Tab keys, which
+		// mutates checkbox/cursor cells without leaving the prompt), keep
+		// status=waiting. The override below assumes hash drift means "user
+		// approved and Claude resumed", but that's wrong when the prompt is
+		// still on screen. Don't bump lastContentChangeAt either — that would
+		// extend the running cooldown for every keystroke.
+		if paneStatus == StatusWaiting {
+			return
+		}
+		// Pane no longer confirms waiting — user likely approved/escaped.
 		// Transition to running (approval is the most common action).
 		// Hooks will correct to the right status within milliseconds.
-		s.lastContentHash = hash
 		s.lastContentChangeAt = time.Now()
 		s.Status = StatusRunning
 		log.Info("content changed while waiting, assuming running")
@@ -926,6 +937,22 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 		trimmedLine := strings.TrimSpace(recentLines[i])
 		if strings.HasPrefix(trimmedLine, "│") && strings.Contains(trimmedLine, "Waiting for team lead") {
 			log.Debug("detectStatus: matched team waiting box", "line", trimmedLine)
+			return StatusWaiting
+		}
+	}
+
+	// Structural check: AskUserQuestion tool dialog.
+	// The footer "Tab to switch questions" only appears in this tool's UI —
+	// no other Claude prompt has tabs between questions. Pair with "Esc to cancel"
+	// to avoid matching conversation text that mentions tabs.
+	// The cursor `❯` and numbered options here are unstable as the user navigates
+	// (Tab moves focus to checkbox-style question rows where `❯` disappears),
+	// so the menu structural check above misses these states. The footer is
+	// rendered identically on every tick regardless of which question has focus.
+	for i := 0; i < bottomN; i++ {
+		lower := strings.ToLower(recentLines[i])
+		if strings.Contains(lower, "tab to switch questions") && strings.Contains(lower, "esc to cancel") {
+			log.Debug("detectStatus: matched askuserquestion footer")
 			return StatusWaiting
 		}
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -264,16 +264,18 @@ func (s *Session) Restart() error {
 	// error and triggers a misleading crash dump.
 	s.clearHookState()
 
-	// Recreate tmux session with same config.
-	s.tmuxSession = tmux.NewSession(s.Title, s.ProjectPath)
+	// Recreate tmux session with same config. Mutate s.tmuxSession under
+	// s.mu so concurrent triggerCrashDump readers see a consistent pointer.
+	newTmux := tmux.NewSession(s.Title, s.ProjectPath)
 	s.mu.Lock()
-	s.TmuxSessionName = s.tmuxSession.Name
+	s.tmuxSession = newTmux
+	s.TmuxSessionName = newTmux.Name
 	s.Status = StatusStarting
 	s.deathRecorded = false
 	s.mu.Unlock()
 
 	cmd := s.buildClaudeCmd()
-	if err := s.tmuxSession.Start(cmd, s.sessionEnv()...); err != nil {
+	if err := newTmux.Start(cmd, s.sessionEnv()...); err != nil {
 		s.mu.Lock()
 		s.Status = StatusError
 		s.mu.Unlock()

--- a/internal/session/testdata/pane_finished_quoted_crashdump_whimsical.txt
+++ b/internal/session/testdata/pane_finished_quoted_crashdump_whimsical.txt
@@ -1,0 +1,56 @@
+  captured_at:    2026-05-06T12:02:37+03:00
+  tmux_dead:      true
+  exit_status:    -
+  exit_signal:    9 (SIGKILL — likely OOM/Jetsam or external kill)
+  hook_event:     SessionEnd
+  hook_reason:    other
+  hook_status:    dead
+  hook_ts:        2026-05-06T12:02:36+03:00
+
+  === pane (last 200 lines, raw ANSI) ===
+  ✽ Filling SessionService gaps (3a)… (11m 4s · ↓47.0k tokens · almost done thinking)
+  [shell prompt now visible since pane survived via remain-on-exit]
+  Killed: 9
+  yuvalhayke@…$
+
+  === recent perfwatch heartbeats (system context) ===
+  …heartbeat goroutines=22 cpu_pct=18.5 sys_free_mb=125 …
+  …heartbeat goroutines=22 cpu_pct=24.9 sys_free_mb=83 …
+  …heartbeat goroutines=22 cpu_pct=33.0 sys_free_mb=41 …
+  …heartbeat goroutines=22 cpu_pct=37.1 sys_free_mb=12 ← collapse
+
+  Single file → diagnosis trivial: [38;5;153msignal=9[39m + [38;5;153msys_free_mb[39m collapsing = Jetsam OOM. [38;5;153msignal=6[39m + clean memory = Claude panic. [38;5;153msignal=0[39m/[38;5;153mhook_reason=logout[39m = clean [38;5;153m/exit[39m.
+
+  [1mSummary of changes[0m
+
+  - [38;5;153minternal/tmux/tmux.go[39m — [38;5;153mremain-on-exit on[39m per-session + [38;5;153mPaneDeadInfo()[39m method
+  - [38;5;153minternal/hooks/status_file.go[39m + [38;5;153mcmd/fleet/hook_handler.go[39m — pass through SessionEnd [38;5;153mreason[39m
+  - [38;5;153minternal/session/session.go[39m — [38;5;153mdeathRecorded[39m flag + [38;5;153mtriggerCrashDump[39m calls in all three death paths; reset on Restart/RespawnClaude; refactored locking in [38;5;153mupdateStatusFromHook[39m to safely defer the trigger
+  - [38;5;153minternal/session/crashdump.go[39m (new) — async dump writer
+  - [38;5;153minternal/perfwatch/perfwatch.go[39m — [38;5;153msys_free_mb[39m field via vm_stat shellout
+  - [38;5;153mchangelog/unreleased/crash-dump-on-session-death.md[39m
+
+  Relaunch with [38;5;153mFLEET_DEBUG=1 FLEET_AUTO_UPDATE_DISABLED=1 ./build/fleet[39m to activate.
+
+[38;5;246m✻[39m [38;5;246mCogitated for 7m 23s[39m
+
+[38;5;239m[48;5;237m❯ [38;5;231mok running?[39m
+[49m
+[38;5;114m⏺[39m [1mBash[0m(pgrep -af 'build/fleet$' | head -3; echo "---"; ps -p $(pgrep -f 'build/fleet$' | head -1) -o pid,etime,command 2>&1; echo "--- env ---"; ps eww -p $(pgrep -f '…)
+[38;5;246m  ⎿  [39m82122
+     ---
+       PID ELAPSED COMMAND
+     [2m… +12 lines (ctrl+o to expand)[0m
+[38;5;246m  ⎿  Allowed by auto mode classifier[39m
+
+[38;5;231m⏺[39m Running and fully wired. PID 82122, 18s old, both env vars set, no auto-update, perfwatch alive with the new [38;5;153msys_free_mb[39m field flowing — currently 63–85 MB free (still tight, system is under pressure, so Jetsam risk remains real). Crash dumps will land in [38;5;153m~/.config/fleet/crashes/[39m next time anything dies.
+
+[38;5;246m✻[39m [38;5;246mCogitated for 14s[39m
+
+[38;5;244m──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m❯ [7mc[0;2mommit this[0m
+[38;5;244m──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m  [36m󰧑 Opus 4.7 (1M context)[38;5;246m [90m│[38;5;246m [32m██░░░░░░░░[38;5;246m [90m│[38;5;246m [32m29%[38;5;246m [90m│[38;5;246m [35m󰍛 290.0k/1000k[38;5;246m [90m│[38;5;246m [33m feat/perfwatch-stall-detection[38;5;246m [90m│[38;5;246m [1m[37m  brizz-code[0m
+  [38;5;220m⏵⏵ auto mode on[38;5;246m (shift+tab to cycle) · PR[39m [4m[38;5;220m]8;id=n98mia;https://github.com/brizzai/fleet/pull/67\#67[0m]8;;\
+
+

--- a/internal/session/testdata/pane_waiting_askuserquestion_checkbox_focus.txt
+++ b/internal/session/testdata/pane_waiting_askuserquestion_checkbox_focus.txt
@@ -1,0 +1,56 @@
+
+  Let me dispatch a research agent to dig deep on Conductor + adjacent products in the background while we continue brainstorming.
+
+[38;5;114m⏺[39m [1mAgent[0m(Research Conductor + competitor landscape)
+[38;5;246m  ⎿  [39mBackgrounded agent[38;5;246m (↓ to manage · ctrl+o to expand)[39m
+
+[38;5;231m⏺[39m Research is running. While that cooks, let me dig into what I see in the Conductor screenshot and ask sharper questions.
+
+  [1mRound 2: Layout & multi-session UX[0m (the core thing you said sells you on desktop)
+
+[38;5;231m⏺ [39mUser answered Claude's questions:
+[38;5;246m  ⎿  · When you said 'tabs' — do you mean Conductor-style (multiple sessions tabbed inside one workspace) or browser-style (top-level tabs across everything)? → (notes only)[39m
+     [38;5;246m· What does 'I hate Conductor's worktree-only feel' mean to you specifically? → 1. forces worktrees, i like to work on my own ~/code/brizzai sometimes, 2. the UI feels kinda wierd, and it connects wierdly to claude, i like the claude TUI, not sure what elwse, (status grouping is optional there...[39m
+     [38;5;246m· When multiple sessions are visible at once, what should happen with input focus and the embedded terminal? → not sure one session at a time, or each pane with its own input[39m
+     [38;5;246m· How important is keeping the embedded view a real tmux session (vs. just spawning Claude Code as a subprocess directly)? → i tend to tmux, 1 i like the claude code tui, 2 i think it might be very hard to "proxy" claude code, but i might be wrong about it, cuz it has advaantages[39m
+
+[38;5;231m⏺[39m Sharp — that crystallizes a really interesting design principle that's actually [1mopposite[0m to Conductor's bet:
+
+  [2m▎[0m [1;3mConductor reimplements Claude's chat UI in native components (their own message bubbles, mentions, model selector, slash commands).[0;3m That's why it "connects weirdly to claude" — they're proxying it.[0m
+  [2m▎[0m
+  [2m▎[0m [1;3mYou want to preserve the actual Claude Code TUI[0;3m as the source of truth, and build a beautiful workspace shell around it.[0m
+
+  That means the desktop app is closer to "iTerm2 with elite workspace management" than "Conductor clone." The embedded view is a real terminal rendering a real tmux session running real Claude. We only build native UI for things [3moutside[0m the Claude pane: sidebar, tabs, diff panel, dev server panel, PR flow,
+  notifications.
+
+  This is actually much more achievable and more Yuval-flavored. Let me drill into the architecture next.
+
+  [1mRound 3: Architecture & stack[0m
+[38;5;246m  ⎿  [38;5;211mInvalid tool parameters[39m
+
+[38;5;246m──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m←  ☒ Stack [38;5;16m[48;5;153m ☐ Process model [39m[49m ☐ V1 scope  ☐ Docs location  ✔ Submit  →
+
+[1m[38;5;231mProcess architecture — how do the Go core and the UI talk?[0m
+
+[38;5;246m 1.[1m[38;5;153m Long-running Go daemon + [0m     [38;5;246m┌──────────────────────────────────────────────────────────────────┐[39m
+   [1m[38;5;153mUI client (Recommended)[0m        [38;5;246m│ [39mfleet daemon (Go)[38;5;246m                                                │[39m
+[38;5;246m 2.[39m Embed Go core into UI         [38;5;246m│[39m    ├─ SQLite, hooks, tmux, git, gh[38;5;246m                          [39m     [38;5;246m│[39m
+   process via FFI                [38;5;246m│[39m    ├─ chrome-host[38;5;246m                                                │[39m
+[38;5;246m 3.[39m Spawn Go subprocess per UI    [38;5;246m│[39m    └─ socket: ~/.config/fleet/daemon.sock                        [38;5;246m│[39m
+    launch                        [38;5;246m│[39m [38;5;246m                               [39m                                  [38;5;246m│[39m
+[38;5;246m 4.[39m Rewrite core in Swift/Rust    [38;5;246m│[39m Clients:                                                         [38;5;246m│[39m
+                                  [38;5;246m│[39m    • Desktop.app (Swift)  ─────┐[38;5;246m               [39m                  [38;5;246m│[39m
+                                  [38;5;246m│[39m    • fleet TUI (Go)       ─────┼──> daemon                       [38;5;246m│[39m
+                                  [38;5;246m│[39m    • fleet CLI (Go)       ─────┘[38;5;246m           [39m                      [38;5;246m│[39m
+                                  [38;5;246m└──────────────────────────────────────────────────────────────────┘[39m
+
+                                  [38;5;153mNotes:[39m [3m[38;5;246mpress n to add notes[0m
+
+[38;5;246m──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m  Chat about this
+
+[38;5;246mEnter to select · ↑/↓ to navigate · n to add notes · Tab to switch questions · Esc to cancel[39m
+
+
+

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -86,11 +86,16 @@ func (s *Session) Start(command string, env ...string) error {
 	debuglog.Logger.Info("tmux session started", "session", s.Name, "workdir", s.WorkDir)
 
 	// Batch set options.
+	// remain-on-exit keeps the dead pane around so the crash dump can read
+	// `pane_dead_status` (exit code) and `pane_dead_signal` (terminating
+	// signal). Without this we just see "tmux session gone" with no clue
+	// what killed claude.
 	optArgs := []string{
 		"set-option", "-t", s.Name, "mouse", "on", ";",
 		"set-option", "-t", s.Name, "history-limit", "10000", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
-		"set-option", "-t", s.Name, "allow-passthrough", "on",
+		"set-option", "-t", s.Name, "allow-passthrough", "on", ";",
+		"set-option", "-t", s.Name, "remain-on-exit", "on",
 	}
 	optCmd := exec.Command("tmux", optArgs...)
 	_ = optCmd.Run() // Best effort.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -160,6 +160,36 @@ func (s *Session) IsPaneDead() bool {
 	return strings.TrimSpace(string(out)) == "1"
 }
 
+// CachedPane returns the most recent pane content captured by CapturePane,
+// regardless of cache TTL. Useful for crash dumps where the live tmux session
+// may already be gone. Returns "" if nothing has been captured yet.
+func (s *Session) CachedPane() string {
+	s.cacheMu.RLock()
+	defer s.cacheMu.RUnlock()
+	return s.cacheContent
+}
+
+// PaneDeadInfo returns whether the pane is dead, plus the exit status and
+// signal that killed it (only meaningful with remain-on-exit set when the
+// pane terminated). Returns ok=false if the tmux session no longer exists.
+//
+// Exit status is the integer returned by the process (typical: 0 clean, 1
+// generic error). Signal is the POSIX number that terminated the process
+// when non-zero (137-128=9 SIGKILL → OOM/manual kill, 134-128=6 SIGABRT →
+// panic, 139-128=11 SIGSEGV).
+func (s *Session) PaneDeadInfo() (dead bool, exitStatus, exitSignal string, ok bool) {
+	out, err := exec.Command("tmux", "list-panes", "-t", s.Name+":0.0",
+		"-F", "#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}").Output()
+	if err != nil {
+		return false, "", "", false
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(out)), "|", 3)
+	if len(parts) != 3 {
+		return false, "", "", false
+	}
+	return parts[0] == "1", parts[1], parts[2], true
+}
+
 // Exists checks if the tmux session is alive.
 func (s *Session) Exists() bool {
 	// Try cache first.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -19,6 +19,11 @@ const (
 	captureCacheTTL = 400 * time.Millisecond
 	captureTimeout  = 3 * time.Second
 	sessionCacheTTL = 2 * time.Second
+	// listPanesTimeout caps tmux list-panes shell-outs from IsPaneDead /
+	// PaneDeadInfo. list-panes is much cheaper than capture-pane, so 2s is
+	// generous; the cap exists so an unresponsive tmux server can't hang the
+	// status worker (called once per session per tick).
+	listPanesTimeout = 2 * time.Second
 )
 
 // Session represents a tmux session managed by fleet.
@@ -157,7 +162,9 @@ func (s *Session) RespawnPane(command string, env ...string) error {
 
 // IsPaneDead checks if the pane's process has exited.
 func (s *Session) IsPaneDead() bool {
-	out, err := exec.Command("tmux", "list-panes", "-t", s.Name+":0.0", "-F", "#{pane_dead}").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), listPanesTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "tmux", "list-panes", "-t", s.Name+":0.0", "-F", "#{pane_dead}").Output()
 	if err != nil {
 		debuglog.Logger.Error("tmux IsPaneDead check failed", "session", s.Name, "err", err)
 		return false
@@ -183,7 +190,9 @@ func (s *Session) CachedPane() string {
 // when non-zero (137-128=9 SIGKILL → OOM/manual kill, 134-128=6 SIGABRT →
 // panic, 139-128=11 SIGSEGV).
 func (s *Session) PaneDeadInfo() (dead bool, exitStatus, exitSignal string, ok bool) {
-	out, err := exec.Command("tmux", "list-panes", "-t", s.Name+":0.0",
+	ctx, cancel := context.WithTimeout(context.Background(), listPanesTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "tmux", "list-panes", "-t", s.Name+":0.0",
 		"-F", "#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}").Output()
 	if err != nil {
 		return false, "", "", false

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2036,13 +2036,14 @@ func (h *Home) finalizeDelete(pd PendingDelete) tea.Cmd {
 
 // finalizeAllPendingDeletes synchronously drains both pendingDeletes (undo
 // window still open) and finalizingDeletes (cleanup goroutine in flight) on
-// quit. Re-running cleanup on a finalizing entry is safe — `tmux kill-session`
-// on a missing session and os.Remove on a missing file are both idempotent
-// (we already check os.IsNotExist), and provider.Destroy is best-effort.
+// quit. tmux kill and hook-file removal are idempotent and run for both lists.
+// Workspace Destroy is NOT idempotent (GitWorktreeProvider.Destroy errors when
+// the worktree is already gone, and a concurrent run would race with the
+// in-flight goroutine's `git worktree remove`), so it only runs for
+// pendingDeletes — finalizingDeletes entries already have a goroutine
+// responsible for the destroy.
 func (h *Home) finalizeAllPendingDeletes() {
-	all := append([]PendingDelete(nil), h.pendingDeletes...)
-	all = append(all, h.finalizingDeletes...)
-	for _, pd := range all {
+	finalize := func(pd PendingDelete, destroyWorkspace bool) {
 		debuglog.Logger.Info("finalizing pending delete on quit", "id", pd.Session.ID, "title", pd.Session.Title)
 		if pd.Session.IsAlive() {
 			if err := pd.Session.Kill(); err != nil {
@@ -2052,8 +2053,7 @@ func (h *Home) finalizeAllPendingDeletes() {
 		if err := os.Remove(filepath.Join(hooks.GetHooksDir(), pd.Session.ID+".json")); err != nil && !os.IsNotExist(err) {
 			debuglog.Logger.Error("failed to remove hook status file on quit", "id", pd.Session.ID, "err", err)
 		}
-		// Best-effort workspace destruction on quit.
-		if pd.DestroyWS && pd.WorkspaceName != "" {
+		if destroyWorkspace && pd.DestroyWS && pd.WorkspaceName != "" {
 			provider := workspace.ResolveProvider(pd.RepoPath)
 			if provider != nil && provider.CanDestroy() {
 				if err := provider.Destroy(pd.RepoPath, pd.WorkspaceName); err != nil {
@@ -2061,6 +2061,13 @@ func (h *Home) finalizeAllPendingDeletes() {
 				}
 			}
 		}
+	}
+
+	for _, pd := range h.pendingDeletes {
+		finalize(pd, true)
+	}
+	for _, pd := range h.finalizingDeletes {
+		finalize(pd, false)
 	}
 	h.pendingDeletes = nil
 	h.finalizingDeletes = nil

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -139,7 +139,12 @@ type Home struct {
 
 	pendingWorkspaces []*PendingWorkspace // in-flight workspace creations
 	pendingDeletes    []PendingDelete     // undo stack for deferred deletions
-	pinnedRepos       map[string]bool     // pinned repo paths (persist in SQLite)
+	// finalizingDeletes holds entries whose undo window has expired but whose
+	// background cleanup (tmux kill, hook removal, workspace destroy) is still
+	// running. Quit drains both this list and pendingDeletes so an in-flight
+	// kill isn't lost when fleet exits mid-cleanup.
+	finalizingDeletes []PendingDelete
+	pinnedRepos       map[string]bool // pinned repo paths (persist in SQLite)
 
 	repoExpanded     map[string]bool // repo path -> expanded state
 	previewCache     map[string]string
@@ -255,8 +260,10 @@ func (h *Home) Init() tea.Cmd {
 
 // Update implements tea.Model.
 func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	tok := perfwatch.MarkUpdateStart(fmt.Sprintf("%T", msg))
-	defer perfwatch.MarkUpdateEnd(tok)
+	if perfwatch.Enabled() {
+		tok := perfwatch.MarkUpdateStart(fmt.Sprintf("%T", msg))
+		defer perfwatch.MarkUpdateEnd(tok)
+	}
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		h.renderStats.RecordResize(msg.Width, msg.Height)
@@ -578,9 +585,15 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			workspaceName: msg.info.Name,
 		})
 
-	case workspaceDestroyResultMsg:
-		if msg.err != nil {
-			h.setError(fmt.Errorf("workspace destroy: %w", msg.err))
+	case deleteCleanupDoneMsg:
+		for i, pd := range h.finalizingDeletes {
+			if pd.Session.ID == msg.sessionID {
+				h.finalizingDeletes = append(h.finalizingDeletes[:i], h.finalizingDeletes[i+1:]...)
+				break
+			}
+		}
+		if msg.workspaceErr != nil {
+			h.setError(fmt.Errorf("workspace destroy: %w", msg.workspaceErr))
 		}
 		return h, nil
 
@@ -1983,6 +1996,9 @@ func (h *Home) handlePendingDeleteExpire(msg pendingDeleteExpireMsg) (tea.Model,
 
 	pd := h.pendingDeletes[idx]
 	h.pendingDeletes = append(h.pendingDeletes[:idx], h.pendingDeletes[idx+1:]...)
+	// Move into finalizingDeletes so an in-flight cleanup is visible to
+	// finalizeAllPendingDeletes if the user quits mid-finalize.
+	h.finalizingDeletes = append(h.finalizingDeletes, pd)
 
 	return h, h.finalizeDelete(pd)
 }
@@ -1991,7 +2007,8 @@ func (h *Home) handlePendingDeleteExpire(msg pendingDeleteExpireMsg) (tea.Model,
 // workspace destruction) on a background goroutine. All steps shell out or
 // hit the filesystem, so they must stay off the Bubble Tea Update loop —
 // otherwise an undo-window expiry blocks keystroke processing for the
-// duration of `tmux kill-session`.
+// duration of `tmux kill-session`. Always returns deleteCleanupDoneMsg so
+// the entry can be removed from finalizingDeletes.
 func (h *Home) finalizeDelete(pd PendingDelete) tea.Cmd {
 	return func() tea.Msg {
 		debuglog.Logger.Info("finalizing delete", "id", pd.Session.ID, "title", pd.Session.Title)
@@ -2006,20 +2023,26 @@ func (h *Home) finalizeDelete(pd PendingDelete) tea.Cmd {
 			debuglog.Logger.Error("failed to remove hook status file", "id", pd.Session.ID, "err", err)
 		}
 
+		var workspaceErr error
 		if pd.DestroyWS && pd.WorkspaceName != "" {
 			provider := workspace.ResolveProvider(pd.RepoPath)
 			if provider != nil && provider.CanDestroy() {
-				err := provider.Destroy(pd.RepoPath, pd.WorkspaceName)
-				return workspaceDestroyResultMsg{sessionID: pd.Session.ID, err: err}
+				workspaceErr = provider.Destroy(pd.RepoPath, pd.WorkspaceName)
 			}
 		}
-		return nil
+		return deleteCleanupDoneMsg{sessionID: pd.Session.ID, workspaceErr: workspaceErr}
 	}
 }
 
-// finalizeAllPendingDeletes cleans up all pending deletes synchronously (called on quit).
+// finalizeAllPendingDeletes synchronously drains both pendingDeletes (undo
+// window still open) and finalizingDeletes (cleanup goroutine in flight) on
+// quit. Re-running cleanup on a finalizing entry is safe — `tmux kill-session`
+// on a missing session and os.Remove on a missing file are both idempotent
+// (we already check os.IsNotExist), and provider.Destroy is best-effort.
 func (h *Home) finalizeAllPendingDeletes() {
-	for _, pd := range h.pendingDeletes {
+	all := append([]PendingDelete(nil), h.pendingDeletes...)
+	all = append(all, h.finalizingDeletes...)
+	for _, pd := range all {
 		debuglog.Logger.Info("finalizing pending delete on quit", "id", pd.Session.ID, "title", pd.Session.Title)
 		if pd.Session.IsAlive() {
 			if err := pd.Session.Kill(); err != nil {
@@ -2040,6 +2063,7 @@ func (h *Home) finalizeAllPendingDeletes() {
 		}
 	}
 	h.pendingDeletes = nil
+	h.finalizingDeletes = nil
 }
 
 // buildUndoFlashMessage builds the flash message for the undo prompt.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/brizzai/fleet/internal/github"
 	"github.com/brizzai/fleet/internal/hooks"
 	"github.com/brizzai/fleet/internal/naming"
+	"github.com/brizzai/fleet/internal/perfwatch"
 	"github.com/brizzai/fleet/internal/session"
 	"github.com/brizzai/fleet/internal/tmux"
 	"github.com/brizzai/fleet/internal/workspace"
@@ -254,6 +255,8 @@ func (h *Home) Init() tea.Cmd {
 
 // Update implements tea.Model.
 func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	tok := perfwatch.MarkUpdateStart(fmt.Sprintf("%T", msg))
+	defer perfwatch.MarkUpdateEnd(tok)
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		h.renderStats.RecordResize(msg.Width, msg.Height)
@@ -1984,37 +1987,34 @@ func (h *Home) handlePendingDeleteExpire(msg pendingDeleteExpireMsg) (tea.Model,
 	return h, h.finalizeDelete(pd)
 }
 
-// finalizeDelete performs the actual cleanup (tmux kill, hook removal, workspace destruction).
+// finalizeDelete schedules cleanup (tmux kill, hook removal, optional
+// workspace destruction) on a background goroutine. All steps shell out or
+// hit the filesystem, so they must stay off the Bubble Tea Update loop —
+// otherwise an undo-window expiry blocks keystroke processing for the
+// duration of `tmux kill-session`.
 func (h *Home) finalizeDelete(pd PendingDelete) tea.Cmd {
-	debuglog.Logger.Info("finalizing delete", "id", pd.Session.ID, "title", pd.Session.Title)
+	return func() tea.Msg {
+		debuglog.Logger.Info("finalizing delete", "id", pd.Session.ID, "title", pd.Session.Title)
 
-	// Kill tmux session if alive.
-	if pd.Session.IsAlive() {
-		if err := pd.Session.Kill(); err != nil {
-			debuglog.Logger.Error("failed to kill tmux session", "id", pd.Session.ID, "err", err)
-		}
-	}
-
-	// Remove hook status file.
-	if err := os.Remove(filepath.Join(hooks.GetHooksDir(), pd.Session.ID+".json")); err != nil && !os.IsNotExist(err) {
-		debuglog.Logger.Error("failed to remove hook status file", "id", pd.Session.ID, "err", err)
-	}
-
-	// If workspace destroy requested, do it async.
-	if pd.DestroyWS && pd.WorkspaceName != "" {
-		repoPath := pd.RepoPath
-		wsName := pd.WorkspaceName
-		sid := pd.Session.ID
-		provider := workspace.ResolveProvider(repoPath)
-		if provider != nil && provider.CanDestroy() {
-			return func() tea.Msg {
-				err := provider.Destroy(repoPath, wsName)
-				return workspaceDestroyResultMsg{sessionID: sid, err: err}
+		if pd.Session.IsAlive() {
+			if err := pd.Session.Kill(); err != nil {
+				debuglog.Logger.Error("failed to kill tmux session", "id", pd.Session.ID, "err", err)
 			}
 		}
-	}
 
-	return nil
+		if err := os.Remove(filepath.Join(hooks.GetHooksDir(), pd.Session.ID+".json")); err != nil && !os.IsNotExist(err) {
+			debuglog.Logger.Error("failed to remove hook status file", "id", pd.Session.ID, "err", err)
+		}
+
+		if pd.DestroyWS && pd.WorkspaceName != "" {
+			provider := workspace.ResolveProvider(pd.RepoPath)
+			if provider != nil && provider.CanDestroy() {
+				err := provider.Destroy(pd.RepoPath, pd.WorkspaceName)
+				return workspaceDestroyResultMsg{sessionID: pd.Session.ID, err: err}
+			}
+		}
+		return nil
+	}
 }
 
 // finalizeAllPendingDeletes cleans up all pending deletes synchronously (called on quit).

--- a/internal/ui/workspace_create.go
+++ b/internal/ui/workspace_create.go
@@ -40,9 +40,13 @@ type (
 		pendingID string
 		repoPath  string
 	}
-	workspaceDestroyResultMsg struct {
-		sessionID string
-		err       error
+	// deleteCleanupDoneMsg fires when finalizeDelete's background cleanup
+	// (tmux kill, hook removal, optional workspace destroy) completes. The
+	// Update handler uses sessionID to drop the entry from finalizingDeletes;
+	// workspaceErr surfaces destroy failures to the user.
+	deleteCleanupDoneMsg struct {
+		sessionID    string
+		workspaceErr error
 	}
 )
 


### PR DESCRIPTION
## Summary

- Adds `internal/perfwatch` (gated on `FLEET_DEBUG`) that instruments the Bubble Tea `Update()` loop, dumps goroutine stacks + block/mutex profiles when it stalls >500ms, and writes a 5s heartbeat to `debug.log` (goroutine count, real CPU%, heap, slow-update counter). SIGUSR1 forces a manual snapshot for attach-lag (Bubble Tea is suspended during `tea.Exec`, so the watchdog can't fire then).
- Fixes a stall this immediately caught: `finalizeDelete` ran `Session.Kill` (tmux exec) + hook-file removal synchronously on the Update goroutine when the 5s undo-delete window expired. Scrolling during expiry froze the list for ~500ms. Cleanup now runs in a `tea.Cmd`.
- Adds a `/debug-perf` skill that walks the dump format and points at common fleet blocking patterns.

## How to use

```bash
FLEET_DEBUG=1 ./build/fleet
```

Stalls auto-dump to `~/.config/fleet/stalls/<ts>_update_stall_<msgType>_<ms>ms.txt`. For lag *inside* an attached session, force a snapshot:

```bash
kill -USR1 $(pgrep -f 'fleet$')
```

Then run `/debug-perf` for analysis.

## Test plan
- [ ] `FLEET_DEBUG=1 ./build/fleet` — verify `perfwatch: enabled` logs in `~/.config/fleet/debug.log`
- [ ] Confirm 5s heartbeats appear with sane `cpu_pct` (multi-core, e.g. 20-30% idle)
- [ ] Delete a session, scroll j/k continuously through the 5s undo window — list should not stutter when `pendingDeleteExpireMsg` fires
- [ ] Without `FLEET_DEBUG`: no stalls dir created, no heartbeats, normal behavior
- [ ] `kill -USR1 <pid>` writes `*_manual_sigusr1.txt` snapshot
- [ ] Existing tests: `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TUI stalling ~500ms when undo-delete expired.
  * Prevented status flicker in AskUserQuestion.
  * Fixed stale hook state showing brief error after restart.

* **Improvements**
  * Built-in performance instrumentation: heartbeats, stall detection, storm snapshots, and crash-dump generation on session death.
  * Deferred-delete cleanup no longer blocks the UI.
  * Add env var to disable auto-update per launch.

* **Documentation**
  * New troubleshooting guide for interpreting performance dumps and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->