### PR TITLE
feat(ui): add PgUp/PgDn navigation in sidebar

### DIFF
--- a/changelog/unreleased/sidebar-page-nav.md
+++ b/changelog/unreleased/sidebar-page-nav.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+PgUp / PgDn navigate the sidebar by a full page; cursor stays in view at list edges

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2684,6 +2684,26 @@ func (h *Home) rebuildSessionMap() {
 	}
 }
 
+// sidebarListHeight returns the height of the sidebar panel in the current
+// layout — i.e. the value View() passes to RenderSidebar as `height`, before
+// chrome rows (title + underline) and scroll indicators are subtracted.
+// Stacked mode gives the sidebar ~55% of the content area; single/dual give
+// it the full content area. Mirrors the arithmetic in View() (app.go:794+).
+func (h *Home) sidebarListHeight() int {
+	contentHeight := h.height - 2 - helpBarHeight
+	if contentHeight < 1 {
+		contentHeight = 1
+	}
+	if h.layoutMode() == "stacked" {
+		sh := (contentHeight * 55) / 100
+		if sh < 3 {
+			sh = 3
+		}
+		return sh
+	}
+	return contentHeight
+}
+
 // sidebarMinVisibleRows is the conservative lower bound on visible session rows
 // in the sidebar — it assumes both scroll indicators are drawn, so the value
 // holds even mid-scroll. Used by syncViewport to anchor the cursor before
