### PR TITLE
feat(naming): title sessions from Claude's native ai-title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,9 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Error history: ring buffer (max 50) of errors that flash for 5s — persists for bug reporting
 - Action log: ring buffer (max 100) of user actions (attach, delete, restart, editor, approve, etc.) for "steps to reproduce"
 - Diagnostics: app version, macOS version, tmux/claude/gh versions, config, last 100 lines of debug.log; home dir sanitized to `~`
-- Auto-naming: sessions auto-titled from user prompt via smart heuristic (filler stripping, word-boundary truncation)
-- Auto-naming pipeline: UserPromptSubmit hook → status file → HookWatcher → Session.FirstPrompt → worker cycle → naming.GenerateTitle
-- Retitle: after 3 prompts, title regenerated from latest prompt (better reflects session scope)
+- Auto-naming: sessions titled from Claude's own session title, read from the conversation JSONL (`session.ReadClaudeSessionName`); falls back to fleet's prompt heuristic (filler stripping, word-boundary truncation) only when Claude has written no title yet
+- Title precedence: manual R-key rename (`ManuallyRenamed`) > Claude `custom-title` (`/rename` in-session) > Claude `ai-title` (auto, model-generated, evolves with the work) > fleet prompt heuristic
+- Auto-naming pipeline: worker cycle re-reads the JSONL each cycle until a Claude title appears (prompt pickup within ~2s), then ~every 30s to follow `ai-title`/`custom-title` drift; heuristic fallback uses UserPromptSubmit hook → status file → HookWatcher → Session.FirstPrompt → naming.GenerateTitle
 - Manual rename (R key) sets ManuallyRenamed flag, prevents auto-rename
 - Chrome tab control: `p` opens PR in Chrome via extension (reuses existing tab), falls back to `open <url>` if unavailable
 - Chrome extension architecture: TUI →[unix socket]→ native host (`fleet chrome-host`) →[stdio]→ Chrome service worker

--- a/changelog/unreleased/ai-title-sessions.md
+++ b/changelog/unreleased/ai-title-sessions.md
@@ -1,0 +1,5 @@
+---
+type: improved
+---
+
+Session titles now use Claude's own model-generated title. fleet reads Claude Code's `ai-title` from the conversation transcript — the same title that evolves as the work shifts — instead of guessing from your first prompt and re-running a heuristic every few prompts. An in-session `/rename` (`custom-title`) still takes precedence, and fleet's `R` rename always wins. When Claude writes no title (e.g. title generation disabled), the old prompt heuristic remains as a fallback. Claude's occasional kebab-case slug titles (e.g. `native-ai-title-integration`) are spaced out for readability (`native ai title integration`) with their casing preserved, so acronyms like `API` survive.

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -40,8 +40,12 @@ func claudeProjectDir(cwd string) (string, error) {
 	return filepath.Join(home, ".claude", "projects", ClaudeProjectDirName(cwd)), nil
 }
 
