### PR TITLE
fix(ui): forward modified keys (Alt / Ctrl) in focus-preview mode

### DIFF
--- a/changelog/unreleased/fix-focus-mode-modified-keys.md
+++ b/changelog/unreleased/fix-focus-mode-modified-keys.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Word-wise line editing in the focus-preview pane: Option/Alt+Backspace, Alt+B/F/D word motions, Alt+arrows, Ctrl+arrows and Shift+Tab are now forwarded to the focused session with their modifier intact instead of degrading to an unmodified keypress (e.g. Option+Backspace had been deleting one character instead of a word, and Ctrl+Left was being typed as the literal text `ctrl+left`).

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1732,6 +1732,148 @@ func (h *Home) focusTick() tea.Cmd {
 	})
 }
 
+// focusKeySend is one tmux send-keys invocation produced for a focused-pane
+// keypress. When literal is true the value is sent verbatim (`send-keys -l`);
+// otherwise it is a tmux key name, optionally with an "M-"/"C-" modifier
+// prefix (`send-keys`).
+type focusKeySend struct {
+	literal bool
+	val     string
+}
+
+// allASCIILetters reports whether rs is non-empty and every rune is an ASCII
+// letter — i.e. safe to embed in a tmux "M-<rune>" key name without tripping
+// the control-mode command parser.
+func allASCIILetters(rs []rune) bool {
+	if len(rs) == 0 {
+		return false
+	}
+	for _, r := range rs {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')) {
+			return false
+		}
+	}
+	return true
+}
+
+// translateFocusKey maps a bubbletea key event onto the tmux send-keys
+// invocation(s) needed to reproduce it inside the focused session. It returns
+// (nil, true) when the key should instead exit focus mode (Esc).
+//
+// Modified keys must keep their modifier: Alt/Meta keys go through with the
+// tmux "M-" prefix (M-BSpace, M-Left, M-a, ...) so word-wise line editing
+// works in the focused pane instead of degrading to an unmodified keypress.
+// Alt+<non-letter rune> can't safely use "M-<rune>" (tmux's command parser
+// treats `;`, quotes, `#`, ... specially), so it falls back to ESC followed by
+// the rune sent literally.
+func translateFocusKey(msg tea.KeyMsg) (sends []focusKeySend, unfocus bool) {
+	if msg.Type == tea.KeyEsc {
+		return nil, true
+	}
+	named := func(v string) []focusKeySend { return []focusKeySend{{val: v}} }
+
+	if msg.Alt {
+		switch msg.Type {
+		case tea.KeyRunes:
+			if allASCIILetters(msg.Runes) {
+				for _, r := range msg.Runes {
+					sends = append(sends, focusKeySend{val: "M-" + string(r)})
+				}
+				return sends, false
+			}
+			// ESC then the rune(s) sent literally (-l → quoteTmux), which is
+			// what Alt+<rune> is at the terminal level anyway.
+			return []focusKeySend{{val: "Escape"}, {literal: true, val: string(msg.Runes)}}, false
+		case tea.KeyBackspace:
+			return named("M-BSpace"), false
+		case tea.KeyDelete:
+			return named("M-DC"), false
+		case tea.KeyLeft:
+			return named("M-Left"), false
+		case tea.KeyRight:
+			return named("M-Right"), false
+		case tea.KeyUp:
+			return named("M-Up"), false
+		case tea.KeyDown:
+			return named("M-Down"), false
+		case tea.KeyEnter:
+			return named("M-Enter"), false
+		default:
+			// Alt+X == ESC then X: emit Escape, then translate the bare key.
+			rest, _ := translateFocusKey(tea.KeyMsg{Type: msg.Type, Runes: msg.Runes})
+			return append(named("Escape"), rest...), false
+		}
+	}
+
+	switch msg.Type {
+	case tea.KeyEnter:
+		return named("Enter"), false
+	case tea.KeyBackspace:
+		return named("BSpace"), false
+	case tea.KeyTab:
+		return named("Tab"), false
+	case tea.KeyShiftTab:
+		return named("BTab"), false
+	case tea.KeySpace:
+		return named("Space"), false
+	case tea.KeyUp:
+		return named("Up"), false
+	case tea.KeyDown:
+		return named("Down"), false
+	case tea.KeyLeft:
+		return named("Left"), false
+	case tea.KeyRight:
+		return named("Right"), false
+	case tea.KeyCtrlLeft:
+		return named("C-Left"), false
+	case tea.KeyCtrlRight:
+		return named("C-Right"), false
+	case tea.KeyCtrlUp:
+		return named("C-Up"), false
+	case tea.KeyCtrlDown:
+		return named("C-Down"), false
+	case tea.KeyHome:
+		return named("Home"), false
+	case tea.KeyEnd:
+		return named("End"), false
+	case tea.KeyPgUp:
+		return named("PageUp"), false
+	case tea.KeyPgDown:
+		return named("PageDown"), false
+	case tea.KeyDelete:
+		return named("DC"), false
+	case tea.KeyCtrlC:
+		return named("C-c"), false
+	case tea.KeyCtrlD:
+		return named("C-d"), false
+	case tea.KeyCtrlA:
+		return named("C-a"), false
+	case tea.KeyCtrlU:
+		return named("C-u"), false
+	case tea.KeyCtrlL:
+		return named("C-l"), false
+	case tea.KeyCtrlW:
+		return named("C-w"), false
+	case tea.KeyCtrlK:
+		return named("C-k"), false
+	case tea.KeyRunes:
+		return []focusKeySend{{literal: true, val: string(msg.Runes)}}, false
+	default:
+		if str := msg.String(); str != "" {
+			return []focusKeySend{{literal: true, val: str}}, false
+		}
+		return nil, false
+	}
+}
+
+// handleFocusKey forwards a keypress to the focused session's tmux pane, or
+// exits focus mode on Esc.
+//
+// The tmux sends run synchronously here rather than from a tea.Cmd on purpose:
+// Bubble Tea processes KeyMsgs sequentially, so staying in Update() keeps
+// forwarded keystrokes in order — concurrent tea.Cmds would not preserve that.
+// Each send is a sub-millisecond write to the long-lived `tmux -C` control
+// client, not a shell-out.
 func (h *Home) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	s := h.selectedSession()
 	if s == nil || !s.IsAlive() {
@@ -1740,7 +1882,8 @@ func (h *Home) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 	}
 
