### PR TITLE
feat(release): brizz-code compatibility shim for legacy auto-update

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,9 +17,23 @@ builds:
       - arm64
     ldflags:
       - -s -w -X main.version={{.Version}}
+  - id: brizz-code-shim
+    main: ./cmd/brizz-code-shim
+    binary: brizz-code
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
 
 archives:
   - id: default
+    ids:
+      - fleet
     formats:
       - tar.gz
     name_template: >-
@@ -27,9 +41,21 @@ archives:
       {{- .Version }}_
       {{- .Os }}_
       {{- .Arch }}
+  - id: brizz-code-shim
+    ids:
+      - brizz-code-shim
+    formats:
+      - tar.gz
+    name_template: >-
+      brizz-code_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
 
 homebrew_casks:
   - name: fleet
+    ids:
+      - default
     binaries:
       - fleet
     repository:

--- a/changelog/unreleased/brizz-code-shim.md
+++ b/changelog/unreleased/brizz-code-shim.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+Compatibility shim for users still on the legacy `brizz-code` binary. Released as `brizz-code_<version>_darwin_<arch>.tar.gz` so v1.x auto-updates land on a small wrapper that prints a deprecation warning (rate-limited to once/day), then either execs `fleet` if installed, falls back to auto-installing the latest fleet release next to itself (verifying via `checksums.txt`), or — if running from a Homebrew prefix — points the user at `brew install brizzai/tap/fleet`.

