### PR TITLE
feat(workspace): add per-repo copy_files config for new worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Worktree creation copies `.claude/settings.local.json` from source repo (configurable via `copy_claude_settings`, default true)
 - `.fleet.json` / `.fleet.local.json` in repo root (legacy `.bc.json` / `.bc.local.json` still read): `{"workspace": {"list": "cmd", "create": "cmd {{name}} {{branch}}", "destroy": "cmd {{name}}"}}`
 - `.fleet.json` / `.fleet.local.json` may also set `{"pr_checks": {"ignore": ["glob", ...]}}` to drop matching CI checks from the PR-badge rollup (path.Match globs; lists from both files merge additively; opt-in, empty by default)
+- `.fleet.json` / `.fleet.local.json` may also set `{"copy_files": {"paths": ["path", "dir", "glob/*", ...]}}` to copy gitignored files/dirs/globs from the source repo into each new worktree (filepath.Glob semantics, repo-relative only; lists from both files merge additively; opt-in, empty by default; applies to both git-worktree and shell providers; independent of `copy_claude_settings`)
 - Claude session resume: captures Claude session_id from hooks, uses `claude --resume <id>` on restart
 - Editor: config.editor > $EDITOR > "code" (VS Code)
 - Themes: tokyo-night (default), catppuccin-mocha, rose-pine, nord, gruvbox — configurable via settings (S key)

--- a/changelog/unreleased/copy-files.md
+++ b/changelog/unreleased/copy-files.md
@@ -1,0 +1,5 @@
+---
+type: added
+---
+
+Per-repo `copy_files.paths` config in `.fleet.json` / `.fleet.local.json` copies declared gitignored files/dirs/globs from the source repo into each new worktree. Opt-in; additive merge across both files; applies to both git-worktree and shell providers.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -569,11 +569,14 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		copyClaudeSettings := h.cfg.IsCopyClaudeSettingsEnabled() && !provider.IsCustom()
 		return h, tea.Batch(func() tea.Msg {
 			info, err := provider.Create(repoPath, name, branch, baseBranch)
-			if err == nil && info != nil {
+			if err == nil && info != nil && info.Path != "" {
 				if copyClaudeSettings {
 					copyClaudeSettingsFile(repoPath, info.Path)
 				}
 				workspace.CopyConfiguredFiles(repoPath, info.Path)
+			} else if err == nil && info != nil && info.Path == "" {
+				debuglog.Logger.Debug("workspace create returned empty path — skipping file copies",
+					"repo", repoPath, "name", name)
 			}
 			return workspaceCreateResultMsg{info: info, err: err, pendingID: pendingID, repoPath: repoPath}
 		}, spinnerTickCmd)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -569,8 +569,11 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		copyClaudeSettings := h.cfg.IsCopyClaudeSettingsEnabled() && !provider.IsCustom()
 		return h, tea.Batch(func() tea.Msg {
 			info, err := provider.Create(repoPath, name, branch, baseBranch)
-			if err == nil && info != nil && copyClaudeSettings {
-				copyClaudeSettingsFile(repoPath, info.Path)
+			if err == nil && info != nil {
+				if copyClaudeSettings {
+					copyClaudeSettingsFile(repoPath, info.Path)
+				}
+				workspace.CopyConfiguredFiles(repoPath, info.Path)
 			}
 			return workspaceCreateResultMsg{info: info, err: err, pendingID: pendingID, repoPath: repoPath}
 		}, spinnerTickCmd)

--- a/internal/workspace/copy_files.go
+++ b/internal/workspace/copy_files.go
@@ -1,0 +1,124 @@
+package workspace
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/brizzai/fleet/internal/debuglog"
+)
+
+// CopyConfiguredFiles copies each path declared in srcRepo's merged
+// copy_files.paths list from srcRepo into dstRepo, preserving relative layout.
+// Each entry is a repo-relative literal path or filepath.Glob pattern; matches
+// may be files (copied) or directories (copied recursively, symlinks not
+// followed). Missing source paths and patterns with no matches are silent.
+// Per-entry errors are logged and the next entry is attempted; this function
+// never fails the caller (worktree already exists by the time it runs).
+func CopyConfiguredFiles(srcRepo, dstRepo string) {
+	patterns := CopyFilesPatterns(srcRepo)
+	if len(patterns) == 0 {
+		return
+	}
+
+	srcRepoAbs, err := filepath.Abs(srcRepo)
+	if err != nil {
+		debuglog.Logger.Error("copy_files: failed to resolve src repo path", "src", srcRepo, "err", err)
+		return
+	}
+
+	for _, pattern := range patterns {
+		if !patternWithinRepo(pattern) {
+			debuglog.Logger.Warn("copy_files: rejecting pattern that escapes repo root",
+				"src", srcRepo, "pattern", pattern)
+			continue
+		}
+		matches, err := filepath.Glob(filepath.Join(srcRepoAbs, pattern))
+		if err != nil {
+			debuglog.Logger.Warn("copy_files: invalid glob pattern",
+				"src", srcRepo, "pattern", pattern, "err", err)
+			continue
+		}
+		if len(matches) == 0 {
+			continue
+		}
+		for _, srcPath := range matches {
+			rel, err := filepath.Rel(srcRepoAbs, srcPath)
+			if err != nil || strings.HasPrefix(rel, "..") {
+				debuglog.Logger.Warn("copy_files: skipping match outside repo",
+					"src", srcRepo, "match", srcPath)
+				continue
+			}
+			dstPath := filepath.Join(dstRepo, rel)
+			if err := copyPath(srcPath, dstPath); err != nil {
+				debuglog.Logger.Error("copy_files: copy failed",
+					"src", srcPath, "dst", dstPath, "err", err)
+			}
+		}
+	}
+}
+
+// patternWithinRepo returns false for patterns that are empty, refer to the
+// repo root itself ("." after Clean), are absolute, or escape the repo root
+// with "..". Repo-root patterns are rejected because they would recursively
+// clone the entire source tree into the new worktree on a typo.
+func patternWithinRepo(pattern string) bool {
+	if pattern == "" || filepath.IsAbs(pattern) {
+		return false
+	}
+	cleaned := filepath.Clean(pattern)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
+// copyPath copies src to dst. If src is a directory, the tree is walked and
+// each regular file is copied with parent dirs created as needed. Symlinks
+// (both file and directory) are skipped to keep the copy confined to content
+// the user actually placed inside the repo.
+func copyPath(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		debuglog.Logger.Warn("copy_files: skipping symlink", "src", src)
+		return nil
+	}
+	if !info.IsDir() {
+		return copyFile(src, dst)
+	}
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0600)
+}

