### PR TITLE
feat(ui): Shift+↑/↓ reorder sessions and repo groups in sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Hook handler: `fleet hook-handler` (invoked by Claude Code hooks, reads FLEET_INSTANCE_ID env)
 - Hooks auto-installed into `~/.claude/settings.json` on TUI launch
 - Debug log: `~/.config/fleet/debug.log` (slog, init in TUI and hook-handler)
-- Config file: `~/.config/fleet/config.json` (tick_interval_sec, default_project_path, editor, theme, auto_name_sessions, copy_claude_settings)
+- Config file: `~/.config/fleet/config.json` (tick_interval_sec, default_project_path, editor, theme, auto_name_sessions, copy_claude_settings, focus_on_new_session)
 - Workspace: built-in git worktree support (zero config), per-repo `.fleet.json` (or legacy `.bc.json`) overrides with custom shell commands
 - Workspace creation is non-blocking: dialog closes immediately, phantom "Creating..." entry with spinner appears in sidebar, user can keep navigating
 - Worktree creation copies `.claude/settings.local.json` from source repo (configurable via `copy_claude_settings`, default true)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,12 @@ internal/tmux/tmux.go        # Tmux abstraction (create, kill, capture)
 internal/tmux/pty.go         # PTY-based attach with Ctrl+Q detach
 internal/session/session.go  # Session model, status detection, claude --resume
 internal/session/storage.go  # SQLite persistence (sessions + claude_session_id)
-internal/git/git.go          # Git operations (branch, dirty, worktree)
-internal/git/repo_info.go    # RepoInfo cache + refresh logic
-internal/github/pr.go        # GitHub PR info via gh CLI
+internal/git/git.go          # Git operations (branch, dirty, worktree, origin remote URL)
+internal/git/repo_info.go    # RepoInfo cache + refresh logic (PR fetched via a forge.Provider)
+internal/forge/forge.go      # Forge abstraction: PR struct, Provider interface, ParseRemote (host/owner-repo from a git URL)
+internal/github/pr.go        # GitHub forge provider — PR info via gh CLI
+internal/gitlab/pr.go        # GitLab forge provider — MR info via glab CLI
+internal/ui/forge_detect.go  # Picks the forge.Provider per repo (origin host + .fleet.json "forge" override)
 internal/hooks/              # Hook-based status detection (claude_hooks, hook_watcher, status_file)
 internal/workspace/provider.go     # Provider interface + GitWorktreeProvider + ShellProvider
 internal/workspace/repo_config.go  # Per-repo .fleet.json loading (legacy .bc.json supported) + ResolveProvider
@@ -78,7 +81,7 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Sessions grouped by git repo root in sidebar with tree lines (├─/└─)
 - Status: Running, Waiting, Finished, Idle, Error, Starting
 - Status icons: ● (running/finished), ◐ (waiting), ○ (idle/starting), ✕ (error)
-- Keybindings: j/k nav, Enter attach, Space jump to next waiting/finished, a new session (instant, repo-scoped), n new session (any repo, path autocomplete), w new worktree session (base branch + new branch), d delete (Y to also destroy workspace, D to also remove repo), z undo delete (5s window), r restart, R rename, e editor, p open PR in browser, Y quick approve (waiting sessions), / filter, : or Ctrl+P command palette, S settings, ! bug report/diagnostics, ? help, q quit
+- Keybindings: j/k nav, Enter attach, Space jump to next waiting/finished, a new session (instant, repo-scoped), n new session (any repo, path autocomplete), w new worktree session (base branch + new branch), d delete (Y to also destroy workspace, D to also remove repo), z undo delete (5s window), r restart, R rename, e editor, p open PR/MR in browser, Y quick approve (waiting sessions), / filter, : or Ctrl+P command palette, S settings, ! bug report/diagnostics, ? help, q quit
 - Session hotkeys (RTS-style): `Alt+0-9` (or `=` then digit) binds the selected session to a slot; re-pressing `Alt+<N>` on a session already in slot N unbinds; `==` then digit clears any slot; plain `0-9` jumps to the bound session (double-tap within 400ms also attaches); `[N]` badge in sidebar marks bound sessions; bindings persist in SQLite `slot_bindings` table (FK cascade on session delete)
 - Command palette (: / Ctrl+P): fuzzy-searchable list of all actions; palette-only commands include "Reload All Sessions" (restarts all dead/error sessions)
 - Undo delete: `z` key restores last deleted session within 5s window (stacked — multiple deletes each undoable). Tmux kept alive during window for full restore.
@@ -86,14 +89,17 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Tmux status bar configured per session with detach hint (ctrl+q)
 - Attach uses PTY with Ctrl+Q intercept for clean detach (creack/pty + golang.org/x/term)
 - Repo headers show branch name (), dirty indicator (*), and PR badge (#N)
-- Git info refreshes every 2s (branch/dirty), PR info every 60s via `gh` CLI
-- PR badge: green ✓ (approved+CI passed), yellow (pending), red ✕ (CI fail) / ↩ (changes requested or unresolved threads), purple ⇡ (merged), hidden (closed)
-- PR info includes unresolved review thread count via GitHub GraphQL API
-- `gh` CLI optional — PR info hidden if not installed
+- PR badge sigil: `#N` for GitHub pull requests, `!N` for GitLab merge requests
+- Git info refreshes every 2s (branch/dirty), PR/MR info every 60s via the repo's forge provider (`gh` for GitHub, `glab` for GitLab)
+- PR badge: green ✓ (approved+CI passed), yellow (pending), red ✕ (CI fail) / ⚠ (merge conflicts) / ↩ (changes requested or unresolved threads), purple ⇡ (merged), hidden (closed)
+- Forge detection: per-repo `forge.Provider` chosen from the `origin` remote host — `*gitlab*`/gitlab.com → GitLab, `github.com`/`github.*` → GitHub, else fall back to GitHub when `gh` is installed (preserves pre-GitLab behaviour for GHE on odd hostnames); `.fleet.json` `"forge": "github"|"gitlab"` overrides. Resolved once per repo, cached in `Home.repoForge` (worker-only map).
+- GitHub PR info: state/review/CI rollup via `gh pr view`, unresolved review-thread count via `gh api graphql`, merge conflicts via `mergeable`
+- GitLab MR info: state/conflicts/pipeline/discussions via `glab mr view -F json`, approval state via `glab api .../approvals`; GitLab states normalised to GitHub spellings (opened→OPEN, merged→MERGED, closed/locked→CLOSED); `pr_checks.ignore` not yet applied to GitLab pipeline jobs
+- `gh` / `glab` optional — PR/MR badge hidden if the repo's forge CLI isn't installed
 - Preview strips OSC-8 hyperlink sequences to prevent dotted underline artifacts
 - Status detection: hook-based (primary, no time expiry) via Claude Code hooks + pane capture (fallback, ANSI-stripped)
 - Agent team status: sub-agents don't fire hooks, so pane detection handles team states via structural checks (numbered menu `❯ 1.`+`2.`+`Esc to cancel`, box-drawing `│`+`Waiting for team lead`); hook=running is never overridden to waiting by pane (avoids false-positives from code in scrollback)
-- All blocking I/O (tmux, git, gh) runs in background worker goroutine, never in Bubble Tea Update()
+- All blocking I/O (tmux, git, gh, glab) runs in background worker goroutine, never in Bubble Tea Update()
 - Hook status files: `~/.config/fleet/hooks/{session_id}.json`
 - Hook handler: `fleet hook-handler` (invoked by Claude Code hooks, reads FLEET_INSTANCE_ID env)
 - Hooks auto-installed into `~/.claude/settings.json` on TUI launch
@@ -103,7 +109,8 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Workspace creation is non-blocking: dialog closes immediately, phantom "Creating..." entry with spinner appears in sidebar, user can keep navigating
 - Worktree creation copies `.claude/settings.local.json` from source repo (configurable via `copy_claude_settings`, default true)
 - `.fleet.json` / `.fleet.local.json` in repo root (legacy `.bc.json` / `.bc.local.json` still read): `{"workspace": {"list": "cmd", "create": "cmd {{name}} {{branch}}", "destroy": "cmd {{name}}"}}`
-- `.fleet.json` / `.fleet.local.json` may also set `{"pr_checks": {"ignore": ["glob", ...]}}` to drop matching CI checks from the PR-badge rollup (path.Match globs; lists from both files merge additively; opt-in, empty by default)
+- `.fleet.json` / `.fleet.local.json` may also set `{"pr_checks": {"ignore": ["glob", ...]}}` to drop matching CI checks from the PR-badge rollup (path.Match globs; lists from both files merge additively; opt-in, empty by default; GitHub only for now)
+- `.fleet.json` / `.fleet.local.json` may also set `{"forge": "github"|"gitlab"}` to override forge auto-detection (mainly for self-hosted GitLab on a hostname that doesn't contain "gitlab")
 - Claude session resume: captures Claude session_id from hooks, uses `claude --resume <id>` on restart
 - Editor: config.editor > $EDITOR > "code" (VS Code)
 - Themes: tokyo-night (default), catppuccin-mocha, rose-pine, nord, gruvbox — configurable via settings (S key)
@@ -111,7 +118,7 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Bug report: `!` key opens dialog showing error history, action log, system diagnostics; `g` opens GitHub issue with pre-filled markdown via `gh issue create --web`
 - Error history: ring buffer (max 50) of errors that flash for 5s — persists for bug reporting
 - Action log: ring buffer (max 100) of user actions (attach, delete, restart, editor, approve, etc.) for "steps to reproduce"
-- Diagnostics: app version, macOS version, tmux/claude/gh versions, config, last 100 lines of debug.log; home dir sanitized to `~`
+- Diagnostics: app version, macOS version, tmux/claude/gh/glab versions, config, last 100 lines of debug.log; home dir sanitized to `~`
 - Auto-naming: sessions auto-titled from user prompt via smart heuristic (filler stripping, word-boundary truncation)
 - Auto-naming pipeline: UserPromptSubmit hook → status file → HookWatcher → Session.FirstPrompt → worker cycle → naming.GenerateTitle
 - Retitle: after 3 prompts, title regenerated from latest prompt (better reflects session scope)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BINARY := fleet
 BUILD_DIR := build
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 
-.PHONY: build run clean test fmt install lint coverage deps vet setup
+.PHONY: build run clean test fmt install install-dev lint coverage deps vet setup
 
 build:
 	go build -v -ldflags "-s -w -X main.version=$(VERSION)" -o $(BUILD_DIR)/$(BINARY) ./cmd/fleet
@@ -41,6 +41,12 @@ vet:
 
 install: build
 	cp $(BUILD_DIR)/$(BINARY) ~/.local/bin/
+
+# install-dev: symlink ~/.local/bin/fleet into this repo's build/ tree so
+# subsequent `make build` runs are picked up without re-installing. Pass
+# extra flags through with FLAGS, e.g. `make install-dev FLAGS=--copy`.
+install-dev:
+	./install-dev.sh $(FLAGS)
 
 setup:
 	pre-commit install

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ go install github.com/brizzai/fleet/cmd/fleet@latest
 
 Requires Go 1.26+.
 
+### From source (fork / local dev)
+
+```bash
+git clone <your-fork-url> && cd fleet
+./install-dev.sh           # symlink ~/.local/bin/fleet -> build/fleet
+# or: make install-dev
+```
+
+Subsequent `make build` runs are picked up automatically (the install is a
+symlink into `build/`). Add `--copy` to install a static copy, `--dir <path>`
+to install elsewhere, or `--name fleet-dev` to install under an alternate
+name so it doesn't shadow your Homebrew install. Disable the auto-updater
+(`auto_update: false` in `~/.config/fleet/config.json`, or
+`FLEET_AUTO_UPDATE_DISABLED=1`) so fork builds don't get replaced by the
+upstream release.
+
 ### Requirements
 
 - macOS

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Every agent's state, always visible. Hook-based detection — no polling, no del
 
 ### Git-Native Sessions
 
-Sessions live under their repo. Branch name, dirty state, and full PR status on every header — CI pass/fail, review state, changes requested, unresolved threads. Collapse groups, filter with **`/`**, switch branches with **`b`**. Requires [`gh`](https://cli.github.com/) for PR info (optional).
+Sessions live under their repo. Branch name, dirty state, and full PR status on every header — CI pass/fail, review state, changes requested, unresolved threads. Collapse groups, filter with **`/`**, switch branches with **`b`**. Works with GitHub (via [`gh`](https://cli.github.com/)) and GitLab merge requests (via [`glab`](https://gitlab.com/gitlab-org/cli)) — the forge is auto-detected from the `origin` remote; both CLIs are optional, install whichever you use.
 
 ### Worktrees
 
@@ -107,7 +107,7 @@ Sessions live under their repo. Branch name, dirty state, and full PR status on 
 - **Full terminal attach** — **`Enter`** for full PTY, **`Tab`** for split mode (beta), **`Ctrl+Q`** to detach
 - **Auto-naming** — sessions title themselves from your prompt
 - **5 themes** — tokyo-night, catppuccin-mocha, rose-pine, nord, gruvbox (**`S`** to switch)
-- **Chrome tab control** — **`p`** opens PR in Chrome, reuses existing tab
+- **Chrome tab control** — **`p`** opens the PR / merge request in Chrome, reuses existing tab
 - **Bug reports** — **`!`** captures diagnostics and opens a pre-filled GitHub issue
 
 ## Why fleet?

--- a/changelog/unreleased/fix-focus-mode-modified-keys.md
+++ b/changelog/unreleased/fix-focus-mode-modified-keys.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Word-wise line editing in the focus-preview pane: Option/Alt+Backspace, Alt+B/F/D word motions, Alt+arrows, Ctrl+arrows and Shift+Tab are now forwarded to the focused session with their modifier intact instead of degrading to an unmodified keypress (e.g. Option+Backspace had been deleting one character instead of a word, and Ctrl+Left was being typed as the literal text `ctrl+left`).

--- a/changelog/unreleased/fix-split-mode-preview-truncation.md
+++ b/changelog/unreleased/fix-split-mode-preview-truncation.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Right side of Claude's output getting chopped off in split-view preview. tmux sessions are now sized to match the preview pane width (new sessions boot at that size, existing sessions resize on startup and whenever the terminal resizes), so Claude wraps to fit instead of rendering wider than fleet can display and being truncated by the ANSI cutter. Attaching temporarily resizes tmux up to the host terminal so the full-screen view isn't cramped; detaching restores the preview-fit size.

--- a/changelog/unreleased/focus-on-new-session.md
+++ b/changelog/unreleased/focus-on-new-session.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+Settings: new "Focus on new" toggle (S key) — when on, newly created sessions are auto-focused using your existing Enter mode (split-view preview or full attach). Applies to all creation paths: `a` (instant), `n` (new-session dialog), `w` (worktree), and the command palette. Default off, so existing behavior is unchanged.

--- a/changelog/unreleased/gitlab-support.md
+++ b/changelog/unreleased/gitlab-support.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+GitLab support: repos hosted on GitLab now get a merge-request badge on the repo header (`!N` instead of `#N`), driven by the `glab` CLI — pipeline status, merge conflicts, approval state and unresolved discussions, refreshed on the same cadence as GitHub PRs. `p` opens the MR in the browser. The forge is auto-detected from the `origin` remote URL (gitlab.com or any `*gitlab*` host); self-hosted instances on an unrelated hostname can force it with `"forge": "gitlab"` in `.fleet.json`. `glab` is optional, exactly like `gh` — install it (`brew install glab`) and authenticate (`glab auth login`) to see MR badges. Known gap vs GitHub: `pr_checks.ignore` globs aren't yet applied to GitLab pipeline jobs (the head pipeline's rolled-up status is used as-is).

--- a/changelog/unreleased/sidebar-reorder.md
+++ b/changelog/unreleased/sidebar-reorder.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+Shift+↑/↓ reorders sessions within a repo group or moves repo groups up/down in the sidebar. Order persists across restarts.

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# fleet local-dev installer
+#
+# Builds fleet from the current source tree and installs it to ~/.local/bin
+# (or a directory of your choosing) so you can run `fleet` from anywhere on
+# your fork. By default the install is a symlink into the repo's build/
+# directory — re-running `make build` after editing source instantly updates
+# the installed binary without re-running this script.
+#
+# Usage:
+#   ./install-dev.sh                     # symlink to ~/.local/bin/fleet
+#   ./install-dev.sh --copy              # copy the binary instead of symlinking
+#   ./install-dev.sh --dir /usr/local/bin
+#   ./install-dev.sh --name fleet-dev    # install under a different name
+#   ./install-dev.sh --force             # overwrite an existing install without asking
+
+set -euo pipefail
+
+INSTALL_DIR="${HOME}/.local/bin"
+BIN_NAME="fleet"
+MODE="link"
+FORCE="0"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --copy)    MODE="copy"; shift ;;
+        --link)    MODE="link"; shift ;;
+        --dir)     INSTALL_DIR="$2"; shift 2 ;;
+        --name)    BIN_NAME="$2"; shift 2 ;;
+        --force|-f) FORCE="1"; shift ;;
+        -h|--help)
+            sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Resolve the repo root from this script's location so the script works
+# regardless of where it's invoked from.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+if [[ ! -f cmd/fleet/main.go ]]; then
+    echo "Error: cmd/fleet/main.go not found — run this script from the fleet repo root." >&2
+    exit 1
+fi
+
+if ! command -v go &>/dev/null; then
+    echo "Error: 'go' not found in PATH (need Go 1.26+ to build fleet)." >&2
+    exit 1
+fi
+
+# Build via make so we pick up the same -ldflags as a real release (notably
+# the `git describe`-derived version, which lets `fleet --version` show your
+# fork's commit and the `-dirty` suffix when you have uncommitted changes).
+echo "==> Building fleet"
+make build
+
+BUILT="$SCRIPT_DIR/build/fleet"
+if [[ ! -x "$BUILT" ]]; then
+    echo "Error: build did not produce $BUILT" >&2
+    exit 1
+fi
+
+mkdir -p "$INSTALL_DIR"
+TARGET="$INSTALL_DIR/$BIN_NAME"
+
+# If something is already at the target, confirm before clobbering — unless
+# it's a symlink we previously created (safe to refresh) or --force was given.
+if [[ -e "$TARGET" || -L "$TARGET" ]]; then
+    is_our_symlink="0"
+    if [[ -L "$TARGET" ]]; then
+        existing=$(readlink "$TARGET")
+        if [[ "$existing" == "$BUILT" ]]; then
+            is_our_symlink="1"
+        fi
+    fi
+    if [[ "$is_our_symlink" != "1" && "$FORCE" != "1" ]]; then
+        printf "%s already exists. Overwrite? [y/N] " "$TARGET"
+        read -r reply
+        case "$reply" in
+            y|Y|yes|YES) ;;
+            *) echo "Aborted."; exit 1 ;;
+        esac
+    fi
+    rm -f "$TARGET"
+fi
+
+case "$MODE" in
+    link)
+        ln -s "$BUILT" "$TARGET"
+        echo "==> Linked $TARGET -> $BUILT"
+        ;;
+    copy)
+        cp "$BUILT" "$TARGET"
+        chmod +x "$TARGET"
+        echo "==> Copied $BUILT -> $TARGET"
+        ;;
+esac
+
+# PATH check.
+if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+    echo ""
+    echo "Note: $INSTALL_DIR is not in your PATH."
+    echo "Add this to your shell config (~/.zshrc or similar):"
+    echo "    export PATH=\"$INSTALL_DIR:\$PATH\""
+fi
+
+# Auto-update would happily replace a fork build with the latest official
+# release. Remind the user to opt out so their fork sticks around.
+echo ""
+echo "Tip: disable the auto-updater so it doesn't replace your fork build with"
+echo "     the upstream release. Either set in ~/.config/fleet/config.json:"
+echo '         { "auto_update": false }'
+echo "     or export the env var (also handy for one-off dev sessions):"
+echo "         export FLEET_AUTO_UPDATE_DISABLED=1"
+
+# Quick dependency sanity check (same checks install.sh does).
+echo ""
+if command -v tmux &>/dev/null; then
+    echo "$(tmux -V) [OK]"
+else
+    echo "Warning: tmux is not installed (required)"
+    echo "  brew install tmux"
+fi
+if command -v claude &>/dev/null; then
+    echo "claude $(claude --version 2>/dev/null | head -1) [OK]"
+else
+    echo "Warning: claude CLI is not installed (required to create sessions)"
+fi
+
+echo ""
+"$TARGET" --version 2>/dev/null || true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	AutoUpdate         *bool  `json:"auto_update,omitempty"`
 	CopyClaudeSettings *bool  `json:"copy_claude_settings,omitempty"`
 	EnterMode          string `json:"enter_mode,omitempty"` // "attach" or "split"
