### PR TITLE
fix(git): default worktree base to origin/<branch>

### DIFF
--- a/changelog/unreleased/worktree-base-origin.md
+++ b/changelog/unreleased/worktree-base-origin.md
@@ -1,0 +1,4 @@
+---
+type: changed
+---
+The "new worktree" dialog now pre-fills the base branch as `origin/<default>` (e.g. `origin/master`) instead of the local branch, so new worktrees start from the remote tip rather than a possibly-stale local ref. Falls back to local `main`/`master` for repos without an `origin` remote.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -137,14 +137,16 @@ func CheckoutBranch(repoPath, branch string) error {
 	return nil
 }
 
-// GetDefaultBranch returns the default branch name for the given repo.
-// Tries origin HEAD, then checks for "main" or "master" locally. Falls back to "main".
+// GetDefaultBranch returns the default base ref for the given repo, used to
+// pre-fill the worktree dialog. When an origin remote is configured, it returns
+// the remote-tracking ref (e.g. "origin/master") so new worktrees start from the
+// remote tip rather than the local branch. Falls back to local "main"/"master".
 func GetDefaultBranch(repoPath string) string {
 	// Try origin HEAD reference first.
 	cmd := exec.Command("git", "-C", repoPath, "symbolic-ref", "refs/remotes/origin/HEAD")
 	if output, err := cmd.Output(); err == nil {
 		ref := strings.TrimSpace(string(output))
-		return strings.TrimPrefix(ref, "refs/remotes/origin/")
+		return "origin/" + strings.TrimPrefix(ref, "refs/remotes/origin/")
 	} else {
 		debuglog.Logger.Debug("GetDefaultBranch symbolic-ref failed, trying fallback", "path", repoPath, "error", err)
 	}


### PR DESCRIPTION
## Summary
- `GetDefaultBranch` now returns `origin/<branch>` (e.g. `origin/master`) when an origin remote is configured, instead of the local branch name.
- The worktree picker dialog (`w` key) pre-fills the base-branch input with this value, so `git worktree add -b <new> <base>` starts the new branch from the remote-tracking ref rather than a possibly-stale local branch.
- Local-only fallback (no `origin`) still returns plain `main`/`master` since there's no remote-tracking ref to use.

Note: nothing here runs `git fetch`, so `origin/master` is only as fresh as the last fetch.

Supersedes #80 (which accidentally bundled the unrelated Codex commit from `feat/codex-support`).

## Test plan
- [ ] Open worktree dialog (`w`) on a repo with an `origin` remote → base branch input pre-fills `origin/master` (or `origin/main`)
- [ ] Submit dialog → new worktree branch starts at `origin/<branch>` commit
- [ ] On a local-only repo (no `origin`) → base branch input pre-fills `main` or `master` as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated worktree creation to default to remote branch tracking (`origin/<default>`) as the base instead of local branches, with fallback to local `main`/`master` when no `origin` remote exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->