### PR TITLE
docs(site): polish TUI demo — remove [1] badge, de-cluster status flips

### DIFF
--- a/site/components/tui-demo/TuiDemo.tsx
+++ b/site/components/tui-demo/TuiDemo.tsx
@@ -40,15 +40,28 @@ export function TuiDemo() {
     return () => clearInterval(id);
   }, []);
 
-  // Script ticker — auto-play idle behavior
+  // Script ticker — auto-play idle behavior. Uses jittered setTimeout chain
+  // (instead of setInterval) so events don't fire on a perfect metronome,
+  // which prevents the demo from looking like everything changes in lockstep.
   useEffect(() => {
-    const id = setInterval(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const tick = () => {
+      if (cancelled) return;
       const now = Date.now();
-      if (isScriptPaused(stateRef.current, now)) return;
-      const ev = nextScriptEvent(stateRef.current);
-      if (ev) dispatch({ type: "script_event", event: ev });
-    }, SCRIPT_INTERVAL_MS);
-    return () => clearInterval(id);
+      if (!isScriptPaused(stateRef.current, now)) {
+        const ev = nextScriptEvent(stateRef.current);
+        if (ev) dispatch({ type: "script_event", event: ev });
+      }
+      // ±35% jitter around SCRIPT_INTERVAL_MS
+      const next = SCRIPT_INTERVAL_MS * (0.65 + Math.random() * 0.7);
+      timer = setTimeout(tick, next);
+    };
+    timer = setTimeout(tick, SCRIPT_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
   }, []);
 
   // Promote any `starting` sessions to `running` after ~1.6s

