### PR TITLE
fix(release): strip quarantine on brew cask install; correct shim brew message

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,6 +58,13 @@ homebrew_casks:
       - default
     binaries:
       - fleet
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/fleet"]
+          end
     repository:
       owner: brizzai
       name: homebrew-tap

--- a/changelog/unreleased/brew-gatekeeper-fix.md
+++ b/changelog/unreleased/brew-gatekeeper-fix.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+`brew install brizzai/tap/fleet` no longer trips macOS Gatekeeper on first launch — the cask now strips the `com.apple.quarantine` attribute via a postflight hook. Also fixed the legacy `brizz-code` shim's brew-path message to point at `brew uninstall brizz-code` + `brew install brizzai/tap/fleet` instead of the incorrect `rm -f` line.

--- a/cmd/brizz-code-shim/main.go
+++ b/cmd/brizz-code-shim/main.go
@@ -69,10 +69,8 @@ func main() {
 	if isBrewPath(exePath) {
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Install fleet via Homebrew:")
+		fmt.Fprintln(os.Stderr, "  brew uninstall brizz-code")
 		fmt.Fprintln(os.Stderr, "  brew install brizzai/tap/fleet")
-		if exePath != "" {
-			fmt.Fprintf(os.Stderr, "  rm -f %q\n", exePath)
-		}
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary

Two follow-ups after v2.4.0 (the brizz-code shim release):

1. **macOS Gatekeeper blocks `fleet` on first launch when installed via the Homebrew cask** ("Apple could not verify 'fleet' is free of malware…"). Homebrew casks preserve the `com.apple.quarantine` extended attribute on extracted binaries; our binary is unsigned, so Gatekeeper trips. Affects every brew-cask user.
2. **The shim's brew-path message was wrong.** It printed `rm -f /opt/homebrew/Caskroom/brizz-code/<ver>/brizz-code`, which leaves brew with a half-installed cask. Correct cleanup is `brew uninstall brizz-code`.

## Changes

- `.goreleaser.yml` — add `hooks.post.install` to the `homebrew_casks` block. Goreleaser renders this into the generated `Casks/fleet.rb` as a `postflight do … end` that runs `xattr -dr com.apple.quarantine "#{staged_path}/fleet"` after install. Verified by inspecting the generated cask from `goreleaser release --snapshot`.
- `cmd/brizz-code-shim/main.go` — replace the `rm -f` line with `brew uninstall brizz-code` + `brew install brizzai/tap/fleet`. The `exePath` interpolation in this branch is dropped (no longer needed).
- `changelog/unreleased/brew-gatekeeper-fix.md` — fragment, `type: fixed`.

## Notes for existing users

After v2.4.1 ships:
- **Fresh brew install** → no Gatekeeper prompt.
- **Existing v2.4.0 brew installs** are still quarantined. Either `xattr -d com.apple.quarantine "$(which fleet)"` once, or `brew reinstall fleet` (re-extracts → postflight runs).
- **v1.x brizz-code cask migrators** (the original target of the shim) now get the correct `brew uninstall brizz-code` + `brew install brizzai/tap/fleet` message.

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `goreleaser check` ✓
- `goreleaser release --snapshot --skip=publish` produces `dist/homebrew/Casks/fleet.rb` containing the expected `postflight do …` block; all 4 archives (`fleet_*` + `brizz-code_*`) still build. ✓

## Test plan

- [ ] Merge + `/ship 2.4.1`
- [ ] On a clean Mac: `brew install brizzai/tap/fleet` → run `fleet` → no Gatekeeper prompt
- [ ] On an existing v2.4.0 cask install: `brew reinstall fleet` → run `fleet` → no Gatekeeper prompt
- [ ] On a v1.x brizz-code cask install (or simulated): run `brizz-code` → shim prints `brew uninstall brizz-code` + `brew install brizzai/tap/fleet` (not the old `rm -f` line)

## Out of scope (noted)

- Proper code signing + notarization (Apple Developer cert, ~\$99/yr) would obviate the quarantine hack entirely. Deferred until the project's ready to manage a cert.
- The legacy `Casks/brizz-code.rb` in `brizzai/homebrew-tap` is unchanged here; `brew uninstall brizz-code` works against it as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)