@@ -2691,7 +2711,7 @@ func (h *Home) rebuildSessionMap() {
 // Subtracts panel chrome (title + underline = 2) and reserves 2 rows for the
 // indicators RenderSidebar may add at top/bottom.
 func (h *Home) sidebarMinVisibleRows() int {
-	v := h.height - 2 - helpBarHeight - 4
+	v := h.sidebarListHeight() - 4
 	if v < 1 {
 		v = 1
 	}
@@ -2703,7 +2723,7 @@ func (h *Home) sidebarMinVisibleRows() int {
 // page-jump moves a full panel; syncViewport handles anchoring if the target
 // would otherwise sit on an indicator row.
 func (h *Home) sidebarPanelRows() int {
-	v := h.height - 2 - helpBarHeight - 2
+	v := h.sidebarListHeight() - 2
 	if v < 1 {
 		v = 1
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1020,7 +1020,7 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.syncViewport()
 		return h, h.fetchPreviewForSelected()
 	case "pgdown":
-		target := h.cursor + h.sidebarVisibleRows()
+		target := h.cursor + h.sidebarPanelRows()
 		if target > len(h.flatItems)-1 {
 			target = len(h.flatItems) - 1
 		}
@@ -1031,7 +1031,7 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.syncViewport()
 		return h, h.fetchPreviewForSelected()
 	case "pgup":
-		target := h.cursor - h.sidebarVisibleRows()
+		target := h.cursor - h.sidebarPanelRows()
 		if target < 0 {
 			target = 0
 		}
@@ -2684,12 +2684,26 @@ func (h *Home) rebuildSessionMap() {
 	}
 }
 
-// sidebarVisibleRows returns the number of session rows visible in the sidebar.
-// Subtracts the panel chrome (title + underline = 2) and reserves 2 rows for
-// the scroll indicators RenderSidebar (sidebar.go) may add at top/bottom — so
-// the cursor stays in view even at the list edges.
-func (h *Home) sidebarVisibleRows() int {
+// sidebarMinVisibleRows is the conservative lower bound on visible session rows
+// in the sidebar — it assumes both scroll indicators are drawn, so the value
+// holds even mid-scroll. Used by syncViewport to anchor the cursor before
+// RenderSidebar (sidebar.go) decides which indicators to draw.
+// Subtracts panel chrome (title + underline = 2) and reserves 2 rows for the
+// indicators RenderSidebar may add at top/bottom.
+func (h *Home) sidebarMinVisibleRows() int {
 	v := h.height - 2 - helpBarHeight - 4
+	if v < 1 {
+		v = 1
+	}
+	return v
+}
+
+// sidebarPanelRows is the actual sidebar panel height in rows, before any
+// scroll indicators are drawn. Used as the PgUp/PgDn page step so a single
+// page-jump moves a full panel; syncViewport handles anchoring if the target
+// would otherwise sit on an indicator row.
+func (h *Home) sidebarPanelRows() int {
+	v := h.height - 2 - helpBarHeight - 2
 	if v < 1 {
 		v = 1
 	}
@@ -2707,7 +2721,7 @@ func (h *Home) syncViewport() {
 	if h.cursor >= len(h.flatItems) {
 		h.cursor = len(h.flatItems) - 1
 	}
-	contentHeight := h.sidebarVisibleRows()
+	contentHeight := h.sidebarMinVisibleRows()
 	prevOffset := h.viewOffset
 	// Scroll to keep cursor visible.
 	if h.cursor < h.viewOffset {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1019,6 +1019,25 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.cursor = NextSelectableItem(h.flatItems, h.cursor, -1)
 		h.syncViewport()
 		return h, h.fetchPreviewForSelected()
+	case "pgdown":
+		target := h.cursor + h.sidebarVisibleRows()
+		if target > len(h.flatItems)-1 {
+			target = len(h.flatItems) - 1
+		}
+		if target < 0 {
+			target = 0
+		}
+		h.cursor = target
+		h.syncViewport()
+		return h, h.fetchPreviewForSelected()
+	case "pgup":
+		target := h.cursor - h.sidebarVisibleRows()
+		if target < 0 {
+			target = 0
+		}
+		h.cursor = target
+		h.syncViewport()
+		return h, h.fetchPreviewForSelected()
 	case "enter":
 		// Toggle repo group or attach session.
 		if h.cursor >= 0 && h.cursor < len(h.flatItems) && h.flatItems[h.cursor].IsRepoHeader {
@@ -2665,6 +2684,18 @@ func (h *Home) rebuildSessionMap() {
 	}
 }
 
+// sidebarVisibleRows returns the number of session rows visible in the sidebar.
+// Subtracts the panel chrome (title + underline = 2) and reserves 2 rows for
+// the scroll indicators RenderSidebar (sidebar.go) may add at top/bottom — so
+// the cursor stays in view even at the list edges.
+func (h *Home) sidebarVisibleRows() int {
+	v := h.height - 2 - helpBarHeight - 4
+	if v < 1 {
+		v = 1
+	}
+	return v
+}
+
 func (h *Home) syncViewport() {
 	if len(h.flatItems) == 0 {
 		return
@@ -2676,11 +2707,7 @@ func (h *Home) syncViewport() {
 	if h.cursor >= len(h.flatItems) {
 		h.cursor = len(h.flatItems) - 1
 	}
-	// Calculate visible height for sidebar (subtract title + underline).
-	contentHeight := h.height - 2 - helpBarHeight - 2
-	if contentHeight < 1 {
-		contentHeight = 1
-	}
+	contentHeight := h.sidebarVisibleRows()
 	prevOffset := h.viewOffset
 	// Scroll to keep cursor visible.
 	if h.cursor < h.viewOffset {

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -17,6 +17,8 @@ var allKeyBindings = []KeyBinding{
 	// Navigation.
 	{Key: "j / ↓", BarKey: "↑↓", BarDesc: "Nav", Desc: "Move down", Section: "nav"},
 	{Key: "k / ↑", Desc: "Move up", Section: "nav"},
+	{Key: "PgDn", Desc: "Page down", Section: "nav"},
+	{Key: "PgUp", Desc: "Page up", Section: "nav"},
 
 	// Session actions.
 	{Key: "Enter", BarKey: "⏎", BarDesc: "Open", Desc: "Attach / toggle group", Section: "session"},


### PR DESCRIPTION
## Summary
- Adds `PgUp` / `PgDn` to jump the sidebar cursor by a full page; clamps at list bounds (no wrap), matching `j`/`k` semantics.
- Fixes a viewport bug where the highlighted row could fall outside the rendered window at the list edges — `syncViewport` was ignoring the rows reserved for top/bottom scroll indicators in `RenderSidebar`. Extracted `sidebarVisibleRows()` so PgUp/PgDn page size and viewport math share the same height.
- Registers both keys in `allKeyBindings` so they show up in the `?` help overlay (no bottom-bar slot, to keep the bar uncluttered).

## Test plan
- [ ] Build and run with enough sessions to overflow the sidebar.
- [ ] Press `PgDn` repeatedly: cursor jumps by ~one page, stops at the last item and remains highlighted.
- [ ] Press `PgUp` repeatedly: cursor jumps back, stops at the first item.
- [ ] Hold `j` past the bottom: highlighted row stays inside the visible window (was previously slipping off-screen by 1 row).
- [ ] Open `?` overlay: `PgUp` / `PgDn` listed in Navigation.
- [ ] Resize terminal small enough that visible rows clamp to 1: PgDn moves by 1 with no panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PgUp/PgDn now move the sidebar by a full page, clamping selection to valid items and keeping the cursor visible; preview refreshes for the newly selected item.
  * Sidebar sizing logic improved to compute stable visible rows so page navigation behaves consistently across window sizes.

* **Documentation**
  * Help overlay updated with Page Up / Page Down entries; unreleased changelog added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->