-	if msg.Type == tea.KeyEsc {
+	sends, unfocus := translateFocusKey(msg)
+	if unfocus {
 		h.focusMode = false
 		h.sidebarDirty = true
 		h.actionLog.Add("unfocus preview", s.Title, true)
@@ -1756,53 +1899,11 @@ func (h *Home) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	target := s.GetTmuxSession().Name
-
-	switch msg.Type {
-	case tea.KeyEnter:
-		cc.SendKeys(target, "Enter")
-	case tea.KeyBackspace:
-		cc.SendKeys(target, "BSpace")
-	case tea.KeyTab:
-		cc.SendKeys(target, "Tab")
-	case tea.KeySpace:
-		cc.SendKeys(target, "Space")
-	case tea.KeyUp:
-		cc.SendKeys(target, "Up")
-	case tea.KeyDown:
-		cc.SendKeys(target, "Down")
-	case tea.KeyLeft:
-		cc.SendKeys(target, "Left")
-	case tea.KeyRight:
-		cc.SendKeys(target, "Right")
-	case tea.KeyHome:
-		cc.SendKeys(target, "Home")
-	case tea.KeyEnd:
-		cc.SendKeys(target, "End")
-	case tea.KeyPgUp:
-		cc.SendKeys(target, "PageUp")
-	case tea.KeyPgDown:
-		cc.SendKeys(target, "PageDown")
-	case tea.KeyDelete:
-		cc.SendKeys(target, "DC")
-	case tea.KeyCtrlC:
-		cc.SendKeys(target, "C-c")
-	case tea.KeyCtrlD:
-		cc.SendKeys(target, "C-d")
-	case tea.KeyCtrlA:
-		cc.SendKeys(target, "C-a")
-	case tea.KeyCtrlU:
-		cc.SendKeys(target, "C-u")
-	case tea.KeyCtrlL:
-		cc.SendKeys(target, "C-l")
-	case tea.KeyCtrlW:
-		cc.SendKeys(target, "C-w")
-	case tea.KeyCtrlK:
-		cc.SendKeys(target, "C-k")
-	case tea.KeyRunes:
-		cc.SendLiteralKeys(target, string(msg.Runes))
-	default:
-		if str := msg.String(); str != "" {
-			cc.SendLiteralKeys(target, str)
+	for _, sk := range sends {
+		if sk.literal {
+			cc.SendLiteralKeys(target, sk.val)
+		} else {
+			cc.SendKeys(target, sk.val)
 		}
 	}
 	return h, nil

--- a/internal/ui/focuskey_test.go
+++ b/internal/ui/focuskey_test.go
@@ -1,0 +1,102 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestTranslateFocusKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		msg         tea.KeyMsg
+		wantSends   []focusKeySend
+		wantUnfocus bool
+	}{
+		{"esc exits focus mode", tea.KeyMsg{Type: tea.KeyEsc}, nil, true},
+
+		// Plain keys.
+		{"enter", tea.KeyMsg{Type: tea.KeyEnter}, []focusKeySend{{val: "Enter"}}, false},
+		{"backspace", tea.KeyMsg{Type: tea.KeyBackspace}, []focusKeySend{{val: "BSpace"}}, false},
+		{"tab", tea.KeyMsg{Type: tea.KeyTab}, []focusKeySend{{val: "Tab"}}, false},
+		{"shift+tab -> BTab", tea.KeyMsg{Type: tea.KeyShiftTab}, []focusKeySend{{val: "BTab"}}, false},
+		{"left", tea.KeyMsg{Type: tea.KeyLeft}, []focusKeySend{{val: "Left"}}, false},
+		{"ctrl+left -> C-Left", tea.KeyMsg{Type: tea.KeyCtrlLeft}, []focusKeySend{{val: "C-Left"}}, false},
+		{"ctrl+right -> C-Right", tea.KeyMsg{Type: tea.KeyCtrlRight}, []focusKeySend{{val: "C-Right"}}, false},
+		{"ctrl+up -> C-Up", tea.KeyMsg{Type: tea.KeyCtrlUp}, []focusKeySend{{val: "C-Up"}}, false},
+		{"ctrl+down -> C-Down", tea.KeyMsg{Type: tea.KeyCtrlDown}, []focusKeySend{{val: "C-Down"}}, false},
+		{"ctrl+w stays C-w", tea.KeyMsg{Type: tea.KeyCtrlW}, []focusKeySend{{val: "C-w"}}, false},
+		{"delete -> DC", tea.KeyMsg{Type: tea.KeyDelete}, []focusKeySend{{val: "DC"}}, false},
+		{"runes are literal", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("hi")}, []focusKeySend{{literal: true, val: "hi"}}, false},
+
+		// Alt/Meta-modified keys keep the modifier.
+		{"alt+backspace -> M-BSpace", tea.KeyMsg{Type: tea.KeyBackspace, Alt: true}, []focusKeySend{{val: "M-BSpace"}}, false},
+		{"alt+delete -> M-DC", tea.KeyMsg{Type: tea.KeyDelete, Alt: true}, []focusKeySend{{val: "M-DC"}}, false},
+		{"alt+b word-back -> M-b", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b"), Alt: true}, []focusKeySend{{val: "M-b"}}, false},
+		{"alt+f word-fwd -> M-f", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f"), Alt: true}, []focusKeySend{{val: "M-f"}}, false},
+		{"alt+d kill-word-fwd -> M-d", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d"), Alt: true}, []focusKeySend{{val: "M-d"}}, false},
+		{"alt+left -> M-Left", tea.KeyMsg{Type: tea.KeyLeft, Alt: true}, []focusKeySend{{val: "M-Left"}}, false},
+		{"alt+right -> M-Right", tea.KeyMsg{Type: tea.KeyRight, Alt: true}, []focusKeySend{{val: "M-Right"}}, false},
+		{"alt+up -> M-Up", tea.KeyMsg{Type: tea.KeyUp, Alt: true}, []focusKeySend{{val: "M-Up"}}, false},
+		{"alt+down -> M-Down", tea.KeyMsg{Type: tea.KeyDown, Alt: true}, []focusKeySend{{val: "M-Down"}}, false},
+		{"alt+enter -> M-Enter", tea.KeyMsg{Type: tea.KeyEnter, Alt: true}, []focusKeySend{{val: "M-Enter"}}, false},
+
+		// Alt + non-letter rune can't use "M-<rune>" safely → ESC then literal.
+		{"alt+semicolon -> ESC then literal", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(";"), Alt: true}, []focusKeySend{{val: "Escape"}, {literal: true, val: ";"}}, false},
+		{"alt+digit -> ESC then literal", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("1"), Alt: true}, []focusKeySend{{val: "Escape"}, {literal: true, val: "1"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSends, gotUnfocus := translateFocusKey(tt.msg)
+			if gotUnfocus != tt.wantUnfocus {
+				t.Errorf("unfocus = %v, want %v", gotUnfocus, tt.wantUnfocus)
+			}
+			if !reflect.DeepEqual(gotSends, tt.wantSends) {
+				t.Errorf("sends = %+v, want %+v", gotSends, tt.wantSends)
+			}
+		})
+	}
+}
+
+// TestTranslateFocusKey_ModifierNotDropped is the regression guard for the bug
+// this code path had: Alt-modified keys were switched on by Type alone, so e.g.
+// Option+Backspace was forwarded to tmux as a plain BSpace and word-wise line
+// editing didn't work in the focused pane.
+func TestTranslateFocusKey_ModifierNotDropped(t *testing.T) {
+	cases := []struct {
+		name  string
+		plain tea.KeyMsg
+		alt   tea.KeyMsg
+	}{
+		{"backspace", tea.KeyMsg{Type: tea.KeyBackspace}, tea.KeyMsg{Type: tea.KeyBackspace, Alt: true}},
+		{"delete", tea.KeyMsg{Type: tea.KeyDelete}, tea.KeyMsg{Type: tea.KeyDelete, Alt: true}},
+		{"left", tea.KeyMsg{Type: tea.KeyLeft}, tea.KeyMsg{Type: tea.KeyLeft, Alt: true}},
+		{"rune b", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b")}, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b"), Alt: true}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			plain, _ := translateFocusKey(c.plain)
+			alt, _ := translateFocusKey(c.alt)
+			if reflect.DeepEqual(plain, alt) {
+				t.Fatalf("Alt+%s produced the same send as plain %s (%+v); the modifier was dropped", c.name, c.name, plain)
+			}
+		})
+	}
+}
+
+// TestTranslateFocusKey_AltFallbackEmitsEscape checks the catch-all path:
+// an Alt-modified key with no explicit mapping is sent as Escape followed by
+// the bare key (Alt+X == ESC then X at the terminal level).
+func TestTranslateFocusKey_AltFallbackEmitsEscape(t *testing.T) {
+	// KeyHome has no Alt-specific case, so it goes through the fallback.
+	sends, unfocus := translateFocusKey(tea.KeyMsg{Type: tea.KeyHome, Alt: true})
+	if unfocus {
+		t.Fatal("unexpected unfocus")
+	}
+	want := []focusKeySend{{val: "Escape"}, {val: "Home"}}
+	if !reflect.DeepEqual(sends, want) {
+		t.Errorf("sends = %+v, want %+v", sends, want)
+	}
+}