-// ReadClaudeSessionName reads the custom session name from Claude's JSONL conversation file.
-// Returns empty string if not found.
+// ReadClaudeSessionName reads Claude's best title for a session from its JSONL
+// conversation file. Claude writes two kinds of title entries: "custom-title"
+// (an explicit /rename inside the session) and "ai-title" (a model-generated
+// title that updates as the work evolves). A custom title wins when present;
+// otherwise the latest ai-title is returned. Returns empty string if neither
+// is found.
 func ReadClaudeSessionName(claudeSessionID, projectPath string) string {
 	if claudeSessionID == "" || projectPath == "" {
 		return ""
@@ -62,27 +66,63 @@ func ReadClaudeSessionName(claudeSessionID, projectPath string) string {
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max buffer
 
-	var lastTitle string
+	var lastCustom, lastAI string
 	for scanner.Scan() {
 		line := scanner.Text()
-		// Quick check before JSON parsing.
-		if !strings.Contains(line, "custom-title") {
+		// Quick check before JSON parsing. Matches both "custom-title" and
+		// "ai-title"; the Type check below filters any incidental hits.
+		if !strings.Contains(line, "-title") {
 			continue
 		}
 
 		var entry struct {
 			Type        string `json:"type"`
 			CustomTitle string `json:"customTitle"`
+			AITitle     string `json:"aiTitle"`
 		}
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
 			continue
 		}
-		if entry.Type == "custom-title" && entry.CustomTitle != "" {
-			lastTitle = entry.CustomTitle
+		switch entry.Type {
+		case "custom-title":
+			if entry.CustomTitle != "" {
+				lastCustom = entry.CustomTitle
+			}
+		case "ai-title":
+			if entry.AITitle != "" {
+				lastAI = entry.AITitle
+			}
 		}
 	}
 
-	return lastTitle
+	if lastCustom != "" {
+		return lastCustom
+	}
+	return deslugify(lastAI)
+}
+
+// slugSeparators replaces a slug's word separators with spaces. Case is left
+// untouched on purpose.
+var slugSeparators = strings.NewReplacer("-", " ", "_", " ")
+
+// deslugify turns a kebab/snake slug into spaced words while preserving each
+// character's original case, so Claude's slug-style ai-titles read naturally:
+//
+//	native-ai-title-integration -> native ai title integration
+//	fix-API-client              -> fix API client
+//
+// It deliberately does NOT capitalize anything (no sentence/title/pascal case),
+// so an already-uppercase acronym like "API" survives but a lowercase word
+// stays lowercase. Titles that already contain spaces are natural language, not
+// slugs, and are returned unchanged.
+func deslugify(s string) string {
+	if s == "" || strings.Contains(s, " ") {
+		return s
+	}
+	if !strings.ContainsAny(s, "-_") {
+		return s
+	}
+	return slugSeparators.Replace(s)
 }
 
 // ErrParentTranscriptMissing is returned by CopyClaudeForkTranscript when the

--- a/internal/session/claude_name_test.go
+++ b/internal/session/claude_name_test.go
@@ -287,4 +287,112 @@ func TestReadClaudeSessionName(t *testing.T) {
 			t.Errorf("expected %q, got %q", "Valid Title", got)
 		}
 	})
+
+	// writeTranscript writes a JSONL transcript under a temp HOME and returns the
+	// (claudeSessionID, projectPath) to read it back.
+	writeTranscript := func(t *testing.T, name, content string) (string, string) {
+		t.Helper()
+		tmpHome := t.TempDir()
+		t.Setenv("HOME", tmpHome)
+		projectPath := "/test/" + name
+		claudeSessionID := "sid-" + name
+		projectDir := filepath.Join(tmpHome, ".claude", "projects", ClaudeProjectDirName(projectPath))
+		if err := os.MkdirAll(projectDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(projectDir, claudeSessionID+".jsonl"), []byte(content), 0o644); err != nil {
+			t.Fatalf("write jsonl: %v", err)
+		}
+		return claudeSessionID, projectPath
+	}
+
+	t.Run("ai-title only returns last aiTitle", func(t *testing.T) {
+		id, path := writeTranscript(t, "ai-only", `{"type":"message","content":"hi"}
+{"type":"ai-title","aiTitle":"First Topic"}
+{"type":"message","content":"more"}
+{"type":"ai-title","aiTitle":"Second Topic"}
+`)
+		if got := ReadClaudeSessionName(id, path); got != "Second Topic" {
+			t.Errorf("got %q, want %q", got, "Second Topic")
+		}
+	})
+
+	t.Run("custom-title wins over ai-title regardless of order", func(t *testing.T) {
+		id, path := writeTranscript(t, "custom-wins", `{"type":"ai-title","aiTitle":"Auto Title"}
+{"type":"custom-title","customTitle":"My Name"}
+{"type":"ai-title","aiTitle":"Auto Title Drifted"}
+`)
+		if got := ReadClaudeSessionName(id, path); got != "My Name" {
+			t.Errorf("got %q, want %q", got, "My Name")
+		}
+	})
+
+	t.Run("evolving ai-title returns the latest", func(t *testing.T) {
+		id, path := writeTranscript(t, "evolving", `{"type":"ai-title","aiTitle":"Boot Splash Work"}
+{"type":"ai-title","aiTitle":"Mutex Refactor"}
+{"type":"ai-title","aiTitle":"Title Swap"}
+`)
+		if got := ReadClaudeSessionName(id, path); got != "Title Swap" {
+			t.Errorf("got %q, want %q", got, "Title Swap")
+		}
+	})
+
+	t.Run("empty aiTitle is skipped", func(t *testing.T) {
+		id, path := writeTranscript(t, "empty-ai", `{"type":"ai-title","aiTitle":""}
+{"type":"message","content":"hi"}
+`)
+		if got := ReadClaudeSessionName(id, path); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("kebab ai-title is de-slugified, case preserved", func(t *testing.T) {
+		id, path := writeTranscript(t, "kebab-ai", `{"type":"ai-title","aiTitle":"native-ai-title-integration"}
+`)
+		if got := ReadClaudeSessionName(id, path); got != "native ai title integration" {
+			t.Errorf("got %q, want %q", got, "native ai title integration")
+		}
+	})
+
+	t.Run("de-slugify keeps existing uppercase acronyms", func(t *testing.T) {
+		id, path := writeTranscript(t, "acronym-ai", `{"type":"ai-title","aiTitle":"fix-API-client"}
+`)
+		if got := ReadClaudeSessionName(id, path); got != "fix API client" {
+			t.Errorf("got %q, want %q", got, "fix API client")
+		}
+	})
+
+	t.Run("sentence-case ai-title is left unchanged", func(t *testing.T) {
+		id, path := writeTranscript(t, "sentence-ai", `{"type":"ai-title","aiTitle":"Improve onboarding for Brizz users"}
+`)
+		if got := ReadClaudeSessionName(id, path); got != "Improve onboarding for Brizz users" {
+			t.Errorf("got %q, want unchanged", got)
+		}
+	})
+
+	t.Run("custom-title slug is NOT de-slugified (explicit rename)", func(t *testing.T) {
+		id, path := writeTranscript(t, "custom-slug", `{"type":"ai-title","aiTitle":"some-auto-title"}
+{"type":"custom-title","customTitle":"my-pinned-name"}
+`)
+		if got := ReadClaudeSessionName(id, path); got != "my-pinned-name" {
+			t.Errorf("got %q, want %q (custom-title verbatim)", got, "my-pinned-name")
+		}
+	})
+}
+
+func TestDeslugify(t *testing.T) {
+	cases := map[string]string{
+		"native-ai-title-integration":  "native ai title integration",
+		"fix-API-client":               "fix API client",
+		"snake_case_title":             "snake case title",
+		"Improve onboarding for Brizz": "Improve onboarding for Brizz", // has spaces → unchanged
+		"single":                       "single",                       // no separator → unchanged
+		"":                             "",
+		"well-known issue":             "well-known issue", // contains a space → natural language, unchanged
+	}
+	for in, want := range cases {
+		if got := deslugify(in); got != want {
+			t.Errorf("deslugify(%q) = %q, want %q", in, got, want)
+		}
+	}
 }

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -368,12 +368,6 @@ func (s *StateDB) MarkTitleGenerated(id string) error {
 	return err
 }
 
-// ResetTitleGenerated clears the title_generated flag to allow re-generation.
-func (s *StateDB) ResetTitleGenerated(id string) error {
-	_, err := s.db.Exec("UPDATE sessions SET title_generated = 0 WHERE id = ?", id)
-	return err
-}
-
 // UpdatePromptCount updates the prompt count for a session.
 func (s *StateDB) UpdatePromptCount(id string, count int) error {
 	_, err := s.db.Exec("UPDATE sessions SET prompt_count = ? WHERE id = ?", count, id)

--- a/internal/session/storage_test.go
+++ b/internal/session/storage_test.go
@@ -479,7 +479,7 @@ func TestUpdatePromptCount(t *testing.T) {
 	}
 }
 
-func TestMarkAndResetTitleGenerated(t *testing.T) {
+func TestMarkTitleGenerated(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
 
@@ -511,18 +511,6 @@ func TestMarkAndResetTitleGenerated(t *testing.T) {
 	}
 	if !sessions[0].TitleGenerated {
 		t.Error("expected TitleGenerated to be true")
-	}
-
-	// Reset.
-	if err := db.ResetTitleGenerated("titlegen-test"); err != nil {
-		t.Fatalf("ResetTitleGenerated failed: %v", err)
-	}
-	sessions, err = db.LoadSessions()
-	if err != nil {
-		t.Fatalf("LoadSessions failed: %v", err)
-	}
-	if sessions[0].TitleGenerated {
-		t.Error("expected TitleGenerated to be false after reset")
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3015,18 +3015,13 @@ func (h *Home) syncHookStatuses(sessions []*session.Session) []string {
 					debuglog.Logger.Error("storage: UpdateClaudeSessionID", "id", s.ID, "err", err)
 				}
 			}
-			// Persist prompt changes and reset title on every new prompt
-			// (for non-manually-renamed, non-Claude-named sessions).
+			// Persist prompt changes. Re-titling on later prompts is driven by
+			// Claude's own ai-title (read from the JSONL in the worker cycle),
+			// not by re-running the heuristic per prompt.
 			if s.PromptCount != oldPromptCount {
 				h.markSessionAccessed(s)
 				if err := h.storage.UpdatePromptCount(s.ID, s.PromptCount); err != nil {
 					debuglog.Logger.Error("storage: UpdatePromptCount", "id", s.ID, "err", err)
-				}
-				if h.cfg.IsAutoNameEnabled() && s.TitleGenerated && !s.ManuallyRenamed && s.ClaudeSessionName == "" {
-					s.TitleGenerated = false
-					if err := h.storage.ResetTitleGenerated(s.ID); err != nil {
-						debuglog.Logger.Error("storage: ResetTitleGenerated", "id", s.ID, "err", err)
-					}
 				}
 			}
 			if s.FirstPrompt != "" && s.FirstPrompt != oldFirstPrompt {
@@ -3096,15 +3091,17 @@ func (h *Home) statusWorkerCycle() {
 	h.syncHookStatuses(sessions)
 
 	// 3b. Auto-name: generate title for ONE session per cycle.
-	// Priority: manual (R key) > Claude session name > last prompt heuristic.
+	// Priority: manual (R key) > custom-title > ai-title > last prompt heuristic.
 	if h.cfg.IsAutoNameEnabled() {
 		for _, s := range sessions {
 			if s.ManuallyRenamed {
 				continue
 			}
 
-			// Periodically re-read Claude's session name from JSONL (~every 30s per session).
-			if s.ClaudeSessionID != "" && time.Since(s.ClaudeNameLastChecked) > 30*time.Second {
+			// Re-read Claude's title from the JSONL. Until we have one, check
+			// every cycle so a fresh session adopts its ai-title promptly;
+			// after that, re-check ~every 30s to follow custom-title/ai-title drift.
+			if s.ClaudeSessionID != "" && (s.ClaudeSessionName == "" || time.Since(s.ClaudeNameLastChecked) > 30*time.Second) {
 				s.ClaudeNameLastChecked = time.Now()
 				name := session.ReadClaudeSessionName(s.ClaudeSessionID, s.ProjectPath)
 				if name != "" && name != s.ClaudeSessionName {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -42,6 +42,15 @@ const (
 	focusFilterFooterRows  = 2 // border + content line — focus mode / filter active
 	statusRoundRobin       = 5 // sessions per tick
 	undoDeleteTimeout      = 5 * time.Second
+
+	// claudeNameRecheckInterval is the steady-state cadence for re-reading a
+	// session's title from its (growing) JSONL transcript.
+	claudeNameRecheckInterval = 30 * time.Second
+	// claudeNameFreshPollWindow is how long after creation a still-untitled
+	// session is polled every cycle so it adopts its ai-title promptly. Past
+	// this window the transcript is large enough that scanning it every tick is
+	// wasteful, so we fall back to claudeNameRecheckInterval.
+	claudeNameFreshPollWindow = 2 * time.Minute
 )
 
 // PendingDelete holds state for a deferred session deletion (undo window).
@@ -3098,10 +3107,17 @@ func (h *Home) statusWorkerCycle() {
 				continue
 			}
 
-			// Re-read Claude's title from the JSONL. Until we have one, check
-			// every cycle so a fresh session adopts its ai-title promptly;
-			// after that, re-check ~every 30s to follow custom-title/ai-title drift.
-			if s.ClaudeSessionID != "" && (s.ClaudeSessionName == "" || time.Since(s.ClaudeNameLastChecked) > 30*time.Second) {
+			// Re-read Claude's title from the JSONL. A freshly-created session
+			// with no title yet is polled every cycle so it adopts its ai-title
+			// promptly; otherwise (already titled, or old enough that its
+			// transcript is large) we re-check ~every 30s to follow
+			// custom-title/ai-title drift without re-scanning a growing file
+			// each tick.
+			recheck := claudeNameRecheckInterval
+			if s.ClaudeSessionName == "" && time.Since(s.CreatedAt) < claudeNameFreshPollWindow {
+				recheck = 0
+			}
+			if s.ClaudeSessionID != "" && time.Since(s.ClaudeNameLastChecked) >= recheck {
 				s.ClaudeNameLastChecked = time.Now()
 				name := session.ReadClaudeSessionName(s.ClaudeSessionID, s.ProjectPath)
 				if name != "" && name != s.ClaudeSessionName {


### PR DESCRIPTION
## What

Replaces fleet's prompt-heuristic session titling with Claude Code's own model-generated title.

Claude Code (2.1.x) writes its title into each session transcript as `{"type":"ai-title","aiTitle":"…"}` — a model-written title that **evolves as the work shifts**, at zero cost to fleet (Claude generates it regardless). Fleet already scanned that transcript for `custom-title` (`/rename`); this extends the same single-pass scan to also pick up `ai-title`.

### Title precedence (highest → lowest)
1. Fleet `R`-key rename (`ManuallyRenamed`) — already short-circuits auto-naming
2. Claude `custom-title` (`/rename` in-session) — returned verbatim
3. Claude `ai-title` (auto, evolves) — **new**
4. Fleet prompt heuristic (`naming.GenerateTitle`) — fallback only when Claude wrote no title

## Changes
- **`claude_name.go`** — `ReadClaudeSessionName` now captures both `custom-title` and `ai-title` (custom wins). Adds `deslugify`: Claude's occasional kebab-case slug titles (`native-ai-title-integration`) are spaced out for readability (`native ai title integration`) with **casing preserved**, so acronyms like `API` survive. Sentence-case titles and explicit `/rename` titles are left untouched.
- **`app.go`** — dropped the per-prompt retitle reset (ai-title drives drift now); fresh sessions adopt their ai-title within ~2s instead of waiting up to 30s; established sessions re-check at 30s for drift.
- **Docs/changelog** — updated CLAUDE.md auto-naming notes + added a changelog fragment.

## Why de-slug
Investigation showed both title styles users see are Claude's own `ai-title` — Claude writes natural-language titles for exploratory work and kebab slugs for focused branch/feature work (it can even flip mid-session). De-slugging normalizes the look without losing meaning.

## Out of scope (researched, deferred)
- Native `status` from `~/.claude/sessions/<pid>.json` (stale-file-prone; hook detection already covers it)
- `/recap` (computed on return, never persisted)
- `pr-link` (free PR number) and a plan-mode badge

## Test
- New `TestReadClaudeSessionName` subtests (ai-title only, custom wins, evolving → latest, empty skipped, kebab de-slugged, acronym preserved, sentence unchanged, custom-title verbatim) + a standalone `TestDeslugify` table.
- `make build` ✓ · `go test -race ./...` ✓ (no failures, no races)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions are now auto-named using Claude's AI-generated titles from conversations, providing more meaningful session names
  * Improved title formatting converts slug-style titles (kebab-case) into readable text while preserving capitalization for acronyms
  * Session titles are periodically refreshed to track updates from Claude
  * Custom session renames via `/rename` remain the highest priority in title precedence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->