--- a/cmd/brizz-code-shim/main.go
+++ b/cmd/brizz-code-shim/main.go
@@ -1,0 +1,306 @@
+// brizz-code-shim is a deprecation wrapper for users still on the legacy
+// `brizz-code` binary. It is packaged inside `brizz-code_*.tar.gz` archives
+// on the renamed `brizzai/fleet` releases so that v1.x auto-updates land
+// here instead of failing.
+//
+// Behavior on invocation:
+//   - Print a deprecation warning (rate-limited to once per 24h).
+//   - If `fleet` is on PATH, exec it with the same args.
+//   - Else if the shim lives under a Homebrew prefix, print brew install
+//     instructions (we don't want to drop a non-brew-managed binary into
+//     a brew-managed directory).
+//   - Else download the latest fleet release, verify its checksum, and
+//     install it next to the shim, then exec it.
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+)
+
+var version = "dev"
+
+const (
+	fleetRepo     = "brizzai/fleet"
+	apiLatest     = "https://api.github.com/repos/" + fleetRepo + "/releases/latest"
+	warnStateName = "brizz-code-deprecation-warned"
+	warnInterval  = 24 * time.Hour
+)
+
+func main() {
+	printDeprecationWarning()
+
+	if path, err := exec.LookPath("fleet"); err == nil {
+		execFleet(path)
+	}
+
+	exePath, _ := os.Executable()
+	if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
+		exePath = resolved
+	}
+
+	if isBrewPath(exePath) {
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Install fleet via Homebrew:")
+		fmt.Fprintln(os.Stderr, "  brew install brizzai/tap/fleet")
+		if exePath != "" {
+			fmt.Fprintf(os.Stderr, "  rm -f %q\n", exePath)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Fprintln(os.Stderr, "Installing fleet…")
+	installed, err := installFleetNextTo(exePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Auto-install failed: %v\n", err)
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Install fleet manually:")
+		fmt.Fprintln(os.Stderr, "  brew install brizzai/tap/fleet")
+		fmt.Fprintln(os.Stderr, "  # or")
+		fmt.Fprintln(os.Stderr, "  curl -fsSL https://raw.githubusercontent.com/brizzai/fleet/master/install.sh | bash")
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "Installed fleet to %s\n", installed)
+	execFleet(installed)
+}
+
+func execFleet(path string) {
+	args := append([]string{path}, os.Args[1:]...)
+	if err := syscall.Exec(path, args, os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to exec fleet: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func printDeprecationWarning() {
+	if !shouldWarn() {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "⚠  brizz-code has been renamed to fleet (shim %s).\n", version)
+	fmt.Fprintln(os.Stderr, "   Switch to the `fleet` command — this wrapper will be removed in a future release.")
+	fmt.Fprintln(os.Stderr, "")
+	recordWarning()
+}
+
+func warnStatePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "fleet", warnStateName)
+}
+
+func shouldWarn() bool {
+	path := warnStatePath()
+	if path == "" {
+		return true
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return true
+	}
+	ts, err := time.Parse(time.RFC3339, strings.TrimSpace(string(data)))
+	if err != nil {
+		return true
+	}
+	return time.Since(ts) >= warnInterval
+}
+
+func recordWarning() {
+	path := warnStatePath()
+	if path == "" {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(path), 0700)
+	_ = os.WriteFile(path, []byte(time.Now().Format(time.RFC3339)), 0600)
+}
+
+func isBrewPath(p string) bool {
+	if p == "" {
+		return false
+	}
+	staticPrefixes := []string{
+		"/opt/homebrew/",
+		"/usr/local/Homebrew/",
+		"/usr/local/Cellar/",
+		"/opt/homebrew/Cellar/",
+		"/home/linuxbrew/",
+	}
+	for _, pre := range staticPrefixes {
+		if strings.HasPrefix(p, pre) {
+			return true
+		}
+	}
+	if out, err := exec.Command("brew", "--prefix").Output(); err == nil {
+		prefix := strings.TrimSpace(string(out))
+		if prefix != "" && strings.HasPrefix(p, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+type releaseInfo struct {
+	TagName string         `json:"tag_name"`
+	Assets  []releaseAsset `json:"assets"`
+}
+
+type releaseAsset struct {
+	Name string `json:"name"`
+	URL  string `json:"browser_download_url"`
+}
+
+func installFleetNextTo(brizzExe string) (string, error) {
+	if brizzExe == "" {
+		return "", fmt.Errorf("could not determine install location")
+	}
+	targetDir := filepath.Dir(brizzExe)
+
+	rel, err := fetchLatestRelease()
+	if err != nil {
+		return "", fmt.Errorf("fetch release: %w", err)
+	}
+	ver := strings.TrimPrefix(rel.TagName, "v")
+	archiveName := fmt.Sprintf("fleet_%s_darwin_%s.tar.gz", ver, runtime.GOARCH)
+
+	var archiveURL, checksumsURL string
+	for _, a := range rel.Assets {
+		switch a.Name {
+		case archiveName:
+			archiveURL = a.URL
+		case "checksums.txt":
+			checksumsURL = a.URL
+		}
+	}
+	if archiveURL == "" {
+		return "", fmt.Errorf("asset %s not found in release %s", archiveName, rel.TagName)
+	}
+
+	archiveData, err := httpGet(archiveURL)
+	if err != nil {
+		return "", fmt.Errorf("download %s: %w", archiveName, err)
+	}
+
+	if checksumsURL != "" {
+		if sums, err := httpGet(checksumsURL); err == nil {
+			if want := lookupChecksum(string(sums), archiveName); want != "" {
+				sum := sha256.Sum256(archiveData)
+				got := hex.EncodeToString(sum[:])
+				if got != want {
+					return "", fmt.Errorf("checksum mismatch for %s: want %s got %s", archiveName, want, got)
+				}
+			}
+		}
+	}
+
+	bin, err := extractFleetBinary(bytes.NewReader(archiveData))
+	if err != nil {
+		return "", fmt.Errorf("extract: %w", err)
+	}
+
+	targetPath := filepath.Join(targetDir, "fleet")
+	tmp, err := os.CreateTemp(targetDir, "fleet-install-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(bin); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return "", err
+	}
+	tmp.Close()
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		os.Remove(tmpPath)
+		return "", err
+	}
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		os.Remove(tmpPath)
+		return "", err
+	}
+	return targetPath, nil
+}
+
+func fetchLatestRelease() (*releaseInfo, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest("GET", apiLatest, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+	var rel releaseInfo
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, err
+	}
+	return &rel, nil
+}
+
+func httpGet(url string) ([]byte, error) {
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func lookupChecksum(text, name string) string {
+	for line := range strings.SplitSeq(text, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == name {
+			return fields[0]
+		}
+	}
+	return ""
+}
+
+func extractFleetBinary(r io.Reader) ([]byte, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if filepath.Base(hdr.Name) == "fleet" && hdr.Typeflag == tar.TypeReg {
+			return io.ReadAll(tr)
+		}
+	}
+	return nil, fmt.Errorf("fleet binary not found in archive")
+}

--- a/cmd/brizz-code-shim/main.go
+++ b/cmd/brizz-code-shim/main.go
@@ -42,15 +42,28 @@ const (
 )
 
 func main() {
-	printDeprecationWarning()
-
-	if path, err := exec.LookPath("fleet"); err == nil {
-		execFleet(path)
-	}
-
 	exePath, _ := os.Executable()
 	if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
 		exePath = resolved
+	}
+
+	// Chrome launches native messaging hosts with `chrome-extension://...` as
+	// the sole argument and speaks a length-prefixed JSON protocol on stdio.
+	// v1.x `brizz-code` NMH manifests still point Chrome here until fleet runs
+	// interactively and rewrites the manifest, so suppress all human-facing
+	// output on this code path and just bridge to fleet (or exit non-zero so
+	// Chrome retries later).
+	if len(os.Args) > 1 && strings.HasPrefix(os.Args[1], "chrome-extension://") {
+		if path, err := exec.LookPath("fleet"); err == nil && !resolvesToSelf(path, exePath) {
+			execFleet(path)
+		}
+		os.Exit(1)
+	}
+
+	printDeprecationWarning()
+
+	if path, err := exec.LookPath("fleet"); err == nil && !resolvesToSelf(path, exePath) {
+		execFleet(path)
 	}
 
 	if isBrewPath(exePath) {
@@ -129,6 +142,24 @@ func recordWarning() {
 	_ = os.WriteFile(path, []byte(time.Now().Format(time.RFC3339)), 0600)
 }
 
+// resolvesToSelf reports whether `candidate` ultimately points at the same
+// file as `self`. Used to skip a `fleet` entry on PATH that is actually this
+// shim binary (or a symlink to it), which would cause an infinite re-exec.
+func resolvesToSelf(candidate, self string) bool {
+	if candidate == "" || self == "" {
+		return false
+	}
+	if candidate == self {
+		return true
+	}
+	cr, errC := filepath.EvalSymlinks(candidate)
+	sr, errS := filepath.EvalSymlinks(self)
+	if errC != nil || errS != nil {
+		return false
+	}
+	return cr == sr
+}
+
 func isBrewPath(p string) bool {
 	if p == "" {
 		return false
@@ -195,16 +226,24 @@ func installFleetNextTo(brizzExe string) (string, error) {
 		return "", fmt.Errorf("download %s: %w", archiveName, err)
 	}
 
-	if checksumsURL != "" {
-		if sums, err := httpGet(checksumsURL); err == nil {
-			if want := lookupChecksum(string(sums), archiveName); want != "" {
-				sum := sha256.Sum256(archiveData)
-				got := hex.EncodeToString(sum[:])
-				if got != want {
-					return "", fmt.Errorf("checksum mismatch for %s: want %s got %s", archiveName, want, got)
-				}
-			}
-		}
+	// Fail closed: every fleet release ships checksums.txt with an entry for
+	// every archive. Missing manifest, fetch failure, missing entry, and
+	// mismatched digest are all fatal — we're about to syscall.Exec this binary.
+	if checksumsURL == "" {
+		return "", fmt.Errorf("checksums.txt not found in release %s", rel.TagName)
+	}
+	sums, err := httpGet(checksumsURL)
+	if err != nil {
+		return "", fmt.Errorf("download checksums.txt: %w", err)
+	}
+	want := lookupChecksum(string(sums), archiveName)
+	if want == "" {
+		return "", fmt.Errorf("checksum for %s not found in checksums.txt", archiveName)
+	}
+	sum := sha256.Sum256(archiveData)
+	got := hex.EncodeToString(sum[:])
+	if got != want {
+		return "", fmt.Errorf("checksum mismatch for %s: want %s got %s", archiveName, want, got)
 	}
 
 	bin, err := extractFleetBinary(bytes.NewReader(archiveData))


### PR DESCRIPTION
## Summary

- v1.x `brizz-code` binaries auto-update from `brizzai/brizz-code` (now redirected to `brizzai/fleet`) and look for `brizz-code_<ver>_<os>_<arch>.tar.gz` assets containing a binary named `brizz-code`. After the rename, releases ship `fleet_*` only, so auto-update fails with `asset brizz-code_X.Y.Z_darwin_arm64.tar.gz not found in release` and users are stranded on v1.3.0.
- This PR adds a small shim binary, packaged as the legacy asset name, that v1.x clients can successfully auto-update to. The shim then bridges them to `fleet`.

## How it works

The shim is built by goreleaser into a `brizz-code_<ver>_<os>_<arch>.tar.gz` archive whose binary is named `brizz-code` (matching the v1.x extractor's expectations). On invocation:

1. Prints a deprecation warning to stderr (rate-limited to once per 24h via `~/.config/fleet/brizz-code-deprecation-warned`).
2. If `fleet` is on `PATH` → `syscall.Exec` into it with the original args. **`brizz-code` keeps working.**
3. Else if the shim lives under a Homebrew prefix (`/opt/homebrew`, `/usr/local/Homebrew`, `brew --prefix`, …) → print `brew install brizzai/tap/fleet` and exit. (We don't drop a non-brew-managed `fleet` next to a brew-managed binary — it would conflict on a later `brew install`.)
4. Else → fetch the latest release, verify the archive against `checksums.txt`, extract `fleet`, install it next to the shim, and exec it. Subsequent runs hit the fast path in step 2.

End-to-end: a v1.x user on auto-update silently lands on the shim within ~1h of their next launch (via the existing v1.3.0 auto-update path → `os.Rename` swap → `syscall.Exec`), then continues working with `fleet` underneath.

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `goreleaser check` ✓
- `goreleaser release --snapshot --skip=publish` produced both `brizz-code_*.tar.gz` (containing binary `brizz-code`) and `fleet_*.tar.gz` (containing binary `fleet`); Homebrew cask references the `fleet_*` archive only. ✓

## Test plan

- [ ] Merge & `/ship` to cut v2.3.1.
- [ ] Confirm the release has all 4 archives: `brizz-code_2.3.1_darwin_{arm64,amd64}.tar.gz` + `fleet_2.3.1_darwin_{arm64,amd64}.tar.gz`.
- [ ] On a machine with a v1.3.0 `brizz-code` binary outside any brew prefix (e.g. `~/.local/bin/brizz-code`): launch it, watch auto-update apply, then verify the shim auto-installs `fleet` next to it and execs into the TUI.
- [ ] On a brew-installed v1.3.0 machine: launch `brizz-code`, confirm the shim prints `brew install brizzai/tap/fleet` and exits non-zero.
- [ ] Re-invoke the shim within 24h → no second warning. After 24h → warning re-appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a compatibility shim for the legacy `brizz-code` command that displays a deprecation notice and seamlessly transitions users to the `fleet` command via automatic installation from GitHub, direct execution when available, or Homebrew installation guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brizzai/fleet/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->