### PR DESCRIPTION
## Problem

In focus-preview mode (`Tab`), `handleFocusKey()` translates keypresses into `tmux send-keys` by switching on `msg.Type` only — it never looks at `msg.Alt`. So modified keys collapsed to their unmodified form:

- **Option/Alt+Backspace** → plain `BSpace` (deletes one char, not a word)
- **Alt+B / Alt+F / Alt+D** (word-back / word-fwd / kill-word) → a literal `b` / `f` / `d` typed into the pane
- **Ctrl+Left / Ctrl+Right** → fell through to `default:` and were sent as the literal string `ctrl+left`

Net effect: no word-wise line editing inside the focused pane (noticeable e.g. editing a long prompt through the preview).

## Fix

- Extract the keypress → `tmux send-keys` mapping into a pure `translateFocusKey(tea.KeyMsg) ([]focusKeySend, unfocus bool)` — no `Home`, no control client, no I/O — so it's unit-testable without a live `tmux -C`. `handleFocusKey()` now just dispatches its result.
- Forward `msg.Alt` keys with the tmux `M-` prefix: `M-BSpace`, `M-DC`, `M-Left/Right/Up/Down`, `M-Enter`, and `M-<rune>` for letters. Anything unmapped falls back to `Escape` then the bare key (Alt+X == ESC then X at the terminal level).
- Add explicit cases for `Ctrl+Left/Right/Up/Down` → `C-Left/…` and `Shift+Tab` → `BTab`.

## Tests

New `internal/ui/focuskey_test.go`:
- table test over plain keys, the new Ctrl/Shift mappings, and every Alt mapping;
- `TestTranslateFocusKey_ModifierNotDropped` — regression guard asserting `Alt+X` never produces the same send as plain `X` (the assertion that would have caught this bug);
- `TestTranslateFocusKey_AltFallbackEmitsEscape` — covers the `Escape`-then-key fallback.

`go build ./...`, `go vet ./...`, `go test ./internal/ui/...` all pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus-mode key handling with enhanced support for Alt and Meta modifiers
  * Fixed Escape key behavior to properly exit focus mode and restore normal operations
  * Enhanced keyboard event forwarding and translation for improved tmux compatibility

* **Tests**
  * Added comprehensive test coverage for focus-mode key translation including modifier variants and edge cases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brizzai/fleet/pull/73)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->