--- a/internal/workspace/copy_files.go
+++ b/internal/workspace/copy_files.go
@@ -45,7 +45,7 @@ func CopyConfiguredFiles(srcRepo, dstRepo string) {
 		}
 		for _, srcPath := range matches {
 			rel, err := filepath.Rel(srcRepoAbs, srcPath)
-			if err != nil || strings.HasPrefix(rel, "..") {
+			if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 				debuglog.Logger.Warn("copy_files: skipping match outside repo",
 					"src", srcRepo, "match", srcPath)
 				continue

--- a/internal/workspace/copy_files_test.go
+++ b/internal/workspace/copy_files_test.go
@@ -66,6 +66,17 @@ func TestCopyConfiguredFiles(t *testing.T) {
 		}
 	})
 
+	t.Run("copies filenames starting with two dots (e.g. ..env)", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		writeFile(t, src, "..env", "DOTDOT")
+		writeFile(t, src, ".fleet.json", `{"copy_files":{"paths":["..env"]}}`)
+
+		CopyConfiguredFiles(src, dst)
+
+		assertFile(t, filepath.Join(dst, "..env"), "DOTDOT")
+	})
+
 	t.Run("skips symlinks instead of following them", func(t *testing.T) {
 		src := t.TempDir()
 		dst := t.TempDir()

--- a/internal/workspace/copy_files_test.go
+++ b/internal/workspace/copy_files_test.go
@@ -1,0 +1,123 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyConfiguredFiles(t *testing.T) {
+	t.Run("copies files, glob matches, and directory trees", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+
+		writeFile(t, src, ".env", "ENV=1")
+		mustMkdir(t, filepath.Join(src, "config"))
+		writeFile(t, filepath.Join(src, "config"), "a.local.json", "A")
+		writeFile(t, filepath.Join(src, "config"), "b.local.json", "B")
+		writeFile(t, filepath.Join(src, "config"), "shared.json", "SHARED") // should NOT copy
+		mustMkdir(t, filepath.Join(src, ".vscode"))
+		writeFile(t, filepath.Join(src, ".vscode"), "settings.json", "VS")
+		writeFile(t, src, "README.md", "READ") // should NOT copy
+
+		writeFile(t, src, ".fleet.json", `{"copy_files":{"paths":[".env","config/*.local.json",".vscode"]}}`)
+
+		CopyConfiguredFiles(src, dst)
+
+		assertFile(t, filepath.Join(dst, ".env"), "ENV=1")
+		assertFile(t, filepath.Join(dst, "config", "a.local.json"), "A")
+		assertFile(t, filepath.Join(dst, "config", "b.local.json"), "B")
+		assertFile(t, filepath.Join(dst, ".vscode", "settings.json"), "VS")
+		assertMissing(t, filepath.Join(dst, "config", "shared.json"))
+		assertMissing(t, filepath.Join(dst, "README.md"))
+	})
+
+	t.Run("merges .fleet.json and .fleet.local.json additively", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+
+		writeFile(t, src, "shared.env", "S")
+		writeFile(t, src, "personal.env", "P")
+		writeFile(t, src, ".fleet.json", `{"copy_files":{"paths":["shared.env"]}}`)
+		writeFile(t, src, ".fleet.local.json", `{"copy_files":{"paths":["personal.env"]}}`)
+
+		CopyConfiguredFiles(src, dst)
+
+		assertFile(t, filepath.Join(dst, "shared.env"), "S")
+		assertFile(t, filepath.Join(dst, "personal.env"), "P")
+	})
+
+	t.Run("rejects patterns escaping repo root or referring to root itself", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		// Plant a file that a "." pattern would otherwise clone wholesale.
+		writeFile(t, src, "would-be-cloned.txt", "X")
+		writeFile(t, src, ".fleet.json", `{"copy_files":{"paths":["../escape.txt","/abs/path","",".","./"]}}`)
+
+		// Must not panic and must not create anything in dst.
+		CopyConfiguredFiles(src, dst)
+
+		entries, err := os.ReadDir(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("expected empty dst, got %d entries", len(entries))
+		}
+	})
+
+	t.Run("skips symlinks instead of following them", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		outside := t.TempDir()
+		writeFile(t, outside, "secret.txt", "OUTSIDE")
+		if err := os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(src, "link.txt")); err != nil {
+			t.Skipf("symlink unsupported: %v", err)
+		}
+		writeFile(t, src, ".fleet.json", `{"copy_files":{"paths":["link.txt"]}}`)
+
+		CopyConfiguredFiles(src, dst)
+
+		assertMissing(t, filepath.Join(dst, "link.txt"))
+	})
+
+	t.Run("no config is a no-op", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		writeFile(t, src, ".env", "X")
+		CopyConfiguredFiles(src, dst)
+		assertMissing(t, filepath.Join(dst, ".env"))
+	})
+
+	t.Run("missing source paths are silently skipped", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		writeFile(t, src, ".fleet.json", `{"copy_files":{"paths":["does-not-exist.txt"]}}`)
+		CopyConfiguredFiles(src, dst) // must not panic
+	})
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertFile(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Errorf("%s: got %q, want %q", path, got, want)
+	}
+}
+
+func assertMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("%s exists but should not (err=%v)", path, err)
+	}
+}

