### PR TITLE
feat(pr-checks): add per-repo CI check ignore list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Workspace creation is non-blocking: dialog closes immediately, phantom "Creating..." entry with spinner appears in sidebar, user can keep navigating
 - Worktree creation copies `.claude/settings.local.json` from source repo (configurable via `copy_claude_settings`, default true)
 - `.fleet.json` / `.fleet.local.json` in repo root (legacy `.bc.json` / `.bc.local.json` still read): `{"workspace": {"list": "cmd", "create": "cmd {{name}} {{branch}}", "destroy": "cmd {{name}}"}}`
+- `.fleet.json` / `.fleet.local.json` may also set `{"pr_checks": {"ignore": ["glob", ...]}}` to drop matching CI checks from the PR-badge rollup (path.Match globs; lists from both files merge additively; opt-in, empty by default)
 - Claude session resume: captures Claude session_id from hooks, uses `claude --resume <id>` on restart
 - Editor: config.editor > $EDITOR > "code" (VS Code)
 - Themes: tokyo-night (default), catppuccin-mocha, rose-pine, nord, gruvbox — configurable via settings (S key)

--- a/changelog/unreleased/pr-checks-ignore.md
+++ b/changelog/unreleased/pr-checks-ignore.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+Per-repo `pr_checks.ignore` config in `.fleet.json` / `.fleet.local.json` (path.Match globs) to drop noisy CI checks like gitstream's `minimum-review/default_reviewers` from the PR-badge rollup, so a single non-actionable failure no longer turns the whole badge red.