--- a/site/components/tui-demo/script.ts
+++ b/site/components/tui-demo/script.ts
@@ -13,6 +13,18 @@ function rng<T>(pool: readonly T[]): T {
 }
 
 /**
+ * Sessions can't transition status again until this many ms after their last
+ * status change. Stops the demo from feeling like everything flips at once
+ * (e.g. after a wave of approvals, all the approved sessions would otherwise
+ * head straight back to waiting on consecutive ticks).
+ */
+const STATUS_COOLDOWN_MS = 5_500;
+
+function fresh(s: Session, now: number): boolean {
+  return now - (s.lastStatusChangeAt ?? 0) >= STATUS_COOLDOWN_MS;
+}
+
+/**
  * Possible auto-play events with relative weights. Each recipe returns null
  * when no eligible session exists this tick — the dispatcher filters those
  * out so the chosen event always has a valid target. This is what keeps the
@@ -20,13 +32,15 @@ function rng<T>(pool: readonly T[]): T {
  */
 const RECIPES: Array<{
   weight: number;
-  make: (sessions: Session[]) => ScriptEvent | null;
+  make: (sessions: Session[], now: number) => ScriptEvent | null;
 }> = [
   // running → waiting (the headline behavior — most "fun")
   {
     weight: 32,
-    make: (sessions) => {
-      const c = sessions.filter((s) => s.status === "running");
+    make: (sessions, now) => {
+      const c = sessions.filter(
+        (s) => s.status === "running" && fresh(s, now),
+      );
       if (!c.length) return null;
       return { kind: "set_waiting", sessionId: rng(c).id };
     },
@@ -34,8 +48,10 @@ const RECIPES: Array<{
   // waiting → running (auto-resolution, prevents the demo deadlocking)
   {
     weight: 18,
-    make: (sessions) => {
-      const c = sessions.filter((s) => s.status === "waiting");
+    make: (sessions, now) => {
+      const c = sessions.filter(
+        (s) => s.status === "waiting" && fresh(s, now),
+      );
       if (!c.length) return null;
       return { kind: "flip_status", sessionId: rng(c).id, to: "running" };
     },
@@ -43,8 +59,10 @@ const RECIPES: Array<{
   // running → finished
   {
     weight: 16,
-    make: (sessions) => {
-      const c = sessions.filter((s) => s.status === "running");
+    make: (sessions, now) => {
+      const c = sessions.filter(
+        (s) => s.status === "running" && fresh(s, now),
+      );
       if (!c.length) return null;
       return { kind: "flip_status", sessionId: rng(c).id, to: "finished" };
     },
@@ -52,15 +70,16 @@ const RECIPES: Array<{
   // finished/idle → running
   {
     weight: 15,
-    make: (sessions) => {
+    make: (sessions, now) => {
       const c = sessions.filter(
-        (s) => s.status === "finished" || s.status === "idle",
+        (s) =>
+          (s.status === "finished" || s.status === "idle") && fresh(s, now),
       );
       if (!c.length) return null;
       return { kind: "flip_status", sessionId: rng(c).id, to: "running" };
     },
   },
-  // refresh activity text on a running session
+  // refresh activity text on a running session (no cooldown — visual only)
   {
     weight: 17,
     make: (sessions) => {
@@ -78,11 +97,12 @@ const RECIPES: Array<{
 export function nextScriptEvent(state: DemoState): ScriptEvent | null {
   const sessions = state.repos.flatMap((r) => r.sessions);
   if (!sessions.length) return null;
+  const now = Date.now();
 
   // Materialize only viable events (recipe + concrete event with a real target).
   const viable: Array<{ weight: number; event: ScriptEvent }> = [];
   for (const recipe of RECIPES) {
-    const event = recipe.make(sessions);
+    const event = recipe.make(sessions, now);
     if (event) viable.push({ weight: recipe.weight, event });
   }
   if (!viable.length) return null;

--- a/site/components/tui-demo/state.ts
+++ b/site/components/tui-demo/state.ts
@@ -15,6 +15,13 @@ export interface Session {
   activity?: string;
   /** When true, a fake permission prompt is shown and Y will approve it. */
   pendingApprove?: boolean;
+  /**
+   * Wall-clock ms when this session last had a *status* transition.
+   * The auto-play script uses this to skip recently-flipped sessions, so the
+   * demo doesn't visually cluster (everything turning waiting at once after
+   * a wave of approvals, etc).
+   */
+  lastStatusChangeAt?: number;
 }
 
 export type PRState = "pending" | "approved" | "failing" | "merged";
@@ -94,7 +101,6 @@ export const INITIAL_STATE: DemoState = {
           id: "s1",
           name: "api-fix",
           status: "running",
-          slot: 1,
           activity: "Editing internal/api/routes.go",
         },
         {
@@ -306,6 +312,7 @@ export function reducer(state: DemoState, action: Action): DemoState {
                       status: "running" as Status,
                       pendingApprove: false,
                       activity: "Approved — resuming…",
+                      lastStatusChangeAt: now,
                     },
               ),
             },
@@ -323,6 +330,7 @@ export function reducer(state: DemoState, action: Action): DemoState {
         name,
         status: "starting",
         activity: "Spawning Claude session…",
+        lastStatusChangeAt: now,
       };
       const repos = state.repos.map((r, i) =>
         i === repoIdx ? { ...r, sessions: [...r.sessions, session], collapsed: false } : r,
@@ -409,6 +417,7 @@ export function reducer(state: DemoState, action: Action): DemoState {
                       pendingApprove: false,
                       activity:
                         text.length > 70 ? `${text.slice(0, 70)}…` : text,
+                      lastStatusChangeAt: now,
                     },
               ),
             },
@@ -440,6 +449,7 @@ export function reducer(state: DemoState, action: Action): DemoState {
                         : ev.to === "finished"
                           ? "Done. Awaiting next prompt."
                           : s.activity,
+                    lastStatusChangeAt: now,
                   }
                 : s,
             ),
@@ -456,6 +466,7 @@ export function reducer(state: DemoState, action: Action): DemoState {
                     status: "waiting" as Status,
                     pendingApprove: true,
                     activity: "Permission requested: Tool use Bash",
+                    lastStatusChangeAt: now,
                   }
                 : s,
             ),


### PR DESCRIPTION
## Summary

Three small polish fixes for the landing-page TUI demo.

- **Remove the cyan `[1]` slot badge** next to `api-fix` in the demo's initial state — it implied a feature (RTS-style slot bindings) that isn't actually drivable inside the demo.
- **De-cluster status flips.** When you approved a batch of waiting sessions back to running, the auto-play script would drag several of them straight back to waiting on the next few ticks. Two changes fix this:
  - Per-session 5.5s status-change cooldown — sessions can't flip status again that fast. `set_activity` (text-only refresh) is exempt so running sessions still look lively while cooling down.
  - Tick jitter — script ran on a strict 1364ms `setInterval`. Now a `setTimeout` chain schedules each next tick at `±35%` jitter (887–2319ms range), so events stop feeling rhythmic.

## Type of Change

- [x] Documentation
- [x] Improvement

## Checklist

- [x] Site \`npm run build\` succeeds locally
- [ ] No changelog fragment — this only changes the demo's behavior on the marketing site; no fleet-binary user impact

## Test plan

- [ ] Open https://brizzai.github.io/fleet/ (after deploy) and confirm `api-fix` no longer has a `[1]` badge
- [ ] Click into the demo, press `Space` to jump through waiting sessions, hit `Enter` to approve a few in quick succession — sessions should stagger naturally back to waiting/finished rather than all flipping within the next 2 ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced demo session timing with jittered intervals for more realistic behavior
  * Added status transition cooldown to prevent rapid state changes and improve overall demo stability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brizzai/fleet/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->