--- a/internal/workspace/repo_config.go
+++ b/internal/workspace/repo_config.go
@@ -11,8 +11,9 @@ import (
 
 // RepoWorkspaceConfig is the structure of .fleet.json files.
 type RepoWorkspaceConfig struct {
-	Workspace ShellConfig    `json:"workspace"`
-	PRChecks  PRChecksConfig `json:"pr_checks"`
+	Workspace ShellConfig     `json:"workspace"`
+	PRChecks  PRChecksConfig  `json:"pr_checks"`
+	CopyFiles CopyFilesConfig `json:"copy_files"`
 }
 
 // ShellConfig holds shell command configuration for workspace operations.
@@ -28,6 +29,13 @@ type PRChecksConfig struct {
 	// are dropped from the PR-badge rollup so a single noisy check (e.g. a
 	// gitstream "minimum reviewers" gate) doesn't turn the whole badge red.
 	Ignore []string `json:"ignore,omitempty"`
+}
+
+// CopyFilesConfig holds the list of repo-relative paths (files, dirs, or
+// filepath.Glob patterns) that should be copied from the source repo into a
+// freshly created worktree. Opt-in per repo; empty by default.
+type CopyFilesConfig struct {
+	Paths []string `json:"paths,omitempty"`
 }
 
 // loadMergedRepoConfig resolves .fleet.json / .fleet.local.json (with legacy
@@ -51,6 +59,7 @@ func loadMergedRepoConfig(repoPath string) RepoWorkspaceConfig {
 	}
 
 	merged.PRChecks.Ignore = dedupeStrings(append(base.PRChecks.Ignore, local.PRChecks.Ignore...))
+	merged.CopyFiles.Paths = dedupeStrings(append(base.CopyFiles.Paths, local.CopyFiles.Paths...))
 	return merged
 }
 