+	FocusOnNewSession  *bool  `json:"focus_on_new_session,omitempty"`
 	Telemetry          *bool  `json:"telemetry,omitempty"`
 }
 
@@ -120,6 +121,15 @@ func (c *Config) GetEnterMode() string {
 		return "split"
 	}
 	return "attach"
+}
+
+// IsFocusOnNewSessionEnabled returns whether to auto-focus newly created
+// sessions using the configured Enter mode (default: false).
+func (c *Config) IsFocusOnNewSessionEnabled() bool {
+	if c.FocusOnNewSession == nil {
+		return false
+	}
+	return *c.FocusOnNewSession
 }
 
 // IsTelemetryEnabled returns whether telemetry is enabled (default: true).

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -22,6 +22,7 @@ type Report struct {
 	TmuxVersion   string
 	ClaudeVersion string
 	GhVersion     string
+	GlabVersion   string
 	Config        string
 	SessionCount  int
 	RecentErrors  []string // pre-formatted from ErrorHistory
@@ -63,6 +64,7 @@ func Collect(version string, sessionCount int) *Report {
 	r.TmuxVersion = runCmd("tmux", "-V")
 	r.ClaudeVersion = runCmd("claude", "--version")
 	r.GhVersion = firstLine(runCmd("gh", "--version"))
+	r.GlabVersion = firstLine(runCmd("glab", "--version"))
 
 	r.TerminalEnv = collectTerminalEnv()
 
@@ -160,6 +162,9 @@ func (r *Report) formatMarkdown(description string) string {
 	}
 	if r.GhVersion != "" {
 		fmt.Fprintf(&b, "- **gh CLI**: %s\n", r.GhVersion)
+	}
+	if r.GlabVersion != "" {
+		fmt.Fprintf(&b, "- **glab CLI**: %s\n", r.GlabVersion)
 	}
 	fmt.Fprintf(&b, "- **Sessions**: %d\n", r.SessionCount)
 	b.WriteString("\n")

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -1,0 +1,99 @@
+// Package forge abstracts over code-hosting platforms (GitHub, GitLab) so the
+// rest of fleet can render a single "PR badge" without caring which forge a repo
+// lives on. Each concrete forge lives in its own package (internal/github,
+// internal/gitlab) and implements Provider; the ui layer picks the right one per
+// repo via remote-URL inspection (see internal/ui detectForge).
+//
+// The vocabulary here is GitHub-flavoured ("PR", "ReviewDecision") because that's
+// what the codebase grew up with — a GitLab merge request maps onto the same
+// shape, with state strings normalised to the GitHub spellings.
+package forge
+
+import "strings"
+
+// PR is a normalised pull/merge request. State, ReviewDecision and CIStatus use
+// the GitHub spellings regardless of the underlying forge so renderPRBadge stays
+// forge-agnostic.
+type PR struct {
+	Number            int
+	Title             string
+	URL               string
+	State             string // OPEN, CLOSED, MERGED
+	ReviewDecision    string // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, ""
+	CIStatus          string // SUCCESS, FAILURE, PENDING, ""
+	UnresolvedThreads int    // count of unresolved review threads / discussions
+	HasConflicts      bool   // forge reports merge conflicts
+	Forge             string // "github" | "gitlab" — drives badge labelling (#N vs !N)
+}
+
+// Provider fetches PR/MR metadata for a single forge.
+type Provider interface {
+	// Name is the forge identifier ("github" | "gitlab").
+	Name() string
+	// Available reports whether the backing CLI (gh / glab) is installed.
+	Available() bool
+	// GetPRForBranch returns the PR/MR for branch, or nil if there is none.
+	// ignorePatterns are path.Match globs applied to CI check / job names before
+	// the CI status is rolled up (see workspace.IgnorePatterns).
+	GetPRForBranch(repoPath, branch string, ignorePatterns []string) (*PR, error)
+}
+
+// ParseRemote extracts the host and "owner/repo" path (with any GitLab
+// subgroups, no ".git" suffix) from a git remote URL. It handles the common
+// forms:
+//
+//	https://host/owner/repo(.git)
+//	http://host/owner/repo(.git)
+//	git@host:owner/repo(.git)
+//	ssh://git@host[:port]/owner/repo(.git)
+//	host:owner/repo(.git)            (scp-like, no user)
+//
+// On anything it can't parse it returns ("", "").
+func ParseRemote(rawURL string) (host, path string) {
+	s := strings.TrimSpace(rawURL)
+	if s == "" {
+		return "", ""
+	}
+
+	switch {
+	case strings.HasPrefix(s, "ssh://"):
+		s = strings.TrimPrefix(s, "ssh://")
+		s = stripUserInfo(s)
+		host, path = splitHostPath(s, "/")
+	case strings.HasPrefix(s, "https://"):
+		host, path = splitHostPath(strings.TrimPrefix(s, "https://"), "/")
+	case strings.HasPrefix(s, "http://"):
+		host, path = splitHostPath(strings.TrimPrefix(s, "http://"), "/")
+	case strings.HasPrefix(s, "git://"):
+		host, path = splitHostPath(strings.TrimPrefix(s, "git://"), "/")
+	default:
+		// scp-like: [user@]host:owner/repo
+		s = stripUserInfo(s)
+		host, path = splitHostPath(s, ":")
+	}
+
+	// Drop a port if one snuck through (ssh://git@host:22/...).
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	return host, path
+}
+
+func stripUserInfo(s string) string {
+	if i := strings.IndexByte(s, '@'); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
+// splitHostPath splits s into the part before the first sep and the rest.
+func splitHostPath(s, sep string) (string, string) {
+	i := strings.Index(s, sep)
+	if i < 0 {
+		return s, ""
+	}
+	return s[:i], s[i+len(sep):]
+}

--- a/internal/forge/forge_test.go
+++ b/internal/forge/forge_test.go
@@ -1,0 +1,34 @@
+package forge
+
+import "testing"
+
+func TestParseRemote(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		wantHost string
+		wantPath string
+	}{
+		{"https github", "https://github.com/brizzai/fleet.git", "github.com", "brizzai/fleet"},
+		{"https no .git", "https://github.com/brizzai/fleet", "github.com", "brizzai/fleet"},
+		{"https trailing slash", "https://github.com/brizzai/fleet/", "github.com", "brizzai/fleet"},
+		{"scp git@", "git@github.com:brizzai/fleet.git", "github.com", "brizzai/fleet"},
+		{"scp no user", "github.com:brizzai/fleet.git", "github.com", "brizzai/fleet"},
+		{"ssh url with port", "ssh://git@github.com:22/brizzai/fleet.git", "github.com", "brizzai/fleet"},
+		{"gitlab subgroup scp", "git@gitlab.com:group/sub/repo.git", "gitlab.com", "group/sub/repo"},
+		{"gitlab subgroup https", "https://gitlab.example.com/group/sub/repo.git", "gitlab.example.com", "group/sub/repo"},
+		{"http", "http://gitlab.local/team/proj.git", "gitlab.local", "team/proj"},
+		{"git protocol", "git://github.com/brizzai/fleet.git", "github.com", "brizzai/fleet"},
+		{"empty", "", "", ""},
+		{"whitespace", "  ", "", ""},
+		{"garbage", "not a url", "not a url", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, path := ParseRemote(tt.url)
+			if host != tt.wantHost || path != tt.wantPath {
+				t.Errorf("ParseRemote(%q) = (%q, %q), want (%q, %q)", tt.url, host, path, tt.wantHost, tt.wantPath)
+			}
+		})
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -22,6 +22,18 @@ func GetBranchName(repoPath string) string {
 	return strings.TrimSpace(string(output))
 }
 
+// RemoteURL returns the fetch URL of the repo's "origin" remote, or empty string
+// if there is no origin (or not a git repo). Used to detect which forge a repo
+// lives on.
+func RemoteURL(repoPath string) string {
+	cmd := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
 // HasUncommittedChanges returns true if the working tree has uncommitted changes.
 func HasUncommittedChanges(repoPath string) bool {
 	cmd := exec.Command("git", "-C", repoPath, "status", "--porcelain")

--- a/internal/git/repo_info.go
+++ b/internal/git/repo_info.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/brizzai/fleet/internal/debuglog"
-	"github.com/brizzai/fleet/internal/github"
+	"github.com/brizzai/fleet/internal/forge"
 )
 
 // RepoInfo holds cached git and PR metadata for a repository.
@@ -12,7 +12,7 @@ type RepoInfo struct {
 	Branch         string
 	IsDirty        bool
 	IsWorktreeRepo bool
-	PR             *github.PR
+	PR             *forge.PR
 	LastGitRefresh time.Time
 	LastPRRefresh  time.Time
 }
@@ -28,15 +28,19 @@ func RefreshGitInfo(repoPath string) *RepoInfo {
 	}
 }
 
-// RefreshPRInfo fetches PR info via gh CLI and updates the RepoInfo.
-// Slower operation (~200ms, network call).
-// ignorePatterns is the per-repo CI-check ignore list (path.Match globs);
-// caller is responsible for loading it (typically via workspace.IgnorePatterns)
+// RefreshPRInfo fetches PR/MR info via the repo's forge provider and updates the
+// RepoInfo. Slower operation (~200ms, network call). A nil provider (repo has no
+// recognised forge, or the forge's CLI isn't installed) is a no-op that leaves
+// any cached PR in place. ignorePatterns is the per-repo CI-check ignore list
+// (path.Match globs); the caller loads it (typically via workspace.IgnorePatterns)
 // to keep this package free of a workspace-package dependency.
-func RefreshPRInfo(info *RepoInfo, repoPath string, ignorePatterns []string) {
-	pr, err := github.GetPRForBranch(repoPath, info.Branch, ignorePatterns)
+func RefreshPRInfo(info *RepoInfo, repoPath string, ignorePatterns []string, provider forge.Provider) {
+	if provider == nil {
+		return
+	}
+	pr, err := provider.GetPRForBranch(repoPath, info.Branch, ignorePatterns)
 	if err != nil {
-		debuglog.Logger.Debug("RefreshPRInfo failed", "path", repoPath, "branch", info.Branch, "error", err)
+		debuglog.Logger.Debug("RefreshPRInfo failed", "path", repoPath, "branch", info.Branch, "forge", provider.Name(), "error", err)
 	}
 	info.PR = pr
 	info.LastPRRefresh = time.Now()

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -1,3 +1,4 @@
+// Package github implements the forge.Provider interface on top of the `gh` CLI.
 package github
 
 import (
@@ -8,27 +9,37 @@ import (
 	"strings"
 
 	"github.com/brizzai/fleet/internal/debuglog"
+	"github.com/brizzai/fleet/internal/forge"
 )
 
-// PR represents a GitHub pull request.
-type PR struct {
-	Number            int
-	Title             string
-	URL               string
-	State             string // OPEN, CLOSED, MERGED
-	ReviewDecision    string // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, ""
-	CIStatus          string // SUCCESS, FAILURE, PENDING, ""
-	UnresolvedThreads int    // count of unresolved review threads
-	HasConflicts      bool   // true when GitHub reports merge conflicts
+// Provider fetches PR metadata via the GitHub CLI.
+type Provider struct{}
+
+// New returns a GitHub forge provider.
+func New() *Provider { return &Provider{} }
+
+// Name implements forge.Provider.
+func (*Provider) Name() string { return "github" }
+
+// Available reports whether the `gh` CLI is installed and runnable.
+func (*Provider) Available() bool {
+	return exec.Command("gh", "--version").Run() == nil
 }
 
-// IsGHAvailable checks if the gh CLI is installed and accessible.
-func IsGHAvailable() bool {
-	cmd := exec.Command("gh", "--version")
-	return cmd.Run() == nil
+// IsAvailable is the package-level shorthand for (&Provider{}).Available().
+func IsAvailable() bool { return (&Provider{}).Available() }
+
+// HostMatches reports whether host looks like github.com or a GitHub Enterprise
+// instance (best-effort: matches "github.com" and "github.*"). GHE hosts without
+// "github" in the name aren't recognised here — detectForge falls back to
+// treating any repo as GitHub when `gh` is installed, which preserves the
+// pre-GitLab behaviour for those.
+func HostMatches(host string) bool {
+	host = strings.ToLower(host)
+	return host == "github.com" || strings.HasPrefix(host, "github.")
 }
 
-// ghPRResponse matches the JSON output of gh pr view.
+// ghPRResponse matches the JSON output of `gh pr view`.
 type ghPRResponse struct {
 	Number            int                `json:"number"`
 	Title             string             `json:"title"`
@@ -45,11 +56,11 @@ type statusCheckEntry struct {
 	Conclusion string `json:"conclusion"`
 }
 
-// GetPRForBranch returns the PR associated with the current branch, or nil if none.
+// GetPRForBranch returns the PR associated with branch, or nil if none.
 // ignorePatterns are path.Match globs applied to check names; matching checks are
 // dropped from the rollup before CI status is derived (lets repos suppress noisy
 // gates without affecting real check failures).
-func GetPRForBranch(repoPath, branch string, ignorePatterns []string) (*PR, error) {
+func (*Provider) GetPRForBranch(repoPath, branch string, ignorePatterns []string) (*forge.PR, error) {
 	if branch == "" || branch == "HEAD" {
 		return nil, nil
 	}
@@ -66,11 +77,11 @@ func GetPRForBranch(repoPath, branch string, ignorePatterns []string) (*PR, erro
 
 	var resp ghPRResponse
 	if err := json.Unmarshal(output, &resp); err != nil {
-		debuglog.Logger.Debug("GetPRForBranch JSON parse failed", "path", repoPath, "branch", branch, "error", err)
+		debuglog.Logger.Debug("github: GetPRForBranch JSON parse failed", "path", repoPath, "branch", branch, "error", err)
 		return nil, nil
 	}
 
-	pr := &PR{
+	return &forge.PR{
 		Number:            resp.Number,
 		Title:             resp.Title,
 		URL:               resp.URL,
@@ -79,9 +90,8 @@ func GetPRForBranch(repoPath, branch string, ignorePatterns []string) (*PR, erro
 		CIStatus:          deriveCIStatus(resp.StatusCheckRollup, ignorePatterns),
 		UnresolvedThreads: getUnresolvedThreadCount(repoPath, resp.Number, resp.URL),
 		HasConflicts:      resp.Mergeable == "CONFLICTING",
-	}
-
-	return pr, nil
+		Forge:             "github",
+	}, nil
 }
 
 // getUnresolvedThreadCount queries GitHub GraphQL API for unresolved review thread count.
@@ -90,7 +100,7 @@ func getUnresolvedThreadCount(repoPath string, prNumber int, prURL string) int {
 	trimmed := strings.TrimPrefix(prURL, "https://github.com/")
 	parts := strings.Split(trimmed, "/")
 	if len(parts) < 3 {
-		debuglog.Logger.Debug("getUnresolvedThreadCount failed to parse PR URL", "url", prURL)
+		debuglog.Logger.Debug("github: getUnresolvedThreadCount failed to parse PR URL", "url", prURL)
 		return 0
 	}
 	owner, repo := parts[0], parts[1]
@@ -109,7 +119,7 @@ func getUnresolvedThreadCount(repoPath string, prNumber int, prURL string) int {
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {
-		debuglog.Logger.Debug("getUnresolvedThreadCount GraphQL query failed", "pr", prNumber, "error", err)
+		debuglog.Logger.Debug("github: getUnresolvedThreadCount GraphQL query failed", "pr", prNumber, "error", err)
 		return 0
 	}
 
@@ -127,7 +137,7 @@ func getUnresolvedThreadCount(repoPath string, prNumber int, prURL string) int {
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(output, &result); err != nil {
-		debuglog.Logger.Debug("getUnresolvedThreadCount JSON parse failed", "pr", prNumber, "error", err)
+		debuglog.Logger.Debug("github: getUnresolvedThreadCount JSON parse failed", "pr", prNumber, "error", err)
 		return 0
 	}
 

--- a/internal/gitlab/pr.go
+++ b/internal/gitlab/pr.go
@@ -1,0 +1,206 @@
+// Package gitlab implements the forge.Provider interface on top of the `glab`
+// CLI. A GitLab merge request is mapped onto the same shape fleet uses for
+// GitHub pull requests (see internal/forge): state strings are normalised to the
+// GitHub spellings, the pipeline status becomes the "CI status", and an MR with
+// unresolved discussions is reported with a single unresolved-thread count so
+// the badge lights up the same way.
+//
+// Known gap vs GitHub: pr_checks.ignore globs are not yet applied to GitLab
+// pipeline jobs — the badge uses the head pipeline's rolled-up status as-is.
+package gitlab
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/brizzai/fleet/internal/debuglog"
+	"github.com/brizzai/fleet/internal/forge"
+)
+
+// Provider fetches MR metadata via the GitLab CLI.
+type Provider struct{}
+
+// New returns a GitLab forge provider.
+func New() *Provider { return &Provider{} }
+
+// Name implements forge.Provider.
+func (*Provider) Name() string { return "gitlab" }
+
+// Available reports whether the `glab` CLI is installed and runnable.
+func (*Provider) Available() bool {
+	return exec.Command("glab", "--version").Run() == nil
+}
+
+// IsAvailable is the package-level shorthand for (&Provider{}).Available().
+func IsAvailable() bool { return (&Provider{}).Available() }
+
+// HostMatches reports whether host looks like a GitLab instance: gitlab.com, or
+// any host containing "gitlab" (covers the common self-hosted naming, e.g.
+// gitlab.example.com). Self-hosted instances on an unrelated hostname need an
+// explicit `"forge": "gitlab"` in .fleet.json.
+func HostMatches(host string) bool {
+	host = strings.ToLower(host)
+	return host == "gitlab.com" || strings.Contains(host, "gitlab")
+}
+
+type glabPipeline struct {
+	ID     int    `json:"id"`
+	Status string `json:"status"`
+}
+
+// glabMR is the subset of `glab mr view -F json` (the GitLab MR API object) we use.
+type glabMR struct {
+	IID                         int           `json:"iid"`
+	Title                       string        `json:"title"`
+	WebURL                      string        `json:"web_url"`
+	State                       string        `json:"state"` // opened, closed, merged, locked
+	ProjectID                   int           `json:"project_id"`
+	HasConflicts                bool          `json:"has_conflicts"`
+	DetailedMergeStatus         string        `json:"detailed_merge_status"`
+	BlockingDiscussionsResolved *bool         `json:"blocking_discussions_resolved"`
+	Pipeline                    *glabPipeline `json:"pipeline"`
+	HeadPipeline                *glabPipeline `json:"head_pipeline"`
+}
+
+type glabApprovals struct {
+	ApprovalsRequired int  `json:"approvals_required"`
+	ApprovalsLeft     int  `json:"approvals_left"`
+	Approved          bool `json:"approved"` // GitLab >= 16.0
+	ApprovedBy        []struct {
+		User struct {
+			Username string `json:"username"`
+		} `json:"user"`
+	} `json:"approved_by"`
+}
+
+// GetPRForBranch returns the MR whose source branch is branch, or nil if none.
+// ignorePatterns is accepted for interface parity with the GitHub provider but
+// is not yet applied to GitLab pipeline jobs.
+func (*Provider) GetPRForBranch(repoPath, branch string, _ []string) (*forge.PR, error) {
+	if branch == "" || branch == "HEAD" {
+		return nil, nil
+	}
+
+	cmd := exec.Command("glab", "mr", "view", branch, "-F", "json")
+	cmd.Dir = repoPath
+	output, err := cmd.Output()
+	if err != nil {
+		// glab exits non-zero when no MR exists for the branch, or when the
+		// host isn't authenticated — both expected, not surfaced as an error.
+		return nil, nil
+	}
+
+	pr, mr, err := parseMR(output)
+	if err != nil {
+		debuglog.Logger.Debug("gitlab: GetPRForBranch JSON parse failed", "path", repoPath, "branch", branch, "error", err)
+		return nil, nil
+	}
+	if pr == nil {
+		return nil, nil
+	}
+	pr.ReviewDecision = reviewDecision(repoPath, mr.ProjectID, mr.IID)
+	return pr, nil
+}
+
+// parseMR parses `glab mr view -F json` output into a normalised PR. The
+// ReviewDecision is left empty here — it needs a separate approvals API call
+// (see reviewDecision). Returns (nil, _, nil) when the payload contains no MR.
+func parseMR(data []byte) (*forge.PR, glabMR, error) {
+	var mr glabMR
+	if err := json.Unmarshal(data, &mr); err != nil {
+		return nil, mr, err
+	}
+	if mr.IID == 0 {
+		return nil, mr, nil
+	}
+
+	unresolved := 0
+	if mr.BlockingDiscussionsResolved != nil && !*mr.BlockingDiscussionsResolved {
+		unresolved = 1 // glab mr view doesn't give a count; 1 is enough to flag the badge
+	}
+
+	return &forge.PR{
+		Number:            mr.IID,
+		Title:             mr.Title,
+		URL:               mr.WebURL,
+		State:             normalizeState(mr.State),
+		CIStatus:          pipelineStatus(mr.HeadPipeline, mr.Pipeline),
+		UnresolvedThreads: unresolved,
+		HasConflicts:      mr.HasConflicts || strings.EqualFold(mr.DetailedMergeStatus, "conflict"),
+		Forge:             "gitlab",
+	}, mr, nil
+}
+
+// normalizeState maps GitLab MR states onto the GitHub spellings used by the badge.
+func normalizeState(state string) string {
+	switch strings.ToLower(state) {
+	case "merged":
+		return "MERGED"
+	case "opened":
+		return "OPEN"
+	default: // closed, locked
+		return "CLOSED"
+	}
+}
+
+// pipelineStatus picks the head pipeline (latest) when present, falling back to
+// the MR's pipeline field, and maps the GitLab status onto SUCCESS/FAILURE/PENDING.
+// Neutral terminal states (canceled, skipped, manual) and an absent pipeline map
+// to "" so they don't colour the badge.
+func pipelineStatus(head, fallback *glabPipeline) string {
+	p := head
+	if p == nil {
+		p = fallback
+	}
+	if p == nil {
+		return ""
+	}
+	switch strings.ToLower(p.Status) {
+	case "success":
+		return "SUCCESS"
+	case "failed":
+		return "FAILURE"
+	case "running", "pending", "created", "preparing", "waiting_for_resource", "scheduled":
+		return "PENDING"
+	default:
+		return ""
+	}
+}
+
+// reviewDecision returns "APPROVED" when the MR has met its approval requirement,
+// else "". GitLab has no clean per-MR "changes requested" signal, so that case
+// isn't reported here — unresolved discussions still flag the badge separately.
+func reviewDecision(repoPath string, projectID, iid int) string {
+	if projectID == 0 || iid == 0 {
+		return ""
+	}
+	endpoint := "projects/" + strconv.Itoa(projectID) + "/merge_requests/" + strconv.Itoa(iid) + "/approvals"
+	cmd := exec.Command("glab", "api", endpoint)
+	cmd.Dir = repoPath
+	output, err := cmd.Output()
+	if err != nil {
+		debuglog.Logger.Debug("gitlab: approvals query failed", "project", projectID, "mr", iid, "error", err)
+		return ""
+	}
+	var ap glabApprovals
+	if err := json.Unmarshal(output, &ap); err != nil {
+		debuglog.Logger.Debug("gitlab: approvals JSON parse failed", "project", projectID, "mr", iid, "error", err)
+		return ""
+	}
+	return approvalDecision(ap)
+}
+
+// approvalDecision derives the GitHub-style review decision from a GitLab
+// approvals payload: "APPROVED" when the approval rule is satisfied (or, when no
+// approvals are required, at least one approval exists), else "".
+func approvalDecision(ap glabApprovals) string {
+	approved := ap.Approved ||
+		(ap.ApprovalsRequired > 0 && ap.ApprovalsLeft == 0) ||
+		(ap.ApprovalsRequired == 0 && len(ap.ApprovedBy) > 0)
+	if approved {
+		return "APPROVED"
+	}
+	return ""
+}

--- a/internal/gitlab/pr_test.go
+++ b/internal/gitlab/pr_test.go
@@ -1,0 +1,176 @@
+package gitlab
+
+import "testing"
+
+func TestHostMatches(t *testing.T) {
+	cases := map[string]bool{
+		"gitlab.com":         true,
+		"GitLab.com":         true,
+		"gitlab.example.com": true,
+		"git.gitlab.acme.io": true,
+		"github.com":         false,
+		"bitbucket.org":      false,
+		"git.corp.com":       false,
+		"":                   false,
+	}
+	for host, want := range cases {
+		if got := HostMatches(host); got != want {
+			t.Errorf("HostMatches(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+
+func TestNormalizeState(t *testing.T) {
+	cases := map[string]string{
+		"opened": "OPEN",
+		"merged": "MERGED",
+		"closed": "CLOSED",
+		"locked": "CLOSED",
+		"OPENED": "OPEN",
+		"":       "CLOSED",
+	}
+	for in, want := range cases {
+		if got := normalizeState(in); got != want {
+			t.Errorf("normalizeState(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPipelineStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		head, fallback *glabPipeline
+		want           string
+	}{
+		{"nil both", nil, nil, ""},
+		{"head success", &glabPipeline{Status: "success"}, nil, "SUCCESS"},
+		{"head failed", &glabPipeline{Status: "failed"}, nil, "FAILURE"},
+		{"head running", &glabPipeline{Status: "running"}, nil, "PENDING"},
+		{"head created", &glabPipeline{Status: "created"}, nil, "PENDING"},
+		{"head canceled -> neutral", &glabPipeline{Status: "canceled"}, nil, ""},
+		{"head manual -> neutral", &glabPipeline{Status: "manual"}, nil, ""},
+		{"head preferred over fallback", &glabPipeline{Status: "running"}, &glabPipeline{Status: "success"}, "PENDING"},
+		{"fallback used when no head", nil, &glabPipeline{Status: "success"}, "SUCCESS"},
+		{"case insensitive", &glabPipeline{Status: "Success"}, nil, "SUCCESS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pipelineStatus(tt.head, tt.fallback); got != tt.want {
+				t.Errorf("pipelineStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApprovalDecision(t *testing.T) {
+	approvedBy := func(n int) glabApprovals {
+		a := glabApprovals{}
+		a.ApprovedBy = make([]struct {
+			User struct {
+				Username string `json:"username"`
+			} `json:"user"`
+		}, n)
+		return a
+	}
+	tests := []struct {
+		name string
+		ap   glabApprovals
+		want string
+	}{
+		{"explicit approved flag", glabApprovals{Approved: true}, "APPROVED"},
+		{"rule satisfied", glabApprovals{ApprovalsRequired: 2, ApprovalsLeft: 0}, "APPROVED"},
+		{"rule not satisfied", glabApprovals{ApprovalsRequired: 2, ApprovalsLeft: 1}, ""},
+		{"no rule, no approvals", glabApprovals{}, ""},
+		{"no rule, one approval", approvedBy(1), "APPROVED"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := approvalDecision(tt.ap); got != tt.want {
+				t.Errorf("approvalDecision() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMR(t *testing.T) {
+	t.Run("open MR with passing pipeline and conflicts", func(t *testing.T) {
+		data := []byte(`{
+			"iid": 42,
+			"title": "Add widget",
+			"web_url": "https://gitlab.com/group/sub/proj/-/merge_requests/42",
+			"state": "opened",
+			"project_id": 7,
+			"has_conflicts": true,
+			"detailed_merge_status": "conflict",
+			"blocking_discussions_resolved": false,
+			"head_pipeline": {"id": 99, "status": "running"},
+			"pipeline": {"id": 50, "status": "success"}
+		}`)
+		pr, mr, err := parseMR(data)
+		if err != nil {
+			t.Fatalf("parseMR: %v", err)
+		}
+		if pr == nil {
+			t.Fatal("parseMR returned nil PR")
+		}
+		if pr.Number != 42 || pr.Title != "Add widget" {
+			t.Errorf("number/title = %d/%q", pr.Number, pr.Title)
+		}
+		if pr.State != "OPEN" {
+			t.Errorf("state = %q, want OPEN", pr.State)
+		}
+		if pr.CIStatus != "PENDING" { // head pipeline wins
+			t.Errorf("CIStatus = %q, want PENDING", pr.CIStatus)
+		}
+		if !pr.HasConflicts {
+			t.Error("HasConflicts = false, want true")
+		}
+		if pr.UnresolvedThreads != 1 {
+			t.Errorf("UnresolvedThreads = %d, want 1", pr.UnresolvedThreads)
+		}
+		if pr.Forge != "gitlab" {
+			t.Errorf("Forge = %q, want gitlab", pr.Forge)
+		}
+		if pr.ReviewDecision != "" {
+			t.Errorf("ReviewDecision = %q, want empty (set separately)", pr.ReviewDecision)
+		}
+		if mr.ProjectID != 7 {
+			t.Errorf("ProjectID = %d, want 7", mr.ProjectID)
+		}
+	})
+
+	t.Run("merged MR, resolved discussions, no conflicts", func(t *testing.T) {
+		data := []byte(`{
+			"iid": 3,
+			"title": "Fix typo",
+			"web_url": "https://gitlab.com/x/y/-/merge_requests/3",
+			"state": "merged",
+			"project_id": 1,
+			"blocking_discussions_resolved": true,
+			"pipeline": {"id": 1, "status": "success"}
+		}`)
+		pr, _, err := parseMR(data)
+		if err != nil {
+			t.Fatalf("parseMR: %v", err)
+		}
+		if pr.State != "MERGED" || pr.CIStatus != "SUCCESS" || pr.HasConflicts || pr.UnresolvedThreads != 0 {
+			t.Errorf("unexpected pr: %+v", pr)
+		}
+	})
+
+	t.Run("empty payload -> nil", func(t *testing.T) {
+		pr, _, err := parseMR([]byte(`{}`))
+		if err != nil {
+			t.Fatalf("parseMR: %v", err)
+		}
+		if pr != nil {
+			t.Errorf("expected nil PR, got %+v", pr)
+		}
+	})
+
+	t.Run("garbage -> error", func(t *testing.T) {
+		if _, _, err := parseMR([]byte("not json")); err == nil {
+			t.Error("expected error for invalid JSON")
+		}
+	})
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -67,6 +67,12 @@ type Session struct {
 	tmuxSession  *tmux.Session
 	paneCapturer PaneCapturer // optional override for testing; if nil, uses tmuxSession
 	mu           sync.RWMutex
+
+	// Preferred tmux window size — used when starting/restarting the underlying
+	// tmux session so Claude wraps to fleet's preview pane width. The UI keeps
+	// this in sync via SetPreferredSize when the terminal resizes.
+	preferredCols int
+	preferredRows int
 }
 
 // NewSession creates a new session for the given project path.
@@ -104,11 +110,43 @@ func (s *Session) sessionEnv() []string {
 	}
 }
 
+// SetPreferredSize records the preview-pane size that future tmux starts should
+// match, and resizes the live tmux session if one already exists. Safe to call
+// from the UI goroutine; the tmux command itself is short and best-effort, but
+// callers that care about UI latency should run it from a background goroutine.
+func (s *Session) SetPreferredSize(cols, rows int) {
+	if cols <= 0 || rows <= 0 {
+		return
+	}
+	s.mu.Lock()
+	s.preferredCols = cols
+	s.preferredRows = rows
+	ts := s.tmuxSession
+	s.mu.Unlock()
+	if ts == nil {
+		return
+	}
+	ts.Cols = cols
+	ts.Rows = rows
+	_ = ts.ResizeWindow(cols, rows)
+}
+
+// applyPreferredSizeLocked copies the preferred size onto the tmux session
+// handle so the next Start call uses it. Must be called with s.mu held.
+func (s *Session) applyPreferredSizeLocked() {
+	if s.tmuxSession == nil {
+		return
+	}
+	s.tmuxSession.Cols = s.preferredCols
+	s.tmuxSession.Rows = s.preferredRows
+}
+
 // Start launches the Claude Code session in tmux.
 func (s *Session) Start() error {
 	debuglog.Logger.Info("session start", "id", s.ID, "title", s.Title, "path", s.ProjectPath)
 	s.mu.Lock()
 	s.Status = StatusStarting
+	s.applyPreferredSizeLocked()
 	s.mu.Unlock()
 
 	cmd := s.buildClaudeCmd()
@@ -272,6 +310,7 @@ func (s *Session) Restart() error {
 	s.TmuxSessionName = newTmux.Name
 	s.Status = StatusStarting
 	s.deathRecorded = false
+	s.applyPreferredSizeLocked()
 	s.mu.Unlock()
 
 	cmd := s.buildClaudeCmd()

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -53,6 +53,7 @@ type Session struct {
 	FirstPrompt           string
 	TitleGenerated        bool
 	PromptCount           int
+	SortKey               int64  // Sidebar reorder key. Default 0 ties on created_at (legacy order); non-zero values place the session explicitly.
 	ForkFromID            string // Transient: if set, start with --resume <id> --fork-session (cleared after start)
 
 	hookStatus       string
@@ -741,6 +742,7 @@ func (s *Session) ToRow() *SessionRow {
 		FirstPrompt:     s.FirstPrompt,
 		TitleGenerated:  s.TitleGenerated,
 		PromptCount:     s.PromptCount,
+		SortKey:         s.SortKey,
 	}
 }
 
@@ -811,6 +813,7 @@ func FromRow(row *SessionRow) *Session {
 		FirstPrompt:     row.FirstPrompt,
 		TitleGenerated:  row.TitleGenerated,
 		PromptCount:     row.PromptCount,
+		SortKey:         row.SortKey,
 		tmuxSession:     ts,
 	}
 }

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -32,6 +32,7 @@ type SessionRow struct {
 	FirstPrompt     string
 	TitleGenerated  bool
 	PromptCount     int
+	SortKey         int64
 }
 
 // DefaultDBPath returns the default database path.
@@ -152,6 +153,18 @@ func (s *StateDB) migrate() error {
 		}
 	}
 
+	// Add sort_key column if missing. Default 0 means "no explicit order" — rows
+	// tie on sort_key and fall through to created_at, matching the pre-feature
+	// load order so existing installations don't see their sidebar reshuffle on
+	// upgrade. Non-zero keys are seeded the first time a user reorders a pair.
+	if !s.hasColumn("sessions", "sort_key") {
+		_, err = s.db.Exec(`ALTER TABLE sessions ADD COLUMN sort_key INTEGER NOT NULL DEFAULT 0`)
+		if err != nil {
+			debuglog.Logger.Error("migration failed: add sort_key column", "error", err)
+			return err
+		}
+	}
+
 	_, err = s.db.Exec(`
 		CREATE TABLE IF NOT EXISTS slot_bindings (
 			slot_number INTEGER PRIMARY KEY CHECK (slot_number BETWEEN 0 AND 9),
@@ -168,6 +181,18 @@ func (s *StateDB) migrate() error {
 	_, err = s.db.Exec(`CREATE TABLE IF NOT EXISTS pinned_repos (repo_path TEXT PRIMARY KEY)`)
 	if err != nil {
 		debuglog.Logger.Error("migration failed: create pinned_repos table", "error", err)
+		return err
+	}
+
+	// Repo order table for user-controlled sidebar group ordering. Repos absent
+	// from this table fall back to alphabetical (matching pre-feature behaviour);
+	// the first user reorder seeds the affected pair with explicit keys.
+	_, err = s.db.Exec(`CREATE TABLE IF NOT EXISTS repo_order (
+		repo_path TEXT PRIMARY KEY,
+		sort_key  INTEGER NOT NULL
+	)`)
+	if err != nil {
+		debuglog.Logger.Error("migration failed: create repo_order table", "error", err)
 		return err
 	}
 
@@ -199,14 +224,14 @@ func (s *StateDB) hasColumn(table, column string) bool {
 // SaveSession inserts or replaces a session row.
 func (s *StateDB) SaveSession(row *SessionRow) error {
 	_, err := s.db.Exec(`
-		INSERT OR REPLACE INTO sessions (id, title, project_path, status, tmux_session, created_at, last_accessed, acknowledged, claude_session_id, workspace_name, manually_renamed, first_prompt, title_generated, prompt_count)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT OR REPLACE INTO sessions (id, title, project_path, status, tmux_session, created_at, last_accessed, acknowledged, claude_session_id, workspace_name, manually_renamed, first_prompt, title_generated, prompt_count, sort_key)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		row.ID, row.Title, row.ProjectPath, row.Status, row.TmuxSession,
 		row.CreatedAt.Unix(), row.LastAccessed.Unix(), boolToInt(row.Acknowledged),
 		row.ClaudeSessionID, row.WorkspaceName,
 		boolToInt(row.ManuallyRenamed), row.FirstPrompt, boolToInt(row.TitleGenerated),
-		row.PromptCount,
+		row.PromptCount, row.SortKey,
 	)
 	if err != nil {
 		debuglog.Logger.Error("failed to save session", "id", row.ID, "error", err)
@@ -214,11 +239,13 @@ func (s *StateDB) SaveSession(row *SessionRow) error {
 	return err
 }
 
-// LoadSessions returns all sessions ordered by creation time.
+// LoadSessions returns all sessions ordered by (sort_key, created_at). Rows
+// with the default sort_key of 0 tie and fall through to created_at, so
+// pre-feature databases load in the same order as before.
 func (s *StateDB) LoadSessions() ([]*SessionRow, error) {
 	rows, err := s.db.Query(`
-		SELECT id, title, project_path, status, tmux_session, created_at, last_accessed, acknowledged, claude_session_id, workspace_name, manually_renamed, first_prompt, title_generated, prompt_count
-		FROM sessions ORDER BY created_at
+		SELECT id, title, project_path, status, tmux_session, created_at, last_accessed, acknowledged, claude_session_id, workspace_name, manually_renamed, first_prompt, title_generated, prompt_count, sort_key
+		FROM sessions ORDER BY sort_key, created_at
 	`)
 	if err != nil {
 		debuglog.Logger.Error("failed to query sessions", "error", err)
@@ -231,7 +258,7 @@ func (s *StateDB) LoadSessions() ([]*SessionRow, error) {
 		var r SessionRow
 		var createdAt, lastAccessed int64
 		var ack, manuallyRenamed, titleGenerated int
-		if err := rows.Scan(&r.ID, &r.Title, &r.ProjectPath, &r.Status, &r.TmuxSession, &createdAt, &lastAccessed, &ack, &r.ClaudeSessionID, &r.WorkspaceName, &manuallyRenamed, &r.FirstPrompt, &titleGenerated, &r.PromptCount); err != nil {
+		if err := rows.Scan(&r.ID, &r.Title, &r.ProjectPath, &r.Status, &r.TmuxSession, &createdAt, &lastAccessed, &ack, &r.ClaudeSessionID, &r.WorkspaceName, &manuallyRenamed, &r.FirstPrompt, &titleGenerated, &r.PromptCount, &r.SortKey); err != nil {
 			debuglog.Logger.Error("failed to scan session row", "error", err)
 			return nil, err
 		}
@@ -436,6 +463,61 @@ func (s *StateDB) LoadPinnedRepos() ([]string, error) {
 		repos = append(repos, path)
 	}
 	return repos, rows.Err()
+}
+
+// UpdateSessionSortKey sets the sort_key for a session. Used by the sidebar
+// reorder shortcut to persist explicit ordering. Sessions with sort_key 0
+// (the default) sort by created_at, matching legacy behaviour.
+func (s *StateDB) UpdateSessionSortKey(id string, key int64) error {
+	_, err := s.db.Exec("UPDATE sessions SET sort_key = ? WHERE id = ?", key, id)
+	if err != nil {
+		debuglog.Logger.Error("failed to update session sort_key", "id", id, "sort_key", key, "error", err)
+	}
+	return err
+}
+
+// UpsertRepoOrder sets the sort_key for a repo path (insert if missing).
+func (s *StateDB) UpsertRepoOrder(repoPath string, key int64) error {
+	_, err := s.db.Exec(`
+		INSERT INTO repo_order (repo_path, sort_key) VALUES (?, ?)
+		ON CONFLICT(repo_path) DO UPDATE SET sort_key = excluded.sort_key
+	`, repoPath, key)
+	if err != nil {
+		debuglog.Logger.Error("failed to upsert repo_order", "repo", repoPath, "sort_key", key, "error", err)
+	}
+	return err
+}
+
+// DeleteRepoOrder removes a repo's explicit ordering (falls back to alphabetical).
+func (s *StateDB) DeleteRepoOrder(repoPath string) error {
+	_, err := s.db.Exec("DELETE FROM repo_order WHERE repo_path = ?", repoPath)
+	if err != nil {
+		debuglog.Logger.Error("failed to delete repo_order", "repo", repoPath, "error", err)
+	}
+	return err
+}
+
+// LoadRepoOrder returns the repo_path → sort_key map for user-ordered repos.
+// Repos absent from the map sort alphabetically (legacy behaviour).
+func (s *StateDB) LoadRepoOrder() (map[string]int64, error) {
+	rows, err := s.db.Query("SELECT repo_path, sort_key FROM repo_order")
+	if err != nil {
+		debuglog.Logger.Error("failed to load repo_order", "error", err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]int64)
+	for rows.Next() {
+		var path string
+		var key int64
+		if err := rows.Scan(&path, &key); err != nil {
+			debuglog.Logger.Error("failed to scan repo_order row", "error", err)
+			return nil, err
+		}
+		out[path] = key
+	}
+	return out, rows.Err()
 }
 
 func boolToInt(b bool) int {

--- a/internal/session/storage_test.go
+++ b/internal/session/storage_test.go
@@ -571,6 +571,7 @@ func TestMigrationIdempotent(t *testing.T) {
 		ProjectPath: "/tmp/project",
 		Status:      "idle",
 		CreatedAt:   now,
+		SortKey:     7,
 	}
 	if err := db2.SaveSession(row); err != nil {
 		t.Fatalf("SaveSession after re-migration failed: %v", err)
@@ -582,6 +583,183 @@ func TestMigrationIdempotent(t *testing.T) {
 	}
 	if len(sessions) != 1 {
 		t.Errorf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].SortKey != 7 {
+		t.Errorf("SortKey: got %d, want 7", sessions[0].SortKey)
+	}
+
+	// repo_order table should also persist across reopen.
+	if err := db2.UpsertRepoOrder("/tmp/r", 42); err != nil {
+		t.Fatalf("UpsertRepoOrder after re-migration failed: %v", err)
+	}
+	order, err := db2.LoadRepoOrder()
+	if err != nil {
+		t.Fatalf("LoadRepoOrder after re-migration failed: %v", err)
+	}
+	if order["/tmp/r"] != 42 {
+		t.Errorf("LoadRepoOrder: /tmp/r got %d, want 42", order["/tmp/r"])
+	}
+}
+
+func TestSessionSortKeyRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().Truncate(time.Second)
+	row := &SessionRow{
+		ID:          "sk-test",
+		Title:       "Sort Key Test",
+		ProjectPath: "/tmp/p",
+		Status:      "idle",
+		CreatedAt:   now,
+		SortKey:     12345,
+	}
+	if err := db.SaveSession(row); err != nil {
+		t.Fatalf("SaveSession failed: %v", err)
+	}
+
+	sessions, err := db.LoadSessions()
+	if err != nil {
+		t.Fatalf("LoadSessions failed: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].SortKey != 12345 {
+		t.Errorf("SortKey: got %d, want 12345", sessions[0].SortKey)
+	}
+
+	// UpdateSessionSortKey should persist a new value.
+	if err := db.UpdateSessionSortKey("sk-test", 999); err != nil {
+		t.Fatalf("UpdateSessionSortKey failed: %v", err)
+	}
+	sessions, err = db.LoadSessions()
+	if err != nil {
+		t.Fatalf("LoadSessions failed: %v", err)
+	}
+	if sessions[0].SortKey != 999 {
+		t.Errorf("after update, SortKey: got %d, want 999", sessions[0].SortKey)
+	}
+}
+
+func TestLoadSessionsRespectsSortKeyThenCreated(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now()
+	rows := []*SessionRow{
+		{ID: "old", Title: "old", ProjectPath: "/p", Status: "idle", CreatedAt: now, SortKey: 0},
+		{ID: "new", Title: "new", ProjectPath: "/p", Status: "idle", CreatedAt: now.Add(time.Second), SortKey: 0},
+		{ID: "explicit", Title: "explicit", ProjectPath: "/p", Status: "idle", CreatedAt: now.Add(2 * time.Second), SortKey: 5},
+	}
+	for _, r := range rows {
+		if err := db.SaveSession(r); err != nil {
+			t.Fatalf("SaveSession %q: %v", r.ID, err)
+		}
+	}
+
+	sessions, err := db.LoadSessions()
+	if err != nil {
+		t.Fatalf("LoadSessions: %v", err)
+	}
+	if len(sessions) != 3 {
+		t.Fatalf("expected 3 sessions, got %d", len(sessions))
+	}
+	// sort_key=0 ties → ordered by created_at: old, new.
+	// sort_key=5 sorts after.
+	wantOrder := []string{"old", "new", "explicit"}
+	for i, want := range wantOrder {
+		if sessions[i].ID != want {
+			t.Errorf("position %d: got %q, want %q (full order: %v)", i, sessions[i].ID, want,
+				[]string{sessions[0].ID, sessions[1].ID, sessions[2].ID})
+		}
+	}
+
+	// Move "old" into the middle with sort_key=3 — it should now slot between
+	// the sort_key=0 group ("new") and the sort_key=5 entry ("explicit").
+	if err := db.UpdateSessionSortKey("old", 3); err != nil {
+		t.Fatalf("UpdateSessionSortKey: %v", err)
+	}
+	sessions, err = db.LoadSessions()
+	if err != nil {
+		t.Fatalf("LoadSessions after update: %v", err)
+	}
+	wantOrder = []string{"new", "old", "explicit"}
+	for i, want := range wantOrder {
+		if sessions[i].ID != want {
+			t.Errorf("after update, position %d: got %q, want %q (full order: %v)", i, sessions[i].ID, want,
+				[]string{sessions[0].ID, sessions[1].ID, sessions[2].ID})
+		}
+	}
+}
+
+func TestRepoOrder(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	// Initial: empty map (not nil — caller can iterate without a nil check).
+	order, err := db.LoadRepoOrder()
+	if err != nil {
+		t.Fatalf("LoadRepoOrder: %v", err)
+	}
+	if len(order) != 0 {
+		t.Errorf("expected empty repo_order, got %v", order)
+	}
+
+	// Upsert two entries.
+	if err := db.UpsertRepoOrder("/tmp/a", 100); err != nil {
+		t.Fatalf("UpsertRepoOrder /tmp/a: %v", err)
+	}
+	if err := db.UpsertRepoOrder("/tmp/b", 200); err != nil {
+		t.Fatalf("UpsertRepoOrder /tmp/b: %v", err)
+	}
+	order, _ = db.LoadRepoOrder()
+	if order["/tmp/a"] != 100 || order["/tmp/b"] != 200 {
+		t.Errorf("unexpected order: %v", order)
+	}
+
+	// Upsert again with new key — should overwrite (ON CONFLICT DO UPDATE).
+	if err := db.UpsertRepoOrder("/tmp/a", 300); err != nil {
+		t.Fatalf("UpsertRepoOrder rewrite: %v", err)
+	}
+	order, _ = db.LoadRepoOrder()
+	if order["/tmp/a"] != 300 {
+		t.Errorf("expected /tmp/a=300 after rewrite, got %d", order["/tmp/a"])
+	}
+
+	// Delete an entry.
+	if err := db.DeleteRepoOrder("/tmp/a"); err != nil {
+		t.Fatalf("DeleteRepoOrder: %v", err)
+	}
+	order, _ = db.LoadRepoOrder()
+	if _, ok := order["/tmp/a"]; ok {
+		t.Errorf("expected /tmp/a to be deleted, got %v", order)
+	}
+	if order["/tmp/b"] != 200 {
+		t.Errorf("/tmp/b should still be 200, got %d", order["/tmp/b"])
+	}
+
+	// DeleteRepoOrder on a missing key should be a no-op (no error).
+	if err := db.DeleteRepoOrder("/does/not/exist"); err != nil {
+		t.Errorf("DeleteRepoOrder on missing key: %v", err)
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -32,6 +32,13 @@ type Session struct {
 	DisplayName string
 	WorkDir     string
 
+	// Cols/Rows: initial window size for Start. Zero values fall back to tmux's
+	// default (host terminal at server-start time, which is usually wrong for
+	// fleet — the UI sets these to the preview-pane size so Claude wraps to
+	// fit). After creation, ResizeWindow keeps them in sync.
+	Cols int
+	Rows int
+
 	cacheMu      sync.RWMutex
 	cacheContent string
 	cacheTime    time.Time
@@ -77,9 +84,16 @@ func ReconnectSession(tmuxName, displayName, workDir string) *Session {
 // Start creates a detached tmux session and runs the given command.
 // Optional env vars are set at the tmux session level via -e flags,
 // inherited by the shell and all child processes (avoids race with shell plugins).
+//
+// If s.Cols and s.Rows are both > 0, the new window is created at that size so
+// Claude wraps to fit the fleet preview pane instead of inheriting whatever
+// width tmux's server first booted at.
 func (s *Session) Start(command string, env ...string) error {
 	// Create detached session.
 	args := []string{"new-session", "-d", "-s", s.Name, "-c", s.WorkDir}
+	if s.Cols > 0 && s.Rows > 0 {
+		args = append(args, "-x", fmt.Sprintf("%d", s.Cols), "-y", fmt.Sprintf("%d", s.Rows))
+	}
 	for _, e := range env {
 		args = append(args, "-e", e)
 	}
@@ -266,6 +280,31 @@ func (s *Session) Kill() error {
 	delete(sessionCacheData, s.Name)
 	sessionCacheMu.Unlock()
 
+	return nil
+}
+
+// ResizeWindow resizes the session's window to (cols × rows). Used to keep
+// tmux's pane matched to fleet's preview pane width so Claude's output isn't
+// wider than what fleet renders. Also called before/after attach so the user
+// sees a full-terminal-size pane while attached.
+//
+// Returns nil if cols/rows are non-positive (caller convenience — UI computes
+// dimensions from terminal size and may produce zero before the first
+// WindowSizeMsg). Updates s.Cols/s.Rows so subsequent Start/restart use the
+// same size.
+func (s *Session) ResizeWindow(cols, rows int) error {
+	if cols <= 0 || rows <= 0 {
+		return nil
+	}
+	s.Cols = cols
+	s.Rows = rows
+	cmd := exec.Command("tmux", "resize-window", "-t", s.Name, "-x", fmt.Sprintf("%d", cols), "-y", fmt.Sprintf("%d", rows))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		// Best-effort: a missing session (just-killed, race with cleanup) is
+		// not a real error, but log other failures.
+		debuglog.Logger.Debug("tmux resize-window failed", "session", s.Name, "cols", cols, "rows", rows, "err", err, "out", strings.TrimSpace(string(output)))
+		return fmt.Errorf("tmux resize-window failed: %w", err)
+	}
 	return nil
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1732,6 +1732,148 @@ func (h *Home) focusTick() tea.Cmd {
 	})
 }
 
+// focusKeySend is one tmux send-keys invocation produced for a focused-pane
+// keypress. When literal is true the value is sent verbatim (`send-keys -l`);
+// otherwise it is a tmux key name, optionally with an "M-"/"C-" modifier
+// prefix (`send-keys`).
+type focusKeySend struct {
+	literal bool
+	val     string
+}
+
+// allASCIILetters reports whether rs is non-empty and every rune is an ASCII
+// letter — i.e. safe to embed in a tmux "M-<rune>" key name without tripping
+// the control-mode command parser.
+func allASCIILetters(rs []rune) bool {
+	if len(rs) == 0 {
+		return false
+	}
+	for _, r := range rs {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')) {
+			return false
+		}
+	}
+	return true
+}
+
+// translateFocusKey maps a bubbletea key event onto the tmux send-keys
+// invocation(s) needed to reproduce it inside the focused session. It returns
+// (nil, true) when the key should instead exit focus mode (Esc).
+//
+// Modified keys must keep their modifier: Alt/Meta keys go through with the
+// tmux "M-" prefix (M-BSpace, M-Left, M-a, ...) so word-wise line editing
+// works in the focused pane instead of degrading to an unmodified keypress.
+// Alt+<non-letter rune> can't safely use "M-<rune>" (tmux's command parser
+// treats `;`, quotes, `#`, ... specially), so it falls back to ESC followed by
+// the rune sent literally.
+func translateFocusKey(msg tea.KeyMsg) (sends []focusKeySend, unfocus bool) {
+	if msg.Type == tea.KeyEsc {
+		return nil, true
+	}
+	named := func(v string) []focusKeySend { return []focusKeySend{{val: v}} }
+
+	if msg.Alt {
+		switch msg.Type {
+		case tea.KeyRunes:
+			if allASCIILetters(msg.Runes) {
+				for _, r := range msg.Runes {
+					sends = append(sends, focusKeySend{val: "M-" + string(r)})
+				}
+				return sends, false
+			}
+			// ESC then the rune(s) sent literally (-l → quoteTmux), which is
+			// what Alt+<rune> is at the terminal level anyway.
+			return []focusKeySend{{val: "Escape"}, {literal: true, val: string(msg.Runes)}}, false
+		case tea.KeyBackspace:
+			return named("M-BSpace"), false
+		case tea.KeyDelete:
+			return named("M-DC"), false
+		case tea.KeyLeft:
+			return named("M-Left"), false
+		case tea.KeyRight:
+			return named("M-Right"), false
+		case tea.KeyUp:
+			return named("M-Up"), false
+		case tea.KeyDown:
+			return named("M-Down"), false
+		case tea.KeyEnter:
+			return named("M-Enter"), false
+		default:
+			// Alt+X == ESC then X: emit Escape, then translate the bare key.
+			rest, _ := translateFocusKey(tea.KeyMsg{Type: msg.Type, Runes: msg.Runes})
+			return append(named("Escape"), rest...), false
+		}
+	}
+
+	switch msg.Type {
+	case tea.KeyEnter:
+		return named("Enter"), false
+	case tea.KeyBackspace:
+		return named("BSpace"), false
+	case tea.KeyTab:
+		return named("Tab"), false
+	case tea.KeyShiftTab:
+		return named("BTab"), false
+	case tea.KeySpace:
+		return named("Space"), false
+	case tea.KeyUp:
+		return named("Up"), false
+	case tea.KeyDown:
+		return named("Down"), false
+	case tea.KeyLeft:
+		return named("Left"), false
+	case tea.KeyRight:
+		return named("Right"), false
+	case tea.KeyCtrlLeft:
+		return named("C-Left"), false
+	case tea.KeyCtrlRight:
+		return named("C-Right"), false
+	case tea.KeyCtrlUp:
+		return named("C-Up"), false
+	case tea.KeyCtrlDown:
+		return named("C-Down"), false
+	case tea.KeyHome:
+		return named("Home"), false
+	case tea.KeyEnd:
+		return named("End"), false
+	case tea.KeyPgUp:
+		return named("PageUp"), false
+	case tea.KeyPgDown:
+		return named("PageDown"), false
+	case tea.KeyDelete:
+		return named("DC"), false
+	case tea.KeyCtrlC:
+		return named("C-c"), false
+	case tea.KeyCtrlD:
+		return named("C-d"), false
+	case tea.KeyCtrlA:
+		return named("C-a"), false
+	case tea.KeyCtrlU:
+		return named("C-u"), false
+	case tea.KeyCtrlL:
+		return named("C-l"), false
+	case tea.KeyCtrlW:
+		return named("C-w"), false
+	case tea.KeyCtrlK:
+		return named("C-k"), false
+	case tea.KeyRunes:
+		return []focusKeySend{{literal: true, val: string(msg.Runes)}}, false
+	default:
+		if str := msg.String(); str != "" {
+			return []focusKeySend{{literal: true, val: str}}, false
+		}
+		return nil, false
+	}
+}
+
+// handleFocusKey forwards a keypress to the focused session's tmux pane, or
+// exits focus mode on Esc.
+//
+// The tmux sends run synchronously here rather than from a tea.Cmd on purpose:
+// Bubble Tea processes KeyMsgs sequentially, so staying in Update() keeps
+// forwarded keystrokes in order — concurrent tea.Cmds would not preserve that.
+// Each send is a sub-millisecond write to the long-lived `tmux -C` control
+// client, not a shell-out.
 func (h *Home) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	s := h.selectedSession()
 	if s == nil || !s.IsAlive() {
@@ -1740,7 +1882,8 @@ func (h *Home) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 	}
 
-	if msg.Type == tea.KeyEsc {
+	sends, unfocus := translateFocusKey(msg)
+	if unfocus {
 		h.focusMode = false
 		h.sidebarDirty = true
 		h.actionLog.Add("unfocus preview", s.Title, true)
@@ -1756,53 +1899,11 @@ func (h *Home) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	target := s.GetTmuxSession().Name
-
-	switch msg.Type {
-	case tea.KeyEnter:
-		cc.SendKeys(target, "Enter")
-	case tea.KeyBackspace:
-		cc.SendKeys(target, "BSpace")
-	case tea.KeyTab:
-		cc.SendKeys(target, "Tab")
-	case tea.KeySpace:
-		cc.SendKeys(target, "Space")
-	case tea.KeyUp:
-		cc.SendKeys(target, "Up")
-	case tea.KeyDown:
-		cc.SendKeys(target, "Down")
-	case tea.KeyLeft:
-		cc.SendKeys(target, "Left")
-	case tea.KeyRight:
-		cc.SendKeys(target, "Right")
-	case tea.KeyHome:
-		cc.SendKeys(target, "Home")
-	case tea.KeyEnd:
-		cc.SendKeys(target, "End")
-	case tea.KeyPgUp:
-		cc.SendKeys(target, "PageUp")
-	case tea.KeyPgDown:
-		cc.SendKeys(target, "PageDown")
-	case tea.KeyDelete:
-		cc.SendKeys(target, "DC")
-	case tea.KeyCtrlC:
-		cc.SendKeys(target, "C-c")
-	case tea.KeyCtrlD:
-		cc.SendKeys(target, "C-d")
-	case tea.KeyCtrlA:
-		cc.SendKeys(target, "C-a")
-	case tea.KeyCtrlU:
-		cc.SendKeys(target, "C-u")
-	case tea.KeyCtrlL:
-		cc.SendKeys(target, "C-l")
-	case tea.KeyCtrlW:
-		cc.SendKeys(target, "C-w")
-	case tea.KeyCtrlK:
-		cc.SendKeys(target, "C-k")
-	case tea.KeyRunes:
-		cc.SendLiteralKeys(target, string(msg.Runes))
-	default:
-		if str := msg.String(); str != "" {
-			cc.SendLiteralKeys(target, str)
+	for _, sk := range sends {
+		if sk.literal {
+			cc.SendLiteralKeys(target, sk.val)
+		} else {
+			cc.SendKeys(target, sk.val)
 		}
 	}
 	return h, nil

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -17,8 +17,8 @@ import (
 	"github.com/brizzai/fleet/internal/chrome"
 	"github.com/brizzai/fleet/internal/config"
 	"github.com/brizzai/fleet/internal/debuglog"
+	"github.com/brizzai/fleet/internal/forge"
 	"github.com/brizzai/fleet/internal/git"
-	"github.com/brizzai/fleet/internal/github"
 	"github.com/brizzai/fleet/internal/hooks"
 	"github.com/brizzai/fleet/internal/naming"
 	"github.com/brizzai/fleet/internal/perfwatch"
@@ -85,7 +85,6 @@ type (
 	loadSessionsMsg struct {
 		sessions     []*session.Session
 		slotBindings map[int]string
-		ghAvailable  bool
 		warning      string
 		err          error
 	}
@@ -151,9 +150,9 @@ type Home struct {
 	previewCacheTime map[string]time.Time
 	statusRRIndex    int // round-robin index for status updates
 
-	gitInfoCache map[string]*git.RepoInfo // repo root path -> git info
-	gitRRIndex   int                      // round-robin index for git refresh
-	ghAvailable  bool                     // cached gh CLI availability
+	gitInfoCache map[string]*git.RepoInfo  // repo root path -> git info
+	gitRRIndex   int                       // round-robin index for git refresh
+	repoForge    map[string]forge.Provider // repo root path -> forge provider (nil = none); worker-only, populated lazily
 
 	hookWatcher *hooks.HookWatcher
 
@@ -236,6 +235,7 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string) *Home
 		previewCache:          make(map[string]string),
 		previewCacheTime:      make(map[string]time.Time),
 		gitInfoCache:          make(map[string]*git.RepoInfo),
+		repoForge:             make(map[string]forge.Provider),
 		filterInput:           fi,
 		cfg:                   cfg,
 		version:               version,
@@ -688,7 +688,6 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.repoExpanded[repo] = true
 			}
 		}
-		h.ghAvailable = msg.ghAvailable
 		h.rebuildFlatItems()
 		if len(h.flatItems) > 0 && h.cursor == 0 {
 			h.cursor = FirstSelectableItem(h.flatItems)
@@ -1883,6 +1882,10 @@ func (h *Home) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	sends, unfocus := translateFocusKey(msg)
+	debuglog.Logger.Debug("focus key",
+		"type", int(msg.Type), "typeStr", msg.Type.String(), "alt", msg.Alt,
+		"runes", string(msg.Runes), "string", msg.String(),
+		"sends", fmt.Sprintf("%+v", sends), "unfocus", unfocus)
 	if unfocus {
 		h.focusMode = false
 		h.sidebarDirty = true
@@ -2493,8 +2496,14 @@ drainPriority:
 		}
 		h.workerMu.Unlock()
 
-		if h.ghAvailable && (info.LastPRRefresh.IsZero() || time.Since(info.LastPRRefresh) > 60*time.Second) {
-			git.RefreshPRInfo(info, repo, workspace.IgnorePatterns(repo))
+		// Resolve the repo's forge once, then cache it (worker-only map).
+		provider, seen := h.repoForge[repo]
+		if !seen {
+			provider = detectForge(repo)
+			h.repoForge[repo] = provider
+		}
+		if provider != nil && (info.LastPRRefresh.IsZero() || time.Since(info.LastPRRefresh) > 60*time.Second) {
+			git.RefreshPRInfo(info, repo, workspace.IgnorePatterns(repo), provider)
 		}
 
 		h.workerMu.Lock()
@@ -2920,7 +2929,6 @@ func (h *Home) loadSessions() tea.Msg {
 	configDir := hooks.GetClaudeConfigDir()
 	hooks.InjectClaudeHooks(configDir)
 	chrome.InstallNativeMessagingHost()
-	ghAvailable := github.IsGHAvailable()
 
 	// Check for claude CLI availability.
 	var warning string
@@ -2928,7 +2936,7 @@ func (h *Home) loadSessions() tea.Msg {
 		warning = "claude CLI not found — install Claude Code to create sessions"
 	}
 
-	return loadSessionsMsg{sessions: sessions, slotBindings: slotBindings, ghAvailable: ghAvailable, warning: warning}
+	return loadSessionsMsg{sessions: sessions, slotBindings: slotBindings, warning: warning}
 }
 
 func (h *Home) setError(err error) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -86,6 +86,7 @@ type (
 	loadSessionsMsg struct {
 		sessions     []*session.Session
 		slotBindings map[int]string
+		repoOrder    map[string]int64
 		warning      string
 		err          error
 	}
@@ -144,7 +145,8 @@ type Home struct {
 	// running. Quit drains both this list and pendingDeletes so an in-flight
 	// kill isn't lost when fleet exits mid-cleanup.
 	finalizingDeletes []PendingDelete
-	pinnedRepos       map[string]bool // pinned repo paths (persist in SQLite)
+	pinnedRepos       map[string]bool  // pinned repo paths (persist in SQLite)
+	repoOrder         map[string]int64 // repo path -> explicit sort key (persist in SQLite); missing = alphabetical fallback
 
 	repoExpanded     map[string]bool // repo path -> expanded state
 	previewCache     map[string]string
@@ -223,6 +225,7 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string) *Home
 		lastSlotTapSlot:       -1,
 		toasts:                NewToastStack(),
 		pinnedRepos:           make(map[string]bool),
+		repoOrder:             make(map[string]int64),
 		newDialog:             NewNewSessionDialog(),
 		confirmDialog:         NewConfirmDialog(),
 		renameDialog:          NewRenameDialog(),
@@ -684,6 +687,11 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.pinnedRepos[p] = true
 			}
 		}
+		// Adopt user-controlled repo order (path → explicit sort_key). Repos absent
+		// from this map sort alphabetically in BuildFlatItems.
+		if msg.repoOrder != nil {
+			h.repoOrder = msg.repoOrder
+		}
 		// Default all repos to expanded on first load.
 		groups := session.GroupByRepo(h.sessions)
 		for repo := range groups {
@@ -1070,6 +1078,12 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.cursor = target
 		h.syncViewport()
 		return h, h.fetchPreviewForSelected()
+	case "shift+down":
+		h.moveCursorItem(1)
+		return h, h.fetchPreviewForSelected()
+	case "shift+up":
+		h.moveCursorItem(-1)
+		return h, h.fetchPreviewForSelected()
 	case "enter":
 		// Toggle repo group or attach session.
 		if h.cursor >= 0 && h.cursor < len(h.flatItems) && h.flatItems[h.cursor].IsRepoHeader {
@@ -1142,6 +1156,15 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				delete(h.pinnedRepos, item.RepoPath)
 				if err := h.storage.UnpinRepo(item.RepoPath); err != nil {
 					debuglog.Logger.Error("failed to unpin repo", "repo", item.RepoPath, "err", err)
+				}
+				// Drop any explicit sidebar ordering for this repo so a future
+				// re-pin/re-add starts from the alphabetical fallback rather
+				// than its old slot.
+				if _, ok := h.repoOrder[item.RepoPath]; ok {
+					delete(h.repoOrder, item.RepoPath)
+					if err := h.storage.DeleteRepoOrder(item.RepoPath); err != nil {
+						debuglog.Logger.Error("failed to delete repo order", "repo", item.RepoPath, "err", err)
+					}
 				}
 				h.actionLog.Add("unpin repo", filepath.Base(item.RepoPath), true)
 				h.rebuildFlatItems()
@@ -2837,6 +2860,197 @@ func (h *Home) unbindSlot(slot int) {
 	h.sidebarDirty = true
 }
 
+// moveCursorItem reorders the item under the cursor within its parent group.
+// dir is +1 for "down" (later in the sidebar) or -1 for "up". Behaviour:
+//
+//   - Session: swap with the adjacent session inside the same repo group.
+//     Top-of-group + dir=-1 and bottom-of-group + dir=+1 are silent no-ops;
+//     reorders never migrate a session across repo boundaries.
+//   - Repo header: swap this repo's position with the neighbouring repo's.
+//     First-repo + dir=-1 and last-repo + dir=+1 are silent no-ops.
+//   - Pending phantom ("Creating…"): silent no-op.
+//   - Filter active: info toast and no mutation (reordering a filtered slice
+//     would rewrite keys for a partial view).
+//
+// All persistence happens synchronously in this handler — matches the
+// BindSlot / PinRepo pattern of writing directly from the UI goroutine.
+func (h *Home) moveCursorItem(dir int) {
+	if h.filterText != "" {
+		h.setInfo("Clear filter (Esc) to reorder")
+		return
+	}
+	if h.cursor < 0 || h.cursor >= len(h.flatItems) {
+		return
+	}
+	item := h.flatItems[h.cursor]
+	switch {
+	case item.Pending != nil:
+		// Phantom workspaces aren't persisted yet; silently ignore.
+		return
+	case item.IsRepoHeader:
+		h.moveRepoGroup(item.RepoPath, dir)
+	case item.Session != nil:
+		h.moveSessionInGroup(item.Session, dir)
+	}
+}
+
+// moveSessionInGroup swaps a session with its same-repo neighbour in the
+// given direction. Out-of-bounds moves are silent (no toast, no log) to match
+// j/k navigation feel.
+func (h *Home) moveSessionInGroup(s *session.Session, dir int) {
+	repo := session.GetRepoRoot(s.ProjectPath)
+	groupSessions := session.GroupByRepo(h.sessions)[repo]
+	idx := -1
+	for i, gs := range groupSessions {
+		if gs.ID == s.ID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return
+	}
+	other := idx + dir
+	if other < 0 || other >= len(groupSessions) {
+		return // top/bottom of group — silent no-op, do not migrate across repos
+	}
+
+	a := groupSessions[idx]
+	b := groupSessions[other]
+
+	// Compute sort_keys for the swap. If both are 0 (sentinel — never reordered
+	// before), seed them by their current position so the swap produces a stable
+	// result. Otherwise swap the existing values.
+	keyA, keyB := a.SortKey, b.SortKey
+	if keyA == 0 && keyB == 0 {
+		// Seed using slot positions, spaced so future inserts don't immediately
+		// collide. The "lower index = lower key" mapping mirrors the current
+		// (sort_key=0, created_at) order, then the swap flips them.
+		keyA = int64((idx + 1) * 100)
+		keyB = int64((other + 1) * 100)
+	}
+	// Swap: a takes b's key, b takes a's key.
+	a.SortKey, b.SortKey = keyB, keyA
+
+	if err := h.storage.UpdateSessionSortKey(a.ID, a.SortKey); err != nil {
+		h.setError(fmt.Errorf("reorder session: %w", err))
+		return
+	}
+	if err := h.storage.UpdateSessionSortKey(b.ID, b.SortKey); err != nil {
+		h.setError(fmt.Errorf("reorder session: %w", err))
+		return
+	}
+
+	// Re-sort the in-memory session list so the next rebuildFlatItems sees the
+	// same order LoadSessions would produce after a restart.
+	sort.SliceStable(h.sessions, func(i, j int) bool {
+		if h.sessions[i].SortKey != h.sessions[j].SortKey {
+			return h.sessions[i].SortKey < h.sessions[j].SortKey
+		}
+		return h.sessions[i].CreatedAt.Before(h.sessions[j].CreatedAt)
+	})
+	h.rebuildFlatItems()
+
+	// Re-anchor the cursor to the moved session.
+	for i, it := range h.flatItems {
+		if !it.IsRepoHeader && it.Session != nil && it.Session.ID == a.ID {
+			h.cursor = i
+			break
+		}
+	}
+	h.syncViewport()
+	h.actionLog.Add("reorder session", fmt.Sprintf("%s (%s)", a.Title, dirLabel(dir)), true)
+}
+
+// moveRepoGroup swaps a repo's sidebar position with the neighbour in the given
+// direction. Out-of-bounds moves are silent.
+func (h *Home) moveRepoGroup(repoPath string, dir int) {
+	// Reproduce BuildFlatItems' repo ordering: same set (sessions ∪ pending ∪
+	// pinned), same comparator. This is the authoritative "what's on screen" list.
+	repoSet := make(map[string]struct{})
+	for _, s := range h.sessions {
+		repoSet[session.GetRepoRoot(s.ProjectPath)] = struct{}{}
+	}
+	for _, pw := range h.pendingWorkspaces {
+		repoSet[pw.RepoPath] = struct{}{}
+	}
+	for r := range h.pinnedRepos {
+		repoSet[r] = struct{}{}
+	}
+	repos := make([]string, 0, len(repoSet))
+	for r := range repoSet {
+		repos = append(repos, r)
+	}
+	sort.SliceStable(repos, func(i, j int) bool {
+		ki, kj := h.repoOrder[repos[i]], h.repoOrder[repos[j]]
+		if ki != kj {
+			return ki < kj
+		}
+		return repos[i] < repos[j]
+	})
+
+	idx := -1
+	for i, r := range repos {
+		if r == repoPath {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return
+	}
+	other := idx + dir
+	if other < 0 || other >= len(repos) {
+		return // first/last repo — silent no-op
+	}
+
+	repoA := repos[idx]
+	repoB := repos[other]
+
+	// Seed sort_keys for any repo that's still on the alphabetical fallback.
+	// We compute defaults from current positions before the swap so the order
+	// from there forward is fully defined by repo_order alone.
+	keyA, hasA := h.repoOrder[repoA]
+	keyB, hasB := h.repoOrder[repoB]
+	if !hasA || keyA == 0 {
+		keyA = int64((idx + 1) * 100)
+	}
+	if !hasB || keyB == 0 {
+		keyB = int64((other + 1) * 100)
+	}
+	// Swap.
+	h.repoOrder[repoA] = keyB
+	h.repoOrder[repoB] = keyA
+
+	if err := h.storage.UpsertRepoOrder(repoA, keyB); err != nil {
+		h.setError(fmt.Errorf("reorder repo: %w", err))
+		return
+	}
+	if err := h.storage.UpsertRepoOrder(repoB, keyA); err != nil {
+		h.setError(fmt.Errorf("reorder repo: %w", err))
+		return
+	}
+
+	h.rebuildFlatItems()
+
+	// Re-anchor the cursor to the moved repo header.
+	for i, it := range h.flatItems {
+		if it.IsRepoHeader && it.RepoPath == repoA {
+			h.cursor = i
+			break
+		}
+	}
+	h.syncViewport()
+	h.actionLog.Add("reorder repo", fmt.Sprintf("%s (%s)", filepath.Base(repoA), dirLabel(dir)), true)
+}
+
+func dirLabel(dir int) string {
+	if dir < 0 {
+		return "up"
+	}
+	return "down"
+}
+
 // jumpToSlot moves the cursor to the session bound at the given slot.
 // A second press of the same slot within 400ms also attaches.
 func (h *Home) jumpToSlot(slot int) (tea.Model, tea.Cmd) {
@@ -2916,7 +3130,7 @@ func (h *Home) repoInfoFromSnap(snap map[string]*git.RepoInfo) *git.RepoInfo {
 // --- Internal helpers ---
 
 func (h *Home) rebuildFlatItems() {
-	h.flatItems = BuildFlatItems(h.sessions, h.pendingWorkspaces, h.repoExpanded, h.filterText, h.pinnedRepos)
+	h.flatItems = BuildFlatItems(h.sessions, h.pendingWorkspaces, h.repoExpanded, h.filterText, h.pinnedRepos, h.repoOrder)
 	h.sidebarDirty = true
 }
 
@@ -3036,6 +3250,12 @@ func (h *Home) loadSessions() tea.Msg {
 		slotBindings = map[int]string{}
 	}
 
+	repoOrder, err := h.storage.LoadRepoOrder()
+	if err != nil {
+		debuglog.Logger.Error("failed to load repo order", "err", err)
+		repoOrder = map[string]int64{}
+	}
+
 	// These block but run in the tea.Cmd goroutine, not Update().
 	configDir := hooks.GetClaudeConfigDir()
 	hooks.InjectClaudeHooks(configDir)
@@ -3047,7 +3267,7 @@ func (h *Home) loadSessions() tea.Msg {
 		warning = "claude CLI not found — install Claude Code to create sessions"
 	}
 
-	return loadSessionsMsg{sessions: sessions, slotBindings: slotBindings, warning: warning}
+	return loadSessionsMsg{sessions: sessions, slotBindings: slotBindings, repoOrder: repoOrder, warning: warning}
 }
 
 func (h *Home) setError(err error) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -75,8 +75,9 @@ type (
 		err error
 	}
 	sessionCreateResultMsg struct {
-		session *session.Session
-		err     error
+		session   *session.Session
+		err       error
+		autoFocus bool // attach/focus immediately after creation (per cfg.IsFocusOnNewSessionEnabled)
 	}
 	previewMsg struct {
 		sessionID string
@@ -1335,12 +1336,13 @@ func (h *Home) handleSessionCreate(msg sessionCreateMsg) (tea.Model, tea.Cmd) {
 	debuglog.Logger.Info("creating session", "title", msg.title, "path", msg.path)
 	s := session.NewSession(msg.title, msg.path)
 	s.WorkspaceName = msg.workspaceName
+	autoFocus := h.cfg.IsFocusOnNewSessionEnabled()
 	return h, func() tea.Msg {
 		if err := s.Start(); err != nil {
 			debuglog.Logger.Error("session Start() failed", "title", msg.title, "path", msg.path, "err", err)
 			return sessionCreateResultMsg{err: err}
 		}
-		return sessionCreateResultMsg{session: s}
+		return sessionCreateResultMsg{session: s, autoFocus: autoFocus}
 	}
 }
 
@@ -1381,6 +1383,19 @@ func (h *Home) handleSessionCreateResult(msg sessionCreateResultMsg) (tea.Model,
 			h.syncViewport()
 			break
 		}
+	}
+
+	// Auto-focus the freshly created session if the user opted in. Uses
+	// the existing Enter mode setting so the post-create behavior matches
+	// what pressing Enter on the session would do.
+	if msg.autoFocus {
+		if h.cfg.GetEnterMode() == "split" {
+			h.actionLog.Add("focus preview", s.Title, true)
+			return h, h.enterFocusMode()
+		}
+		h.actionLog.Add("attach session", s.Title, true)
+		analytics.Track(analytics.EventSessionAttached, nil)
+		return h, h.attachSelected()
 	}
 
 	return h, h.fetchPreviewForSelected()

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -290,6 +290,11 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.commandPalette.SetSize(msg.Width, msg.Height)
 		h.bugReport.SetSize(msg.Width, msg.Height)
 		h.syncViewport()
+		// Resize tmux sessions so Claude wraps to fit the new preview pane.
+		// Without this, capture-pane returns content wider than fleet renders
+		// and ansi.Truncate (preview.go) chops the right side off.
+		cols, rows := h.previewPaneSize()
+		h.dispatchSessionResize(cols, rows)
 		return h, nil
 
 	case tea.KeyMsg:
@@ -332,6 +337,9 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s := session.NewSession(msg.title, msg.path)
 		s.WorkspaceName = msg.workspaceName
 		s.ForkFromID = msg.parentClaudeSessionID
+		if cols, rows := h.previewPaneSize(); cols > 0 {
+			s.SetPreferredSize(cols, rows)
+		}
 		return h, func() tea.Msg {
 			if err := s.Start(); err != nil {
 				return sessionCreateResultMsg{err: err}
@@ -692,6 +700,14 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.rebuildFlatItems()
 		if len(h.flatItems) > 0 && h.cursor == 0 {
 			h.cursor = FirstSelectableItem(h.flatItems)
+		}
+
+		// Apply the current preview size to all reconnected sessions so existing
+		// tmux windows shrink to fit the preview pane on startup (without this,
+		// they stay at whatever size the tmux server first booted at, often the
+		// full host terminal width).
+		if cols, rows := h.previewPaneSize(); cols > 0 {
+			h.dispatchSessionResize(cols, rows)
 		}
 
 		// Start hook watcher.
@@ -1308,7 +1324,15 @@ func (h *Home) attachSelected() tea.Cmd {
 
 	h.isAttaching.Store(true)
 
-	return tea.Exec(attachCmd{session: s.GetTmuxSession()}, func(err error) tea.Msg {
+	previewCols, previewRows := h.previewPaneSize()
+	cmd := attachCmd{
+		session:     s.GetTmuxSession(),
+		termCols:    h.width,
+		termRows:    h.height,
+		previewCols: previewCols,
+		previewRows: previewRows,
+	}
+	return tea.Exec(cmd, func(err error) tea.Msg {
 		// CRITICAL: Clear isAttaching before returning the message.
 		// Prevents race where View() returns empty string after detach.
 		h.isAttaching.Store(false)
@@ -1318,10 +1342,24 @@ func (h *Home) attachSelected() tea.Cmd {
 
 type attachCmd struct {
 	session *tmux.Session
+	// termCols/termRows: host terminal size — tmux is resized up to this
+	// before attach so the user sees a full-screen pane instead of one stuck
+	// at the preview-pane width.
+	termCols, termRows int
+	// previewCols/previewRows: fleet preview size — tmux is resized back to
+	// this on detach so the next capture-pane fits without truncation.
+	previewCols, previewRows int
 }
 
 func (a attachCmd) Run() error {
-	return a.session.Attach(context.Background())
+	if a.termCols > 0 && a.termRows > 0 {
+		_ = a.session.ResizeWindow(a.termCols, a.termRows)
+	}
+	err := a.session.Attach(context.Background())
+	if a.previewCols > 0 && a.previewRows > 0 {
+		_ = a.session.ResizeWindow(a.previewCols, a.previewRows)
+	}
+	return err
 }
 
 func (a attachCmd) SetStdin(r io.Reader)  {}
@@ -1336,6 +1374,11 @@ func (h *Home) handleSessionCreate(msg sessionCreateMsg) (tea.Model, tea.Cmd) {
 	debuglog.Logger.Info("creating session", "title", msg.title, "path", msg.path)
 	s := session.NewSession(msg.title, msg.path)
 	s.WorkspaceName = msg.workspaceName
+	// Boot the new tmux window at preview-pane size so Claude wraps to fit from
+	// the very first render — avoids a brief moment where output is too wide.
+	if cols, rows := h.previewPaneSize(); cols > 0 {
+		s.SetPreferredSize(cols, rows)
+	}
 	autoFocus := h.cfg.IsFocusOnNewSessionEnabled()
 	return h, func() tea.Msg {
 		if err := s.Start(); err != nil {
@@ -2687,6 +2730,59 @@ func (h *Home) layoutMode() string {
 		return "stacked"
 	}
 	return "dual"
+}
+
+// previewPaneSize returns the cols × rows the fleet preview pane occupies in
+// the current layout. tmux sessions are resized to match so Claude wraps to
+// fit and the right side isn't chopped off by ansi.Truncate in preview.go.
+// Returns (0, 0) before WindowSizeMsg has set valid dimensions; callers must
+// skip resizing in that case. Mirrors the arithmetic in View() (app.go:828+).
+func (h *Home) previewPaneSize() (cols, rows int) {
+	if h.width <= 0 || h.height <= 0 {
+		return 0, 0
+	}
+	contentHeight := h.height - 2 - helpBarHeight
+	if contentHeight < 1 {
+		contentHeight = 1
+	}
+	switch h.layoutMode() {
+	case "single", "stacked":
+		// In stacked mode the preview spans full width; in single mode no
+		// preview is shown but a sensible width still helps if the user
+		// switches layouts mid-session.
+		return h.width, contentHeight
+	default: // dual
+		sidebarWidth := h.width * 35 / 100
+		if sidebarWidth < 20 {
+			sidebarWidth = 20
+		}
+		previewWidth := h.width - sidebarWidth - 3 // 3 for separator " │ "
+		if previewWidth < 1 {
+			previewWidth = 1
+		}
+		return previewWidth, contentHeight
+	}
+}
+
+// dispatchSessionResize asynchronously resizes every tmux session to (cols × rows).
+// Runs in a goroutine because tmux resize-window can take a few ms per session
+// when the tmux server is busy, and the UI Update() loop must stay responsive.
+func (h *Home) dispatchSessionResize(cols, rows int) {
+	if cols <= 0 || rows <= 0 {
+		return
+	}
+	h.workerMu.Lock()
+	sessions := make([]*session.Session, len(h.sessions))
+	copy(sessions, h.sessions)
+	h.workerMu.Unlock()
+	if len(sessions) == 0 {
+		return
+	}
+	go func() {
+		for _, s := range sessions {
+			s.SetPreferredSize(cols, rows)
+		}
+	}()
 }
 
 // bindCurrentSessionToSlot persists the selected session under the given slot,

--- a/internal/ui/focuskey_test.go
+++ b/internal/ui/focuskey_test.go
@@ -1,0 +1,102 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestTranslateFocusKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		msg         tea.KeyMsg
+		wantSends   []focusKeySend
+		wantUnfocus bool
+	}{
+		{"esc exits focus mode", tea.KeyMsg{Type: tea.KeyEsc}, nil, true},
+
+		// Plain keys.
+		{"enter", tea.KeyMsg{Type: tea.KeyEnter}, []focusKeySend{{val: "Enter"}}, false},
+		{"backspace", tea.KeyMsg{Type: tea.KeyBackspace}, []focusKeySend{{val: "BSpace"}}, false},
+		{"tab", tea.KeyMsg{Type: tea.KeyTab}, []focusKeySend{{val: "Tab"}}, false},
+		{"shift+tab -> BTab", tea.KeyMsg{Type: tea.KeyShiftTab}, []focusKeySend{{val: "BTab"}}, false},
+		{"left", tea.KeyMsg{Type: tea.KeyLeft}, []focusKeySend{{val: "Left"}}, false},
+		{"ctrl+left -> C-Left", tea.KeyMsg{Type: tea.KeyCtrlLeft}, []focusKeySend{{val: "C-Left"}}, false},
+		{"ctrl+right -> C-Right", tea.KeyMsg{Type: tea.KeyCtrlRight}, []focusKeySend{{val: "C-Right"}}, false},
+		{"ctrl+up -> C-Up", tea.KeyMsg{Type: tea.KeyCtrlUp}, []focusKeySend{{val: "C-Up"}}, false},
+		{"ctrl+down -> C-Down", tea.KeyMsg{Type: tea.KeyCtrlDown}, []focusKeySend{{val: "C-Down"}}, false},
+		{"ctrl+w stays C-w", tea.KeyMsg{Type: tea.KeyCtrlW}, []focusKeySend{{val: "C-w"}}, false},
+		{"delete -> DC", tea.KeyMsg{Type: tea.KeyDelete}, []focusKeySend{{val: "DC"}}, false},
+		{"runes are literal", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("hi")}, []focusKeySend{{literal: true, val: "hi"}}, false},
+
+		// Alt/Meta-modified keys keep the modifier.
+		{"alt+backspace -> M-BSpace", tea.KeyMsg{Type: tea.KeyBackspace, Alt: true}, []focusKeySend{{val: "M-BSpace"}}, false},
+		{"alt+delete -> M-DC", tea.KeyMsg{Type: tea.KeyDelete, Alt: true}, []focusKeySend{{val: "M-DC"}}, false},
+		{"alt+b word-back -> M-b", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b"), Alt: true}, []focusKeySend{{val: "M-b"}}, false},
+		{"alt+f word-fwd -> M-f", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f"), Alt: true}, []focusKeySend{{val: "M-f"}}, false},
+		{"alt+d kill-word-fwd -> M-d", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d"), Alt: true}, []focusKeySend{{val: "M-d"}}, false},
+		{"alt+left -> M-Left", tea.KeyMsg{Type: tea.KeyLeft, Alt: true}, []focusKeySend{{val: "M-Left"}}, false},
+		{"alt+right -> M-Right", tea.KeyMsg{Type: tea.KeyRight, Alt: true}, []focusKeySend{{val: "M-Right"}}, false},
+		{"alt+up -> M-Up", tea.KeyMsg{Type: tea.KeyUp, Alt: true}, []focusKeySend{{val: "M-Up"}}, false},
+		{"alt+down -> M-Down", tea.KeyMsg{Type: tea.KeyDown, Alt: true}, []focusKeySend{{val: "M-Down"}}, false},
+		{"alt+enter -> M-Enter", tea.KeyMsg{Type: tea.KeyEnter, Alt: true}, []focusKeySend{{val: "M-Enter"}}, false},
+
+		// Alt + non-letter rune can't use "M-<rune>" safely → ESC then literal.
+		{"alt+semicolon -> ESC then literal", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(";"), Alt: true}, []focusKeySend{{val: "Escape"}, {literal: true, val: ";"}}, false},
+		{"alt+digit -> ESC then literal", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("1"), Alt: true}, []focusKeySend{{val: "Escape"}, {literal: true, val: "1"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSends, gotUnfocus := translateFocusKey(tt.msg)
+			if gotUnfocus != tt.wantUnfocus {
+				t.Errorf("unfocus = %v, want %v", gotUnfocus, tt.wantUnfocus)
+			}
+			if !reflect.DeepEqual(gotSends, tt.wantSends) {
+				t.Errorf("sends = %+v, want %+v", gotSends, tt.wantSends)
+			}
+		})
+	}
+}
+
+// TestTranslateFocusKey_ModifierNotDropped is the regression guard for the bug
+// this code path had: Alt-modified keys were switched on by Type alone, so e.g.
+// Option+Backspace was forwarded to tmux as a plain BSpace and word-wise line
+// editing didn't work in the focused pane.
+func TestTranslateFocusKey_ModifierNotDropped(t *testing.T) {
+	cases := []struct {
+		name  string
+		plain tea.KeyMsg
+		alt   tea.KeyMsg
+	}{
+		{"backspace", tea.KeyMsg{Type: tea.KeyBackspace}, tea.KeyMsg{Type: tea.KeyBackspace, Alt: true}},
+		{"delete", tea.KeyMsg{Type: tea.KeyDelete}, tea.KeyMsg{Type: tea.KeyDelete, Alt: true}},
+		{"left", tea.KeyMsg{Type: tea.KeyLeft}, tea.KeyMsg{Type: tea.KeyLeft, Alt: true}},
+		{"rune b", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b")}, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b"), Alt: true}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			plain, _ := translateFocusKey(c.plain)
+			alt, _ := translateFocusKey(c.alt)
+			if reflect.DeepEqual(plain, alt) {
+				t.Fatalf("Alt+%s produced the same send as plain %s (%+v); the modifier was dropped", c.name, c.name, plain)
+			}
+		})
+	}
+}
+
+// TestTranslateFocusKey_AltFallbackEmitsEscape checks the catch-all path:
+// an Alt-modified key with no explicit mapping is sent as Escape followed by
+// the bare key (Alt+X == ESC then X at the terminal level).
+func TestTranslateFocusKey_AltFallbackEmitsEscape(t *testing.T) {
+	// KeyHome has no Alt-specific case, so it goes through the fallback.
+	sends, unfocus := translateFocusKey(tea.KeyMsg{Type: tea.KeyHome, Alt: true})
+	if unfocus {
+		t.Fatal("unexpected unfocus")
+	}
+	want := []focusKeySend{{val: "Escape"}, {val: "Home"}}
+	if !reflect.DeepEqual(sends, want) {
+		t.Errorf("sends = %+v, want %+v", sends, want)
+	}
+}

--- a/internal/ui/forge_detect.go
+++ b/internal/ui/forge_detect.go
@@ -1,0 +1,55 @@
+package ui
+
+import (
+	"github.com/brizzai/fleet/internal/debuglog"
+	"github.com/brizzai/fleet/internal/forge"
+	"github.com/brizzai/fleet/internal/git"
+	"github.com/brizzai/fleet/internal/github"
+	"github.com/brizzai/fleet/internal/gitlab"
+	"github.com/brizzai/fleet/internal/workspace"
+)
+
+// detectForge picks the forge provider for a repo by inspecting its origin
+// remote (and any `.fleet.json` "forge" override), returning nil when the repo
+// has no recognised forge or the matching CLI (gh / glab) isn't installed.
+//
+// Detection order:
+//  1. `.fleet.json` "forge" override — wins outright.
+//  2. origin host looks like GitLab (gitlab.com / *gitlab*) → GitLab.
+//  3. origin host looks like GitHub (github.com / github.*) → GitHub.
+//  4. fallback: if `gh` is installed, assume GitHub. This preserves the
+//     pre-GitLab behaviour for GHE hosts on unrelated hostnames (fleet used to
+//     run `gh pr view` against every repo regardless of remote).
+//
+// Result is cached per repo by the caller — a repo's forge identity is stable
+// for the life of the process.
+func detectForge(repoPath string) forge.Provider {
+	switch workspace.ForgeOverride(repoPath) {
+	case "github":
+		return availableOrNil(github.New())
+	case "gitlab":
+		return availableOrNil(gitlab.New())
+	}
+
+	host, _ := forge.ParseRemote(git.RemoteURL(repoPath))
+	switch {
+	case gitlab.HostMatches(host):
+		return availableOrNil(gitlab.New())
+	case github.HostMatches(host):
+		return availableOrNil(github.New())
+	default:
+		if github.IsAvailable() {
+			return github.New()
+		}
+		return nil
+	}
+}
+
+// availableOrNil returns p if its CLI is installed, else nil (and logs why).
+func availableOrNil(p forge.Provider) forge.Provider {
+	if p.Available() {
+		return p
+	}
+	debuglog.Logger.Debug("forge: CLI not available, PR badge disabled for this forge", "forge", p.Name())
+	return nil
+}

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -19,6 +19,7 @@ var allKeyBindings = []KeyBinding{
 	{Key: "k / ↑", Desc: "Move up", Section: "nav"},
 	{Key: "PgDn", Desc: "Page down", Section: "nav"},
 	{Key: "PgUp", Desc: "Page up", Section: "nav"},
+	{Key: "Shift+↑/↓", Desc: "Move session within group / move group", Section: "nav"},
 
 	// Session actions.
 	{Key: "Enter", BarKey: "⏎", BarDesc: "Open", Desc: "Attach / toggle group", Section: "session"},

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -53,7 +53,7 @@ func (d *SettingsDialog) Update(msg tea.Msg) (*SettingsDialog, tea.Cmd) {
 		return d, nil
 	}
 
-	numRows := 8 // theme, editor, tick, auto-name, auto-update, copy-claude, enter-mode, telemetry
+	numRows := 9 // theme, editor, tick, auto-name, auto-update, copy-claude, enter-mode, focus-on-new, telemetry
 	switch keyMsg.String() {
 	case "j", "down":
 		d.cursor = (d.cursor + 1) % numRows
@@ -133,7 +133,12 @@ func (d *SettingsDialog) cycleValue(dir int) {
 			d.cfg.EnterMode = "attach"
 		}
 
-	case 7: // Telemetry
+	case 7: // Focus on new session
+		enabled := d.cfg.IsFocusOnNewSessionEnabled()
+		enabled = !enabled
+		d.cfg.FocusOnNewSession = &enabled
+
+	case 8: // Telemetry
 		enabled := d.cfg.IsTelemetryEnabled()
 		enabled = !enabled
 		d.cfg.Telemetry = &enabled
@@ -169,6 +174,11 @@ func (d *SettingsDialog) View() string {
 		copyClaudeValue = "off"
 	}
 
+	focusOnNewValue := "off"
+	if d.cfg.IsFocusOnNewSessionEnabled() {
+		focusOnNewValue = "on"
+	}
+
 	telemetryValue := "on"
 	if !d.cfg.IsTelemetryEnabled() {
 		telemetryValue = "off"
@@ -182,6 +192,7 @@ func (d *SettingsDialog) View() string {
 		{"Auto-update", autoUpdateValue},
 		{"Copy .claude", copyClaudeValue},
 		{"Enter mode", d.cfg.GetEnterMode()},
+		{"Focus on new", focusOnNewValue},
 		{"Telemetry", telemetryValue},
 	}
 

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/brizzai/fleet/internal/forge"
 	"github.com/brizzai/fleet/internal/git"
-	"github.com/brizzai/fleet/internal/github"
 	"github.com/brizzai/fleet/internal/session"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -341,7 +341,7 @@ func renderRepoHeader(repoPath string, expanded bool, info RepoGroupInfo, repoIn
 	return fmt.Sprintf(" %s %s%s%s %s", icon, RepoHeaderStyle.Render(name), branchStr, dirtyStr, countStr) + statsStr + prStr
 }
 
-func renderPRBadge(pr *github.PR, selected bool) string {
+func renderPRBadge(pr *forge.PR, selected bool) string {
 	if pr == nil {
 		return ""
 	}
@@ -351,7 +351,12 @@ func renderPRBadge(pr *github.PR, selected bool) string {
 		return ""
 	}
 
-	badge := fmt.Sprintf("#%d", pr.Number)
+	// GitLab merge requests are referred to as !N (vs GitHub's #N).
+	sigil := "#"
+	if pr.Forge == "gitlab" {
+		sigil = "!"
+	}
+	badge := fmt.Sprintf("%s%d", sigil, pr.Number)
 
 	// Merged: purple with upward arrow.
 	if pr.State == "MERGED" {

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -41,7 +41,10 @@ type RepoGroupInfo struct {
 // filter, when non-empty, only includes sessions whose title contains the filter string.
 // pending workspaces are injected as phantom entries under their repo group.
 // pinnedRepos includes repos that should appear even with no sessions.
-func BuildFlatItems(sessions []*session.Session, pending []*PendingWorkspace, expanded map[string]bool, filter string, pinnedRepos map[string]bool) []SidebarItem {
+// repoOrder, when present for a repo, sets its explicit sort position; repos
+// absent from the map fall back to alphabetical (sentinel 0 / missing keys
+// preserve legacy ordering on a fresh install).
+func BuildFlatItems(sessions []*session.Session, pending []*PendingWorkspace, expanded map[string]bool, filter string, pinnedRepos map[string]bool, repoOrder map[string]int64) []SidebarItem {
 	groups := session.GroupByRepo(sessions)
 
 	// Include repos that only have pending workspaces (no sessions yet).
@@ -58,12 +61,20 @@ func BuildFlatItems(sessions []*session.Session, pending []*PendingWorkspace, ex
 		}
 	}
 
-	// Sort repo paths alphabetically.
+	// Sort repo paths by (repoOrder key, path). Repos without an entry tie on
+	// key=0 and fall through to the alphabetical tiebreaker, matching the
+	// pre-reorder behaviour for fresh installs.
 	repos := make([]string, 0, len(groups))
 	for repo := range groups {
 		repos = append(repos, repo)
 	}
-	sort.Strings(repos)
+	sort.SliceStable(repos, func(i, j int) bool {
+		ki, kj := repoOrder[repos[i]], repoOrder[repos[j]]
+		if ki != kj {
+			return ki < kj
+		}
+		return repos[i] < repos[j]
+	})
 
 	lowerFilter := strings.ToLower(filter)
 

--- a/internal/ui/sidebar_reorder_test.go
+++ b/internal/ui/sidebar_reorder_test.go
@@ -1,0 +1,300 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/brizzai/fleet/internal/config"
+	"github.com/brizzai/fleet/internal/session"
+)
+
+// newTestHome opens a fresh on-disk SQLite (modernc.org/sqlite doesn't expose
+// :memory: through this storage layer) and returns a Home wired to it. Cleanup
+// is registered via t.Cleanup.
+func newTestHome(t *testing.T) *Home {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "fleet-reorder-*")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	storage, err := session.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { storage.Close() })
+
+	cfg := &config.Config{TickIntervalSec: 2}
+	h := NewHome(storage, cfg, "test")
+	h.width = 120
+	h.height = 40
+	return h
+}
+
+// seedSessions installs sessions on Home (in memory + persisted), then rebuilds
+// the flat sidebar. ProjectPath is used as the repo root via GetRepoRoot's
+// fallback for non-git paths.
+func seedSessions(t *testing.T, h *Home, rows []*session.SessionRow) {
+	t.Helper()
+	for _, r := range rows {
+		if err := h.storage.SaveSession(r); err != nil {
+			t.Fatalf("SaveSession %s: %v", r.ID, err)
+		}
+		s := session.FromRow(r)
+		h.sessions = append(h.sessions, s)
+		// Auto-expand each repo so its sessions appear in flatItems.
+		h.repoExpanded[r.ProjectPath] = true
+	}
+	h.rebuildSessionMap()
+	h.rebuildFlatItems()
+}
+
+// findFlatSessionIdx returns the index of a session in h.flatItems, or -1.
+func findFlatSessionIdx(h *Home, id string) int {
+	for i, it := range h.flatItems {
+		if !it.IsRepoHeader && it.Session != nil && it.Session.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// findFlatRepoIdx returns the index of a repo header in h.flatItems, or -1.
+func findFlatRepoIdx(h *Home, repoPath string) int {
+	for i, it := range h.flatItems {
+		if it.IsRepoHeader && it.RepoPath == repoPath {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestMoveCursorItemSessionReorder(t *testing.T) {
+	h := newTestHome(t)
+	now := time.Now().Truncate(time.Second)
+	seedSessions(t, h, []*session.SessionRow{
+		{ID: "s1", Title: "First", ProjectPath: "/tmp/repo-a", Status: "idle", CreatedAt: now},
+		{ID: "s2", Title: "Second", ProjectPath: "/tmp/repo-a", Status: "idle", CreatedAt: now.Add(time.Second)},
+	})
+
+	// Cursor on s1 (first session).
+	idx := findFlatSessionIdx(h, "s1")
+	if idx < 0 {
+		t.Fatalf("s1 not in flatItems: %+v", h.flatItems)
+	}
+	h.cursor = idx
+
+	// Move s1 down.
+	h.moveCursorItem(1)
+
+	// In memory: s2 should now precede s1.
+	if h.sessions[0].ID != "s2" || h.sessions[1].ID != "s1" {
+		t.Errorf("after move-down, expected [s2, s1] in memory, got [%s, %s]",
+			h.sessions[0].ID, h.sessions[1].ID)
+	}
+
+	// On disk: LoadSessions should yield the same order.
+	loaded, err := h.storage.LoadSessions()
+	if err != nil {
+		t.Fatalf("LoadSessions: %v", err)
+	}
+	if loaded[0].ID != "s2" || loaded[1].ID != "s1" {
+		t.Errorf("after move-down, expected [s2, s1] on disk, got [%s, %s]",
+			loaded[0].ID, loaded[1].ID)
+	}
+
+	// Cursor should follow s1 to its new slot.
+	newIdx := findFlatSessionIdx(h, "s1")
+	if newIdx < 0 {
+		t.Fatalf("s1 vanished from flatItems after move: %+v", h.flatItems)
+	}
+	if h.cursor != newIdx {
+		t.Errorf("cursor did not follow s1: cursor=%d, s1 at %d", h.cursor, newIdx)
+	}
+
+	// Move back: with non-zero keys now, swap should be symmetric.
+	h.moveCursorItem(-1)
+	if h.sessions[0].ID != "s1" || h.sessions[1].ID != "s2" {
+		t.Errorf("after move-up, expected [s1, s2] in memory, got [%s, %s]",
+			h.sessions[0].ID, h.sessions[1].ID)
+	}
+}
+
+func TestMoveCursorItemRepoReorder(t *testing.T) {
+	h := newTestHome(t)
+	now := time.Now().Truncate(time.Second)
+	// Two repos; "aaa" sorts before "zzz" alphabetically.
+	seedSessions(t, h, []*session.SessionRow{
+		{ID: "sa", Title: "A", ProjectPath: "/tmp/aaa", Status: "idle", CreatedAt: now},
+		{ID: "sz", Title: "Z", ProjectPath: "/tmp/zzz", Status: "idle", CreatedAt: now},
+	})
+
+	// Cursor on the /tmp/aaa header.
+	idx := findFlatRepoIdx(h, "/tmp/aaa")
+	if idx < 0 {
+		t.Fatalf("/tmp/aaa header not in flatItems: %+v", h.flatItems)
+	}
+	h.cursor = idx
+
+	// Move /tmp/aaa down → swaps with /tmp/zzz.
+	h.moveCursorItem(1)
+
+	// repoOrder map should now contain both repos with /tmp/zzz < /tmp/aaa.
+	keyA, okA := h.repoOrder["/tmp/aaa"]
+	keyZ, okZ := h.repoOrder["/tmp/zzz"]
+	if !okA || !okZ {
+		t.Fatalf("expected both repos in repoOrder, got %v", h.repoOrder)
+	}
+	if !(keyZ < keyA) {
+		t.Errorf("expected zzz key < aaa key after swap, got aaa=%d, zzz=%d", keyA, keyZ)
+	}
+
+	// flatItems ordering: zzz header should now precede aaa header.
+	zIdx := findFlatRepoIdx(h, "/tmp/zzz")
+	aIdx := findFlatRepoIdx(h, "/tmp/aaa")
+	if !(zIdx < aIdx) {
+		t.Errorf("expected /tmp/zzz before /tmp/aaa in flatItems, got zzz=%d aaa=%d", zIdx, aIdx)
+	}
+
+	// Cursor should follow /tmp/aaa to its new slot.
+	if h.cursor != aIdx {
+		t.Errorf("cursor did not follow /tmp/aaa: cursor=%d, aaa at %d", h.cursor, aIdx)
+	}
+
+	// On disk: repo_order persists.
+	loaded, err := h.storage.LoadRepoOrder()
+	if err != nil {
+		t.Fatalf("LoadRepoOrder: %v", err)
+	}
+	if loaded["/tmp/aaa"] != keyA || loaded["/tmp/zzz"] != keyZ {
+		t.Errorf("on-disk repo_order mismatch: got %v, want aaa=%d zzz=%d", loaded, keyA, keyZ)
+	}
+}
+
+func TestMoveCursorItemBoundaryNoOp(t *testing.T) {
+	h := newTestHome(t)
+	now := time.Now().Truncate(time.Second)
+	// Two sessions in two different repos. First session in repo-a + dir=-1
+	// must be a no-op (does NOT migrate to repo-b).
+	seedSessions(t, h, []*session.SessionRow{
+		{ID: "a1", Title: "A1", ProjectPath: "/tmp/repo-a", Status: "idle", CreatedAt: now},
+		{ID: "b1", Title: "B1", ProjectPath: "/tmp/repo-b", Status: "idle", CreatedAt: now},
+	})
+
+	// Snapshot in-memory + on-disk state.
+	prevA := h.sessions[0].ID
+	prevB := h.sessions[1].ID
+	prevSorted, _ := h.storage.LoadSessions()
+	var prevDiskIDs []string
+	for _, r := range prevSorted {
+		prevDiskIDs = append(prevDiskIDs, r.ID)
+	}
+
+	// Cursor on a1 (only session in /tmp/repo-a). Up is a no-op.
+	h.cursor = findFlatSessionIdx(h, "a1")
+	h.moveCursorItem(-1)
+
+	if h.sessions[0].ID != prevA || h.sessions[1].ID != prevB {
+		t.Errorf("expected in-memory order unchanged, got [%s, %s] (was [%s, %s])",
+			h.sessions[0].ID, h.sessions[1].ID, prevA, prevB)
+	}
+
+	// Down is also a no-op (a1 is the only session in /tmp/repo-a).
+	h.moveCursorItem(1)
+	if h.sessions[0].ID != prevA || h.sessions[1].ID != prevB {
+		t.Errorf("expected in-memory order unchanged after move-down, got [%s, %s]",
+			h.sessions[0].ID, h.sessions[1].ID)
+	}
+
+	// Disk untouched.
+	loaded, _ := h.storage.LoadSessions()
+	if len(loaded) != len(prevDiskIDs) {
+		t.Fatalf("expected %d sessions on disk, got %d", len(prevDiskIDs), len(loaded))
+	}
+	for i, want := range prevDiskIDs {
+		if loaded[i].ID != want {
+			t.Errorf("disk position %d: got %q, want %q", i, loaded[i].ID, want)
+		}
+		if loaded[i].SortKey != 0 {
+			t.Errorf("disk position %d: sort_key should still be 0, got %d", i, loaded[i].SortKey)
+		}
+	}
+}
+
+func TestMoveCursorItemPhantomIgnored(t *testing.T) {
+	h := newTestHome(t)
+	// Inject a phantom "creating..." pending workspace; no real sessions.
+	pw := &PendingWorkspace{ID: "pw-1", Name: "newbranch", RepoPath: "/tmp/repo-a"}
+	h.pendingWorkspaces = []*PendingWorkspace{pw}
+	h.repoExpanded["/tmp/repo-a"] = true
+	h.rebuildFlatItems()
+
+	// Find the phantom in flatItems and put the cursor on it.
+	phantomIdx := -1
+	for i, it := range h.flatItems {
+		if it.Pending != nil && it.Pending.ID == "pw-1" {
+			phantomIdx = i
+			break
+		}
+	}
+	if phantomIdx < 0 {
+		t.Fatalf("phantom not in flatItems: %+v", h.flatItems)
+	}
+	h.cursor = phantomIdx
+
+	// Move down — should be a silent no-op (no toast, no DB write, no error).
+	h.moveCursorItem(1)
+	if h.infoMsg != "" {
+		t.Errorf("expected no info toast on phantom move, got %q", h.infoMsg)
+	}
+	if h.err != nil {
+		t.Errorf("expected no error on phantom move, got %v", h.err)
+	}
+	// Phantom should still be where it was (only one item, anyway).
+	if findFlatSessionIdx(h, "pw-1") != -1 {
+		// (No real sessions to test against, but the phantom slot is unchanged.)
+		t.Errorf("phantom unexpectedly turned into a session")
+	}
+}
+
+func TestMoveCursorItemFilteredGuard(t *testing.T) {
+	h := newTestHome(t)
+	now := time.Now().Truncate(time.Second)
+	seedSessions(t, h, []*session.SessionRow{
+		{ID: "s1", Title: "alpha", ProjectPath: "/tmp/repo-a", Status: "idle", CreatedAt: now},
+		{ID: "s2", Title: "beta", ProjectPath: "/tmp/repo-a", Status: "idle", CreatedAt: now.Add(time.Second)},
+	})
+
+	// Activate filter.
+	h.filterText = "alpha"
+	h.rebuildFlatItems()
+
+	idx := findFlatSessionIdx(h, "s1")
+	if idx < 0 {
+		t.Fatalf("s1 not in filtered flatItems: %+v", h.flatItems)
+	}
+	h.cursor = idx
+
+	h.moveCursorItem(1)
+
+	// In-memory order must be unchanged.
+	if h.sessions[0].ID != "s1" || h.sessions[1].ID != "s2" {
+		t.Errorf("expected order unchanged under filter, got [%s, %s]",
+			h.sessions[0].ID, h.sessions[1].ID)
+	}
+	if h.infoMsg == "" {
+		t.Errorf("expected info toast when reordering under filter, got empty")
+	}
+	// Sort keys on disk should still be 0.
+	loaded, _ := h.storage.LoadSessions()
+	for _, r := range loaded {
+		if r.SortKey != 0 {
+			t.Errorf("session %s: sort_key should still be 0 under filter guard, got %d",
+				r.ID, r.SortKey)
+		}
+	}
+}

--- a/internal/ui/sidebar_test.go
+++ b/internal/ui/sidebar_test.go
@@ -1,0 +1,105 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/brizzai/fleet/internal/session"
+)
+
+// repoHeaderPaths returns the RepoPath of each header item in order, so tests
+// can assert sidebar group ordering without inspecting session-level items.
+func repoHeaderPaths(items []SidebarItem) []string {
+	var out []string
+	for _, it := range items {
+		if it.IsRepoHeader {
+			out = append(out, it.RepoPath)
+		}
+	}
+	return out
+}
+
+func TestBuildFlatItemsAlphabeticalFallback(t *testing.T) {
+	// No repoOrder entries: ordering must match the legacy alphabetical behaviour
+	// so existing installs don't see their sidebar reshuffle on upgrade.
+	expanded := map[string]bool{
+		"/tmp/zebra":  true,
+		"/tmp/apple":  true,
+		"/tmp/mango":  true,
+		"/tmp/banana": true,
+	}
+	pinned := map[string]bool{
+		"/tmp/zebra":  true,
+		"/tmp/apple":  true,
+		"/tmp/mango":  true,
+		"/tmp/banana": true,
+	}
+	items := BuildFlatItems(nil, nil, expanded, "", pinned, nil)
+	got := repoHeaderPaths(items)
+	want := []string{"/tmp/apple", "/tmp/banana", "/tmp/mango", "/tmp/zebra"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d headers, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: got %q, want %q (full order: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestBuildFlatItemsRespectsRepoOrder(t *testing.T) {
+	// Explicit repoOrder keys win over alphabetical. /tmp/apple has the highest
+	// key, so it should sort *after* /tmp/mango and /tmp/zebra (which have key
+	// 50 and 10 respectively); /tmp/banana has no entry → 0 → alphabetical.
+	expanded := map[string]bool{
+		"/tmp/apple":  true,
+		"/tmp/zebra":  true,
+		"/tmp/mango":  true,
+		"/tmp/banana": true,
+	}
+	pinned := map[string]bool{
+		"/tmp/apple":  true,
+		"/tmp/zebra":  true,
+		"/tmp/mango":  true,
+		"/tmp/banana": true,
+	}
+	order := map[string]int64{
+		"/tmp/apple": 100,
+		"/tmp/mango": 50,
+		"/tmp/zebra": 10,
+		// /tmp/banana intentionally absent → key 0, alphabetical fallback.
+	}
+	items := BuildFlatItems(nil, nil, expanded, "", pinned, order)
+	got := repoHeaderPaths(items)
+	// 0-keyed first (alphabetical among them): banana. Then 10, 50, 100.
+	want := []string{"/tmp/banana", "/tmp/zebra", "/tmp/mango", "/tmp/apple"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d headers, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: got %q, want %q (full order: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestBuildFlatItemsRepoOrderTieBreaksAlphabetically(t *testing.T) {
+	// Two repos sharing the same explicit key should fall through to the
+	// alphabetical tiebreaker (deterministic, matches the comparator).
+	expanded := map[string]bool{"/tmp/zzz": true, "/tmp/aaa": true}
+	pinned := map[string]bool{"/tmp/zzz": true, "/tmp/aaa": true}
+	order := map[string]int64{"/tmp/zzz": 50, "/tmp/aaa": 50}
+	items := BuildFlatItems(nil, nil, expanded, "", pinned, order)
+	got := repoHeaderPaths(items)
+	want := []string{"/tmp/aaa", "/tmp/zzz"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d headers, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+	// Reference session to avoid the import being unused if this file ever
+	// drops the other tests.
+	_ = (*session.Session)(nil)
+}

--- a/internal/workspace/repo_config.go
+++ b/internal/workspace/repo_config.go
@@ -13,6 +13,10 @@ import (
 type RepoWorkspaceConfig struct {
 	Workspace ShellConfig    `json:"workspace"`
 	PRChecks  PRChecksConfig `json:"pr_checks"`
+	// Forge overrides forge auto-detection for this repo: "github" or "gitlab".
+	// Empty means detect from the origin remote URL. Mainly useful for
+	// self-hosted GitLab on a hostname that doesn't contain "gitlab".
+	Forge string `json:"forge,omitempty"`
 }
 
 // ShellConfig holds shell command configuration for workspace operations.
@@ -50,6 +54,10 @@ func loadMergedRepoConfig(repoPath string) RepoWorkspaceConfig {
 		merged.Workspace.Destroy = local.Workspace.Destroy
 	}
 
+	if local.Forge != "" {
+		merged.Forge = local.Forge
+	}
+
 	merged.PRChecks.Ignore = dedupeStrings(append(base.PRChecks.Ignore, local.PRChecks.Ignore...))
 	return merged
 }
@@ -75,6 +83,12 @@ func dedupeStrings(in []string) []string {
 // if no config sets it. Patterns are path.Match globs against check names.
 func IgnorePatterns(repoPath string) []string {
 	return loadMergedRepoConfig(repoPath).PRChecks.Ignore
+}
+
+// ForgeOverride returns the repo's configured forge ("github" | "gitlab"), or
+// empty string if none is set (auto-detect).
+func ForgeOverride(repoPath string) string {
+	return loadMergedRepoConfig(repoPath).Forge
 }
 
 // ResolveProvider loads workspace config from repoPath. Preference is by file


### PR DESCRIPTION
## Summary

Lets the user reorder sessions within a repo group, or shuffle repo groups themselves, via `Shift+↑` / `Shift+↓`. Order is persisted to SQLite so it survives restarts.

- Sessions reorder **within** their repo group only — `Shift+↓` on the last session in a repo is a silent no-op (no cross-repo migration).
- Repo headers swap with their neighbouring repo group when reordered.
- Phantom "Creating…" workspace entries are not reorderable (silent no-op).
- Reorder under an active filter (`/…`) is blocked with a "Clear filter (Esc) to reorder" toast — re-keying a partial view would corrupt the on-disk order.

## Implementation

- New `sessions.sort_key INTEGER NOT NULL DEFAULT 0` column and `repo_order(repo_path, sort_key)` table. Default-0 rows tie on `sort_key` and fall through to `created_at`, so existing installations see no order change on upgrade. The first reorder seeds non-zero keys for the affected pair only.
- `LoadSessions` now orders by `(sort_key, created_at)`; `BuildFlatItems` sorts repos by `(repoOrder[path], path)` so repos without an explicit key keep the alphabetical fallback.
- `moveCursorItem(dir)` lives in `internal/ui/app.go` and handles both session and repo-header swaps. Persistence is synchronous in the handler (mirrors the existing `BindSlot` / `PinRepo` pattern).
- Empty-repo unpin (`d` on an empty repo header) also clears any saved `repo_order` entry so a future re-pin starts from the alphabetical fallback rather than its old slot.

## Manual verification

- [x] Multiple sessions in a single repo: `Shift+↓` moves first to second slot, `Shift+↑` moves it back.
- [x] Repo with N sessions: `Shift+↓` on the last session is a silent no-op (does NOT migrate to the next repo).
- [x] Two repos: `Shift+↓` on the first repo header swaps repo positions; all sessions move with their header.
- [x] Quit and re-launch: order persists.
- [x] Phantom "Creating…" entry selected, `Shift+↓`: silent no-op.
- [x] Filter active (`/abc`), `Shift+↓`: info toast "Clear filter (Esc) to reorder", no mutation.

## Tests

- `internal/session/storage_test.go`: new round-trip + ordering + migration-idempotency tests for `sort_key` and `repo_order`. `TestMultipleSessions` (existing) still passes since all rows tie on `sort_key=0` and fall through to `created_at`.
- `internal/ui/sidebar_test.go` (new): `BuildFlatItems` ordering — alphabetical fallback, explicit key wins, same-key tiebreak.
- `internal/ui/sidebar_reorder_test.go` (new): `moveCursorItem` behaviour — session swap, repo swap, boundary no-op, phantom ignored, filter guard.

Full `go test -race ./...` is green.

## Known limitation

Some terminals inside tmux don't emit the shift modifier on arrow keys, in which case `Shift+↑/↓` silently does nothing. That's a terminal-side issue, not a fleet bug — Bubble Tea's modifier parsing is already wired up via `shift+tab` elsewhere in the codebase. If users hit this, falling back from tmux to a passthrough terminal restores the binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitLab merge request badge support alongside GitHub PR badges with automatic forge detection and `glab` CLI integration
  * Added sidebar reordering with Shift+↑/↓ to move sessions within groups or reorder repo groups (persists across restarts)
  * Added "Focus on new session" toggle to auto-focus newly created sessions
  * Added dev installation via `install-dev.sh` for building from source

* **Bug Fixes**
  * Fixed focus mode key forwarding to preserve modifiers (Alt+Backspace, word motions, Ctrl+arrows)
  * Fixed split-view preview truncation by syncing tmux window dimensions with preview pane

* **Documentation**
  * Updated installation and configuration docs with GitLab support and dev build guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->