--- a/internal/git/repo_info.go
+++ b/internal/git/repo_info.go
@@ -30,8 +30,11 @@ func RefreshGitInfo(repoPath string) *RepoInfo {
 
 // RefreshPRInfo fetches PR info via gh CLI and updates the RepoInfo.
 // Slower operation (~200ms, network call).
-func RefreshPRInfo(info *RepoInfo, repoPath string) {
-	pr, err := github.GetPRForBranch(repoPath, info.Branch)
+// ignorePatterns is the per-repo CI-check ignore list (path.Match globs);
+// caller is responsible for loading it (typically via workspace.IgnorePatterns)
+// to keep this package free of a workspace-package dependency.
+func RefreshPRInfo(info *RepoInfo, repoPath string, ignorePatterns []string) {
+	pr, err := github.GetPRForBranch(repoPath, info.Branch, ignorePatterns)
 	if err != nil {
 		debuglog.Logger.Debug("RefreshPRInfo failed", "path", repoPath, "branch", info.Branch, "error", err)
 	}

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path"
 	"strings"
 
 	"github.com/brizzai/fleet/internal/debuglog"
@@ -45,7 +46,10 @@ type statusCheckEntry struct {
 }
 
 // GetPRForBranch returns the PR associated with the current branch, or nil if none.
-func GetPRForBranch(repoPath, branch string) (*PR, error) {
+// ignorePatterns are path.Match globs applied to check names; matching checks are
+// dropped from the rollup before CI status is derived (lets repos suppress noisy
+// gates without affecting real check failures).
+func GetPRForBranch(repoPath, branch string, ignorePatterns []string) (*PR, error) {
 	if branch == "" || branch == "HEAD" {
 		return nil, nil
 	}
@@ -72,7 +76,7 @@ func GetPRForBranch(repoPath, branch string) (*PR, error) {
 		URL:               resp.URL,
 		State:             resp.State,
 		ReviewDecision:    resp.ReviewDecision,
-		CIStatus:          deriveCIStatus(resp.StatusCheckRollup),
+		CIStatus:          deriveCIStatus(resp.StatusCheckRollup, ignorePatterns),
 		UnresolvedThreads: getUnresolvedThreadCount(repoPath, resp.Number, resp.URL),
 		HasConflicts:      resp.Mergeable == "CONFLICTING",
 	}
@@ -137,7 +141,8 @@ func getUnresolvedThreadCount(repoPath string, prNumber int, prURL string) int {
 }
 
 // deriveCIStatus determines overall CI status from status check rollup.
-func deriveCIStatus(checks []statusCheckEntry) string {
+// Checks whose name matches any ignorePatterns glob are dropped before rollup.
+func deriveCIStatus(checks []statusCheckEntry, ignorePatterns []string) string {
 	if len(checks) == 0 {
 		return ""
 	}
@@ -148,6 +153,9 @@ func deriveCIStatus(checks []statusCheckEntry) string {
 	for _, check := range checks {
 		// Skip ghost entries with no name (null checks from GitHub API).
 		if check.Name == "" {
+			continue
+		}
+		if matchesAnyPattern(check.Name, ignorePatterns) {
 			continue
 		}
 		conclusion := strings.ToUpper(check.Conclusion)
@@ -167,4 +175,22 @@ func deriveCIStatus(checks []statusCheckEntry) string {
 		return "PENDING"
 	}
 	return "SUCCESS"
+}
+
+// matchesAnyPattern reports whether name matches any of the path.Match globs in
+// patterns. Bad globs are warn-logged and skipped — never fail-closed, so a
+// typo in one pattern doesn't poison the whole ignore list.
+func matchesAnyPattern(name string, patterns []string) bool {
+	for _, p := range patterns {
+		matched, err := path.Match(p, name)
+		if err != nil {
+			debuglog.Logger.Warn("github: bad ignore pattern; skipping",
+				"pattern", p, "err", err)
+			continue
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -178,17 +178,12 @@ func deriveCIStatus(checks []statusCheckEntry, ignorePatterns []string) string {
 }
 
 // matchesAnyPattern reports whether name matches any of the path.Match globs in
-// patterns. Bad globs are warn-logged and skipped — never fail-closed, so a
-// typo in one pattern doesn't poison the whole ignore list.
+// patterns. Bad globs are silently skipped here as defense-in-depth — they're
+// validated and warn-logged once at config load (workspace.validateGlobs), so
+// nothing malformed should reach this hot path under normal flow.
 func matchesAnyPattern(name string, patterns []string) bool {
 	for _, p := range patterns {
-		matched, err := path.Match(p, name)
-		if err != nil {
-			debuglog.Logger.Warn("github: bad ignore pattern; skipping",
-				"pattern", p, "err", err)
-			continue
-		}
-		if matched {
+		if matched, err := path.Match(p, name); err == nil && matched {
 			return true
 		}
 	}

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -6,15 +6,17 @@ func TestDeriveCIStatus(t *testing.T) {
 	tests := []struct {
 		name   string
 		checks []statusCheckEntry
+		ignore []string
 		want   string
 	}{
-		{"empty", nil, ""},
+		{"empty", nil, nil, ""},
 		{
 			"all success",
 			[]statusCheckEntry{
 				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
 				{Name: "test", Status: "COMPLETED", Conclusion: "SUCCESS"},
 			},
+			nil,
 			"SUCCESS",
 		},
 		{
@@ -23,6 +25,7 @@ func TestDeriveCIStatus(t *testing.T) {
 				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
 				{Name: "test", Status: "COMPLETED", Conclusion: "FAILURE"},
 			},
+			nil,
 			"FAILURE",
 		},
 		{
@@ -31,6 +34,7 @@ func TestDeriveCIStatus(t *testing.T) {
 				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
 				{Name: "test", Status: "IN_PROGRESS", Conclusion: ""},
 			},
+			nil,
 			"PENDING",
 		},
 		{
@@ -39,6 +43,7 @@ func TestDeriveCIStatus(t *testing.T) {
 				{Name: "build", Status: "IN_PROGRESS", Conclusion: ""},
 				{Name: "test", Status: "COMPLETED", Conclusion: "FAILURE"},
 			},
+			nil,
 			"FAILURE",
 		},
 		{
@@ -47,6 +52,7 @@ func TestDeriveCIStatus(t *testing.T) {
 				{Name: "", Status: "", Conclusion: ""},
 				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
 			},
+			nil,
 			"SUCCESS",
 		},
 		{
@@ -54,6 +60,7 @@ func TestDeriveCIStatus(t *testing.T) {
 			[]statusCheckEntry{
 				{Name: "", Status: "", Conclusion: ""},
 			},
+			nil,
 			"SUCCESS", // all named checks pass (none exist)
 		},
 		{
@@ -61,6 +68,7 @@ func TestDeriveCIStatus(t *testing.T) {
 			[]statusCheckEntry{
 				{Name: "deploy", Status: "COMPLETED", Conclusion: "ERROR"},
 			},
+			nil,
 			"FAILURE",
 		},
 		{
@@ -68,6 +76,7 @@ func TestDeriveCIStatus(t *testing.T) {
 			[]statusCheckEntry{
 				{Name: "e2e", Status: "COMPLETED", Conclusion: "TIMED_OUT"},
 			},
+			nil,
 			"FAILURE",
 		},
 		{
@@ -75,13 +84,68 @@ func TestDeriveCIStatus(t *testing.T) {
 			[]statusCheckEntry{
 				{Name: "build", Status: "QUEUED", Conclusion: ""},
 			},
+			nil,
 			"PENDING",
+		},
+		{
+			"ignored failure -> SUCCESS",
+			[]statusCheckEntry{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "minimum-review/default_reviewers", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			[]string{"minimum-review/default_reviewers"},
+			"SUCCESS",
+		},
+		{
+			"ignored + real failure -> FAILURE",
+			[]statusCheckEntry{
+				{Name: "build", Status: "COMPLETED", Conclusion: "FAILURE"},
+				{Name: "minimum-review/default_reviewers", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			[]string{"minimum-review/default_reviewers"},
+			"FAILURE",
+		},
+		{
+			"glob wildcard matches",
+			[]statusCheckEntry{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "minimum-review/default_reviewers", Status: "COMPLETED", Conclusion: "FAILURE"},
+				{Name: "minimum-review/codeowners", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			[]string{"minimum-review/*"},
+			"SUCCESS",
+		},
+		{
+			"non-matching pattern leaves failure",
+			[]statusCheckEntry{
+				{Name: "test", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			[]string{"unrelated/*"},
+			"FAILURE",
+		},
+		{
+			"bad glob is skipped, others still apply",
+			[]statusCheckEntry{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "noisy", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			[]string{"[", "noisy"},
+			"SUCCESS",
+		},
+		{
+			"ignored pending check ignored",
+			[]statusCheckEntry{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "noisy", Status: "IN_PROGRESS", Conclusion: ""},
+			},
+			[]string{"noisy"},
+			"SUCCESS",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := deriveCIStatus(tt.checks)
+			got := deriveCIStatus(tt.checks, tt.ignore)
 			if got != tt.want {
 				t.Errorf("deriveCIStatus() = %q, want %q", got, tt.want)
 			}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2343,7 +2343,7 @@ drainPriority:
 		h.workerMu.Unlock()
 
 		if h.ghAvailable && (info.LastPRRefresh.IsZero() || time.Since(info.LastPRRefresh) > 60*time.Second) {
-			git.RefreshPRInfo(info, repo)
+			git.RefreshPRInfo(info, repo, workspace.IgnorePatterns(repo))
 		}
 
 		h.workerMu.Lock()

--- a/internal/workspace/repo_config.go
+++ b/internal/workspace/repo_config.go
@@ -10,7 +10,8 @@ import (
 
 // RepoWorkspaceConfig is the structure of .fleet.json files.
 type RepoWorkspaceConfig struct {
-	Workspace ShellConfig `json:"workspace"`
+	Workspace ShellConfig    `json:"workspace"`
+	PRChecks  PRChecksConfig `json:"pr_checks"`
 }
 
 // ShellConfig holds shell command configuration for workspace operations.
@@ -20,6 +21,61 @@ type ShellConfig struct {
 	Destroy string `json:"destroy,omitempty"`
 }
 
+// PRChecksConfig holds repo-level controls over how PR check rollup is computed.
+type PRChecksConfig struct {
+	// Ignore is a list of path.Match globs against check names. Matching checks
+	// are dropped from the PR-badge rollup so a single noisy check (e.g. a
+	// gitstream "minimum reviewers" gate) doesn't turn the whole badge red.
+	Ignore []string `json:"ignore,omitempty"`
+}
+
+// loadMergedRepoConfig resolves .fleet.json / .fleet.local.json (with legacy
+// .bc.json / .bc.local.json fallback) and returns the merged config. Workspace
+// fields are merged field-by-field (local overrides base); PRChecks.Ignore is
+// merged additively (concat + dedupe) so a checked-in shared list and a
+// personal local list can coexist.
+func loadMergedRepoConfig(repoPath string) RepoWorkspaceConfig {
+	base := preferredConfig(repoPath, ".fleet.json", ".bc.json")
+	local := preferredConfig(repoPath, ".fleet.local.json", ".bc.local.json")
+
+	merged := base
+	if local.Workspace.List != "" {
+		merged.Workspace.List = local.Workspace.List
+	}
+	if local.Workspace.Create != "" {
+		merged.Workspace.Create = local.Workspace.Create
+	}
+	if local.Workspace.Destroy != "" {
+		merged.Workspace.Destroy = local.Workspace.Destroy
+	}
+
+	merged.PRChecks.Ignore = dedupeStrings(append(base.PRChecks.Ignore, local.PRChecks.Ignore...))
+	return merged
+}
+
+// dedupeStrings returns the input with duplicates removed, preserving order.
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// IgnorePatterns returns the merged pr_checks.ignore list for a repo, or nil
+// if no config sets it. Patterns are path.Match globs against check names.
+func IgnorePatterns(repoPath string) []string {
+	return loadMergedRepoConfig(repoPath).PRChecks.Ignore
+}
+
 // ResolveProvider loads workspace config from repoPath. Preference is by file
 // presence, not contents: if .fleet.json exists it wins (even when empty —
 // that's how a user disables a stale legacy .bc.json without deleting it);
@@ -27,20 +83,7 @@ type ShellConfig struct {
 // .bc.local.json. Local overrides base field-by-field. Returns ShellProvider
 // if any command ends up set, otherwise GitWorktreeProvider.
 func ResolveProvider(repoPath string) Provider {
-	base := preferredConfig(repoPath, ".fleet.json", ".bc.json")
-	local := preferredConfig(repoPath, ".fleet.local.json", ".bc.local.json")
-
-	// Merge: local overrides base field-by-field.
-	merged := base
-	if local.List != "" {
-		merged.List = local.List
-	}
-	if local.Create != "" {
-		merged.Create = local.Create
-	}
-	if local.Destroy != "" {
-		merged.Destroy = local.Destroy
-	}
+	merged := loadMergedRepoConfig(repoPath).Workspace
 
 	// If any shell command is set, use ShellProvider.
 	if merged.List != "" || merged.Create != "" || merged.Destroy != "" {
@@ -59,7 +102,7 @@ func ResolveProvider(repoPath string) Provider {
 // repoPath, otherwise the config from legacyName. File presence is the signal —
 // an empty preferred file still suppresses the legacy one (intended way to
 // "disable" a stale legacy config without deleting it).
-func preferredConfig(repoPath, preferredName, legacyName string) ShellConfig {
+func preferredConfig(repoPath, preferredName, legacyName string) RepoWorkspaceConfig {
 	if cfg, ok := loadRepoConfig(filepath.Join(repoPath, preferredName)); ok {
 		return cfg
 	}
@@ -73,24 +116,24 @@ func preferredConfig(repoPath, preferredName, legacyName string) ShellConfig {
 // parse is logged and treated as "exists with empty config" (true) — the user's
 // intent to override is honored even if their JSON is wrong, and the warning
 // surfaces the parse failure in debug.log.
-func loadRepoConfig(path string) (ShellConfig, bool) {
+func loadRepoConfig(path string) (RepoWorkspaceConfig, bool) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return ShellConfig{}, false
+			return RepoWorkspaceConfig{}, false
 		}
 		// File exists but is unreadable (e.g. permission denied). Treat as
 		// "exists with empty config" so the documented presence-wins behavior
 		// holds — falling through to .bc.json would silently break it.
 		debuglog.Logger.Warn("workspace: failed to read repo config; treating as empty override",
 			"path", path, "err", err)
-		return ShellConfig{}, true
+		return RepoWorkspaceConfig{}, true
 	}
 	var cfg RepoWorkspaceConfig
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		debuglog.Logger.Warn("workspace: failed to parse repo config; treating as empty override",
 			"path", path, "err", err)
-		return ShellConfig{}, true
+		return RepoWorkspaceConfig{}, true
 	}
-	return cfg.Workspace, true
+	return cfg, true
 }

--- a/internal/workspace/repo_config.go
+++ b/internal/workspace/repo_config.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"encoding/json"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/brizzai/fleet/internal/debuglog"
@@ -116,8 +117,8 @@ func preferredConfig(repoPath, preferredName, legacyName string) RepoWorkspaceCo
 // parse is logged and treated as "exists with empty config" (true) — the user's
 // intent to override is honored even if their JSON is wrong, and the warning
 // surfaces the parse failure in debug.log.
-func loadRepoConfig(path string) (RepoWorkspaceConfig, bool) {
-	data, err := os.ReadFile(path)
+func loadRepoConfig(configPath string) (RepoWorkspaceConfig, bool) {
+	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return RepoWorkspaceConfig{}, false
@@ -126,14 +127,35 @@ func loadRepoConfig(path string) (RepoWorkspaceConfig, bool) {
 		// "exists with empty config" so the documented presence-wins behavior
 		// holds — falling through to .bc.json would silently break it.
 		debuglog.Logger.Warn("workspace: failed to read repo config; treating as empty override",
-			"path", path, "err", err)
+			"path", configPath, "err", err)
 		return RepoWorkspaceConfig{}, true
 	}
 	var cfg RepoWorkspaceConfig
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		debuglog.Logger.Warn("workspace: failed to parse repo config; treating as empty override",
-			"path", path, "err", err)
+			"path", configPath, "err", err)
 		return RepoWorkspaceConfig{}, true
 	}
+	cfg.PRChecks.Ignore = validateGlobs(cfg.PRChecks.Ignore, configPath)
 	return cfg, true
+}
+
+// validateGlobs returns the subset of patterns that path.Match accepts as
+// well-formed. Bad patterns are warn-logged once (here, at load time) with the
+// originating config path; this keeps the runtime matcher in internal/github
+// free of repeated log spam every refresh cycle.
+func validateGlobs(patterns []string, configPath string) []string {
+	if len(patterns) == 0 {
+		return patterns
+	}
+	out := patterns[:0:len(patterns)]
+	for _, p := range patterns {
+		if _, err := path.Match(p, ""); err != nil {
+			debuglog.Logger.Warn("workspace: dropping invalid pr_checks.ignore glob",
+				"path", configPath, "pattern", p, "err", err)
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }

--- a/internal/workspace/repo_config_test.go
+++ b/internal/workspace/repo_config_test.go
@@ -132,6 +132,16 @@ func TestIgnorePatterns(t *testing.T) {
 		}
 	})
 
+	t.Run("invalid globs dropped at load time", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, repo, ".fleet.json", `{"pr_checks":{"ignore":["[","good","[bad"]}}`)
+		got := IgnorePatterns(repo)
+		want := []string{"good"}
+		if !equalStrings(got, want) {
+			t.Errorf("got %v, want %v (invalid globs should be filtered)", got, want)
+		}
+	})
+
 	t.Run("workspace and pr_checks coexist", func(t *testing.T) {
 		repo := t.TempDir()
 		writeFile(t, repo, ".fleet.json", `{"workspace":{"create":"mk"},"pr_checks":{"ignore":["x"]}}`)

--- a/internal/workspace/repo_config_test.go
+++ b/internal/workspace/repo_config_test.go
@@ -93,6 +93,73 @@ func TestResolveProvider(t *testing.T) {
 	})
 }
 
+func TestIgnorePatterns(t *testing.T) {
+	t.Run("no config returns nil", func(t *testing.T) {
+		repo := t.TempDir()
+		if got := IgnorePatterns(repo); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("reads from .fleet.json", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, repo, ".fleet.json", `{"pr_checks":{"ignore":["minimum-review/*","gitStream.cm"]}}`)
+		got := IgnorePatterns(repo)
+		want := []string{"minimum-review/*", "gitStream.cm"}
+		if !equalStrings(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("base + local merge additively with dedupe", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, repo, ".fleet.json", `{"pr_checks":{"ignore":["a","b"]}}`)
+		writeFile(t, repo, ".fleet.local.json", `{"pr_checks":{"ignore":["b","c"]}}`)
+		got := IgnorePatterns(repo)
+		want := []string{"a", "b", "c"}
+		if !equalStrings(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("legacy .bc.json honored", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, repo, ".bc.json", `{"pr_checks":{"ignore":["legacy/*"]}}`)
+		got := IgnorePatterns(repo)
+		want := []string{"legacy/*"}
+		if !equalStrings(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("workspace and pr_checks coexist", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, repo, ".fleet.json", `{"workspace":{"create":"mk"},"pr_checks":{"ignore":["x"]}}`)
+		if got := IgnorePatterns(repo); !equalStrings(got, []string{"x"}) {
+			t.Errorf("ignore: got %v, want [x]", got)
+		}
+		sp, ok := ResolveProvider(repo).(*ShellProvider)
+		if !ok {
+			t.Fatalf("got %T, want *ShellProvider", sp)
+		}
+		if sp.CreateCmd != "mk" {
+			t.Errorf("CreateCmd: got %q, want mk", sp.CreateCmd)
+		}
+	})
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func writeFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- New per-repo opt-in: `pr_checks.ignore` in `.fleet.json` / `.fleet.local.json` (and legacy `.bc.json` / `.bc.local.json`). Each entry is a `path.Match` glob; matching CI check names are dropped from the rollup before fleet derives the PR's badge color.
- Lists from base + local files merge **additively** (concat + dedupe), so a checked-in shared list and a personal local list can coexist.
- Bad globs are warn-logged and skipped — never fail-closed.

### Why
A PR can be functionally green (build, tests, lint all passing) yet show a red badge in fleet because of a single noisy gate like gitstream's `minimum-review/default_reviewers`. That makes the sidebar's PR-badge signal unreliable for "actually broken." This lets users mute checks they know are non-actionable for their workflow without affecting real failures.

### How it lands in the code
- `internal/workspace/repo_config.go` — extends `RepoWorkspaceConfig` with `PRChecks { Ignore []string }`. New `IgnorePatterns(repoPath)` exported. `loadRepoConfig`/`preferredConfig` now return the full struct.
- `internal/github/pr.go` — `deriveCIStatus` and `GetPRForBranch` take `ignorePatterns []string`. Filters via `path.Match` before the existing rollup logic.
- `internal/git/repo_info.go` — `RefreshPRInfo` threads patterns through; deliberately no `internal/workspace` dependency added in `internal/git`.
- `internal/ui/app.go` — worker call site loads patterns via `workspace.IgnorePatterns(repo)`.
- `CLAUDE.md` — one-line doc.

### Example
```json
{
  "pr_checks": {
    "ignore": ["minimum-review/*", "gitStream.cm"]
  }
}
```

### Defaults
Empty list. Strictly opt-in. No surprise muting.

## Test plan
- [x] `make build` clean
- [x] `make test` — new cases in `internal/github/pr_test.go` (ignored failure → SUCCESS; ignored + real failure → FAILURE; glob match; bad-glob skipped; ignored pending) and `internal/workspace/repo_config_test.go` (`TestIgnorePatterns`: nil default, `.fleet.json`, additive merge, legacy `.bc.json`, coexistence with `workspace`)
- [x] `make lint` — 0 issues
- [ ] End-to-end: drop `.fleet.local.json` with `{"pr_checks":{"ignore":["minimum-review/*","gitStream.cm"]}}` into a repo whose only failing check is gitstream's reviewer gate → badge turns green within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)