@@ -75,6 +84,13 @@ func dedupeStrings(in []string) []string {
 // if no config sets it. Patterns are path.Match globs against check names.
 func IgnorePatterns(repoPath string) []string {
 	return loadMergedRepoConfig(repoPath).PRChecks.Ignore
+}
+
+// CopyFilesPatterns returns the merged copy_files.paths list for a repo, or
+// nil if no config sets it. Patterns are repo-relative filepath.Glob expressions
+// (or literal paths). Used by CopyConfiguredFiles when a worktree is created.
+func CopyFilesPatterns(repoPath string) []string {
+	return loadMergedRepoConfig(repoPath).CopyFiles.Paths
 }
 
 // ResolveProvider loads workspace config from repoPath. Preference is by file


### PR DESCRIPTION
## Summary
- New top-level `copy_files: { paths: [...] }` block in `.fleet.json` / `.fleet.local.json` lets repos declare gitignored files/dirs/globs (e.g. `.env`, `.envrc`, `config/*.local.json`, `.vscode`) that should be copied from the source repo into each new worktree.
- Additive merge across `.fleet.json` + `.fleet.local.json` (concat + dedupe), matching the existing `pr_checks.ignore` behavior — team-shared base list + personal local additions.
- Opt-in per repo; empty by default. Independent of the existing global `copy_claude_settings` flag. Applies to both `GitWorktreeProvider` and `ShellProvider`.
- Implementation lives in `internal/workspace/copy_files.go` (`CopyConfiguredFiles`), invoked once per worktree creation right after the existing `.claude/settings.local.json` copy in `internal/ui/app.go`. Per-file errors are logged but never fail worktree creation; absolute paths, `..` escapes, repo-root (`""`/`.`) patterns, and symlinks are all skipped.

## Notes
- Supersedes #79 (which inadvertently included the in-flight Codex commit from #78). This is the same `copy_files` work, cherry-picked clean onto master, plus the Copilot fixes from that review (repo-root pattern guard, `os.Lstat`-based symlink skip).

## Test plan
- [x] `make build` clean
- [x] `make test` — `TestCopyConfiguredFiles` covers files+globs+recursive dir copy, additive merge across `.fleet.json`/`.fleet.local.json`, escape/repo-root/empty-pattern rejection, symlink skip, and no-config/missing-path no-ops.
- [ ] Manual smoke: in a repo with `.fleet.local.json` declaring `copy_files.paths`, create a worktree via `w`; confirm declared paths land at mirrored locations in the new worktree.
- [ ] Regression: repo without `copy_files` entry behaves identically to today (only `.claude/settings.local.json` is copied when `copy_claude_settings` is true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `copy_files` configuration option in `.fleet.json` and `.fleet.local.json` to copy specified files and directories into newly created worktrees using glob patterns. Merges additively across both config files.

* **Documentation**
  * Added documentation for the new `copy_files` configuration feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brizzai/fleet/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->