### PR TITLE
feat(ui): add Mark All as Read command to command palette

### DIFF
--- a/changelog/unreleased/mark-all-as-read.md
+++ b/changelog/unreleased/mark-all-as-read.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+"Mark All as Read" command in the command palette to acknowledge all finished sessions at once, transitioning them to idle.

--- a/internal/analytics/events.go
+++ b/internal/analytics/events.go
@@ -21,4 +21,5 @@ const (
 	EventBugReportOpened  = "bug_report_opened"
 	EventCommandPalette   = "command_palette"
 	EventReloadAll        = "reload_all"
+	EventMarkAllRead      = "mark_all_read"
 )

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2870,6 +2870,7 @@ func (h *Home) buildPaletteCommands() []PaletteCommand {
 		{ID: "bug_report", Name: "Bug Report", Shortcut: "!"},
 		{ID: "help", Name: "Help", Shortcut: "?"},
 		{ID: "reload_all", Name: "Reload All Sessions"},
+		{ID: "mark_all_read", Name: "Mark All as Read"},
 		{ID: "quit", Name: "Quit", Shortcut: "q"},
 	}
 }
@@ -2969,6 +2970,10 @@ func (h *Home) dispatchCommand(id string) (tea.Model, tea.Cmd) {
 	case "reload_all":
 		analytics.Track(analytics.EventReloadAll, nil)
 		return h, h.reloadAll()
+	case "mark_all_read":
+		analytics.Track(analytics.EventMarkAllRead, nil)
+		h.markAllAsRead()
+		return h, nil
 	case "quit":
 		return h, tea.Quit
 	}
@@ -3035,6 +3040,27 @@ func (h *Home) reloadAll() tea.Cmd {
 			errors:    errors,
 		}
 	}
+}
+
+// markAllAsRead acknowledges all finished sessions, transitioning them to idle.
+func (h *Home) markAllAsRead() {
+	var count int
+	for _, s := range h.sessions {
+		if s.GetStatus() != session.StatusFinished {
+			continue
+		}
+		s.Acknowledge()
+		if err := h.storage.SetAcknowledged(s.ID, true); err != nil {
+			debuglog.Logger.Error("storage: SetAcknowledged", "id", s.ID, "err", err)
+		}
+		count++
+	}
+	if count == 0 {
+		h.setInfo("No finished sessions")
+		return
+	}
+	h.rebuildFlatItems()
+	h.setInfo(fmt.Sprintf("Marked %d sessions as read", count))
 }
 
 // ensureExactHeight pads or truncates content to exactly n lines.


### PR DESCRIPTION
## Summary
- Adds a "Mark All as Read" command to the command palette (`:` / `Ctrl+P`)
- Acknowledges all finished sessions at once, transitioning them to idle status
- No keyboard shortcut — palette-only, like "Reload All Sessions"

## Test plan
- [ ] Open TUI, let sessions finish
- [ ] Open command palette, type "mark", select "Mark All as Read"
- [ ] Verify all finished sessions transition to idle
- [ ] Verify toast shows count of marked sessions
- [ ] Verify "No finished sessions" toast when none are finished

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Mark All as Read" command to quickly acknowledge all finished sessions and update the interface. Displays confirmation when complete or indicates when no finished sessions are available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brizzai/fleet/pull/74)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->