### PR TITLE
feat(ui): first-run launchpad onboarding

### DIFF
--- a/changelog/unreleased/jump-collapsed-origins.md
+++ b/changelog/unreleased/jump-collapsed-origins.md
@@ -1,0 +1,4 @@
+---
+type: changed
+---
+`Space` (jump to next waiting/finished) now cycles only through **visible** sessions in on-screen order and skips anything inside a collapsed origin/checkout — fold a group to mute it from the jump cycle. (This also fixes jump sometimes only moving in one direction.) Jumping to a slot-bound session with the digit keys still reveals it, expanding its origin group and checkout if folded. `Space` is now labelled "Jump" in the session footer.

--- a/changelog/unreleased/jump-collapsed-origins.md
+++ b/changelog/unreleased/jump-collapsed-origins.md
@@ -1,4 +1,4 @@
 ---
 type: changed
 ---
-`Space` (jump to next waiting/finished) now cycles only through **visible** sessions in on-screen order and skips anything inside a collapsed origin/checkout — fold a group to mute it from the jump cycle. (This also fixes jump sometimes only moving in one direction.) Jumping to a slot-bound session with the digit keys still reveals it, expanding its origin group and checkout if folded. `Space` is now labelled "Jump" in the session footer.
+`Space` (jump to next waiting/finished) now cycles in on-screen order and skips sessions inside a **collapsed origin** — fold an origin to mute its sessions from the jump cycle. A collapsed branch/checkout under an *expanded* origin is still reached: jump expands just that checkout to reveal the target. (This also fixes jump sometimes only moving in one direction.) Jumping to a slot-bound session with the digit keys still reveals it, expanding its origin group and checkout if folded. `Space` is now labelled "Jump" in the session footer.

--- a/changelog/unreleased/launchpad-onboarding.md
+++ b/changelog/unreleased/launchpad-onboarding.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+First-run launchpad: when the fleet is empty, fleet now scans your Claude Code history (`~/.claude/projects`) and offers the repos & worktrees you've recently worked in — grouped by origin with nested branches, exactly like the sidebar — instead of a blank "No Sessions Yet" screen. They're all pre-checked, so a single `↵` adds your whole working set: each repo/worktree is pinned and its last conversation resumed (`claude --resume`). `space` toggles a row, `A` selects all/none, `n` types a path, `Esc` falls back to the bare empty state. The boot splash stays up through the scan and reveals the launchpad in one transition. Non-git and missing paths are dropped.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1,0 +1,221 @@
+// Package discovery surfaces the projects a user has recently worked in with
+// Claude Code, by reading Claude's transcript journal at ~/.claude/projects.
+//
+// Fleet uses this to turn an empty first-run screen into a launchpad: instead
+// of asking a new user to type a filesystem path from memory, it shows the
+// repos they already use — ready to resume the exact conversation they left.
+package discovery
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/brizzai/fleet/internal/git"
+	"github.com/brizzai/fleet/internal/naming"
+)
+
+// Recent is one project the user has run Claude Code in, resolved to a real
+// on-disk path with the newest conversation ready to resume.
+type Recent struct {
+	Path            string    // real cwd, read from the transcript (dash-safe)
+	Branch          string    // git branch recorded in the transcript
+	OriginKey       string    // git origin identity (git.GetOriginKey), for grouping
+	ClaudeSessionID string    // newest transcript's id — the resume target
+	Title           string    // derived from the first real user prompt
+	LastUsed        time.Time // newest transcript's mtime
+	IsWorktree      bool      // cwd/.git is a file (linked worktree) vs a dir
+}
+
+const (
+	maxLineScan = 400             // lines to scan per transcript before giving up
+	maxLineSize = 8 * 1024 * 1024 // generous cap for a single JSONL line
+)
+
+// RecentRepos scans ~/.claude/projects and returns up to limit git projects,
+// most-recently-used first. Non-git dirs and paths that no longer exist are
+// dropped. Best-effort: unreadable entries are skipped silently. A limit <= 0
+// returns every match.
+func RecentRepos(limit int) []Recent {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	entries, err := os.ReadDir(filepath.Join(home, ".claude", "projects"))
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var out []Recent
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		rec, ok := readProject(filepath.Join(home, ".claude", "projects", e.Name()))
+		if !ok || seen[rec.Path] {
+			continue
+		}
+		seen[rec.Path] = true
+		out = append(out, rec)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].LastUsed.After(out[j].LastUsed) })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	// Resolve the git origin only for the items we'll actually show — each is a
+	// `git config` call, so we don't want it for the whole (possibly large)
+	// candidate set. This is what lets the launchpad group worktrees of one
+	// repo under a single origin header, exactly like fleet's sidebar.
+	for i := range out {
+		out[i].OriginKey = git.GetOriginKey(out[i].Path)
+	}
+	return out
+}
+
+// readProject reads one ~/.claude/projects/<dir>, resolving the newest
+// transcript's cwd, branch, session id and a derived title. Returns ok=false
+// when the dir holds no usable transcript or the cwd is gone / not a git repo.
+func readProject(dir string) (Recent, bool) {
+	path, sessionID, mod := newestTranscript(dir)
+	if path == "" {
+		return Recent{}, false
+	}
+	cwd, branch, prompt := scanTranscript(path)
+	if cwd == "" {
+		return Recent{}, false
+	}
+	if info, err := os.Stat(cwd); err != nil || !info.IsDir() {
+		return Recent{}, false
+	}
+	// Fleet manages git repos and worktrees — skip plain directories (e.g. the
+	// home dir, where Claude is sometimes run ad hoc).
+	gitInfo, err := os.Stat(filepath.Join(cwd, ".git"))
+	if err != nil {
+		return Recent{}, false
+	}
+
+	title := naming.GenerateTitle(prompt)
+	if title == "" {
+		title = filepath.Base(cwd)
+	}
+	return Recent{
+		Path:            cwd,
+		Branch:          branch,
+		ClaudeSessionID: sessionID,
+		Title:           title,
+		LastUsed:        mod,
+		IsWorktree:      !gitInfo.IsDir(), // linked worktrees carry a .git *file*
+	}, true
+}
+
+// newestTranscript returns the path, session id (filename sans .jsonl) and
+// mtime of the most-recently-modified non-empty .jsonl in dir.
+func newestTranscript(dir string) (path, sessionID string, mod time.Time) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", "", time.Time{}
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.Size() == 0 {
+			continue
+		}
+		if info.ModTime().After(mod) {
+			mod = info.ModTime()
+			path = filepath.Join(dir, e.Name())
+			sessionID = strings.TrimSuffix(e.Name(), ".jsonl")
+		}
+	}
+	return path, sessionID, mod
+}
+
+// transcriptLine is the subset of a Claude Code JSONL entry we read.
+type transcriptLine struct {
+	Type      string `json:"type"`
+	IsMeta    bool   `json:"isMeta"`
+	Cwd       string `json:"cwd"`
+	GitBranch string `json:"gitBranch"`
+	Message   struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+// scanTranscript walks a transcript for the recorded cwd/branch and the first
+// real user prompt (skipping meta lines and command/caveat blocks). Stops as
+// soon as both are known, or after maxLineScan lines — the early entries are
+// all we need, so even multi-megabyte transcripts stay cheap.
+func scanTranscript(path string) (cwd, branch, prompt string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", "", ""
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), maxLineSize)
+	for n := 0; sc.Scan() && n < maxLineScan; n++ {
+		var ln transcriptLine
+		if err := json.Unmarshal(sc.Bytes(), &ln); err != nil {
+			continue
+		}
+		if cwd == "" && ln.Cwd != "" {
+			cwd, branch = ln.Cwd, ln.GitBranch
+		}
+		if prompt == "" && ln.Type == "user" && !ln.IsMeta {
+			prompt = firstPromptText(ln.Message.Content)
+		}
+		if cwd != "" && prompt != "" {
+			break
+		}
+	}
+	return cwd, branch, prompt
+}
+
+// firstPromptText pulls human prompt text from a message content field, which
+// is either a JSON string or an array of typed parts. Returns "" for tool
+// results and command/caveat blocks (which begin with "<").
+func firstPromptText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return cleanPrompt(s)
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &parts) == nil {
+		for _, p := range parts {
+			if p.Type == "text" {
+				if t := cleanPrompt(p.Text); t != "" {
+					return t
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// cleanPrompt trims a prompt and rejects the messages Claude records as
+// "user" turns that aren't real typed prompts: command/caveat blocks wrapped
+// in tags (<local-command-caveat>) and bracketed system notices
+// ([Request interrupted by user]).
+func cleanPrompt(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.HasPrefix(s, "<") || strings.HasPrefix(s, "[") {
+		return ""
+	}
+	return s
+}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -50,21 +50,33 @@ func RecentRepos(limit int) []Recent {
 		return nil
 	}
 
-	seen := make(map[string]bool)
 	var out []Recent
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
 		}
 		rec, ok := readProject(filepath.Join(home, ".claude", "projects", e.Name()))
-		if !ok || seen[rec.Path] {
+		if !ok {
 			continue
 		}
-		seen[rec.Path] = true
 		out = append(out, rec)
 	}
 
 	sort.Slice(out, func(i, j int) bool { return out[i].LastUsed.After(out[j].LastUsed) })
+	// Dedup AFTER the recency sort so the kept record per resolved cwd is the
+	// most-recently-used one — two project dirs can map to the same path (e.g.
+	// a /var ↔ /private/var symlink), and the resume target must be the latest
+	// transcript, not whichever dir sorted first alphabetically.
+	seen := make(map[string]bool, len(out))
+	deduped := out[:0]
+	for _, rec := range out {
+		if seen[rec.Path] {
+			continue
+		}
+		seen[rec.Path] = true
+		deduped = append(deduped, rec)
+	}
+	out = deduped
 	if limit > 0 && len(out) > limit {
 		out = out[:limit]
 	}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -1,0 +1,103 @@
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTranscript creates a fake Claude project dir + transcript and a real
+// repo dir on disk, then back-dates the transcript so recency is testable.
+func writeTranscript(t *testing.T, home, projDir, repoPath string, lines []string, mod time.Time) {
+	t.Helper()
+	// Real repo dir with a .git dir so it passes the git check.
+	if err := os.MkdirAll(filepath.Join(repoPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".claude", "projects", projDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(dir, "11111111-2222-3333-4444-555555555555.jsonl")
+	if err := os.WriteFile(file, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(file, mod, mod); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecentRepos(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoOld := filepath.Join(home, "code", "old-proj")
+	repoNew := filepath.Join(home, "code", "new-proj")
+
+	// The cwd in the transcript is the source of truth (dash-safe).
+	writeTranscript(t, home, "proj-old", repoOld, []string{
+		`{"type":"user","isMeta":true,"cwd":"` + repoOld + `","gitBranch":"main","message":{"role":"user","content":"<local-command-caveat>/clear</local-command-caveat>"}}`,
+		`{"type":"user","cwd":"` + repoOld + `","gitBranch":"main","message":{"role":"user","content":"please fix the old login bug"}}`,
+	}, time.Now().Add(-48*time.Hour))
+
+	writeTranscript(t, home, "proj-new", repoNew, []string{
+		`{"type":"user","cwd":"` + repoNew + `","gitBranch":"feature/x","message":{"role":"user","content":[{"type":"text","text":"add the launchpad onboarding"}]}}`,
+	}, time.Now().Add(-1*time.Hour))
+
+	got := RecentRepos(10)
+	if len(got) != 2 {
+		t.Fatalf("want 2 repos, got %d: %+v", len(got), got)
+	}
+
+	// Most-recently-used first.
+	if got[0].Path != repoNew {
+		t.Errorf("want newest first (%s), got %s", repoNew, got[0].Path)
+	}
+	if got[0].Branch != "feature/x" {
+		t.Errorf("branch: want feature/x, got %q", got[0].Branch)
+	}
+	if got[0].ClaudeSessionID != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("session id not recovered from filename: %q", got[0].ClaudeSessionID)
+	}
+	if got[0].Title == "" {
+		t.Error("title should be derived from the array-form prompt")
+	}
+
+	// The /clear caveat must be skipped in favor of the real prompt.
+	if got[1].Title == "" || got[1].Path != repoOld {
+		t.Errorf("old repo: title=%q path=%q", got[1].Title, got[1].Path)
+	}
+}
+
+func TestRecentReposSkipsNonGitAndMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// A transcript whose cwd is a plain (non-git) dir → dropped.
+	plain := filepath.Join(home, "scratch")
+	if err := os.MkdirAll(plain, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".claude", "projects", "plain")
+	_ = os.MkdirAll(dir, 0o755)
+	_ = os.WriteFile(filepath.Join(dir, "aaa.jsonl"),
+		[]byte(`{"type":"user","cwd":"`+plain+`","message":{"role":"user","content":"hi"}}`+"\n"), 0o644)
+
+	// A transcript whose cwd no longer exists → dropped.
+	dir2 := filepath.Join(home, ".claude", "projects", "gone")
+	_ = os.MkdirAll(dir2, 0o755)
+	_ = os.WriteFile(filepath.Join(dir2, "bbb.jsonl"),
+		[]byte(`{"type":"user","cwd":"/nope/does/not/exist","message":{"role":"user","content":"hi"}}`+"\n"), 0o644)
+
+	if got := RecentRepos(10); len(got) != 0 {
+		t.Fatalf("want 0 repos (non-git + missing dropped), got %d: %+v", len(got), got)
+	}
+}
+
+func TestRecentReposEmptyHome(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if got := RecentRepos(10); got != nil {
+		t.Fatalf("want nil for missing ~/.claude/projects, got %+v", got)
+	}
+}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -95,6 +95,44 @@ func TestRecentReposSkipsNonGitAndMissing(t *testing.T) {
 	}
 }
 
+// TestRecentReposDedupKeepsNewest: when two project dirs resolve to the same
+// cwd, the kept record must be the most-recently-used transcript — not whichever
+// project dir sorted first alphabetically.
+func TestRecentReposDedupKeepsNewest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repo := filepath.Join(home, "code", "proj")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	write := func(projDir, sessionID string, mod time.Time) {
+		dir := filepath.Join(home, ".claude", "projects", projDir)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		f := filepath.Join(dir, sessionID+".jsonl")
+		line := `{"type":"user","cwd":"` + repo + `","gitBranch":"main","message":{"role":"user","content":"hi there"}}` + "\n"
+		if err := os.WriteFile(f, []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(f, mod, mod); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// proj-a sorts first alphabetically but is OLDER; proj-b is the NEWER one.
+	write("proj-a", "aaaaaaaa-older", time.Now().Add(-10*time.Hour))
+	write("proj-b", "bbbbbbbb-newer", time.Now().Add(-1*time.Hour))
+
+	got := RecentRepos(10)
+	if len(got) != 1 {
+		t.Fatalf("want 1 deduped repo, got %d: %+v", len(got), got)
+	}
+	if got[0].ClaudeSessionID != "bbbbbbbb-newer" {
+		t.Errorf("dedup kept the older transcript: got session %q, want the newer one", got[0].ClaudeSessionID)
+	}
+}
+
 func TestRecentReposEmptyHome(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	if got := RecentRepos(10); got != nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1416,7 +1416,13 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			h.launchpad.ToggleAll()
 			return h, nil
 		case "enter":
-			return h, h.launchLaunchpadSet(h.launchpad.LaunchSet())
+			// Consume the launchpad as we fire the set: launching is async, so
+			// without this a second Enter (before the new sessions register)
+			// would re-launch the whole set and duplicate every resumed
+			// conversation.
+			set := h.launchpad.LaunchSet()
+			h.launchpadDismissed = true
+			return h, h.launchLaunchpadSet(set)
 		case "esc":
 			h.launchpadDismissed = true
 			return h, nil

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2351,15 +2351,24 @@ func (h *Home) jumpToNextAttentionSession() {
 		return
 	}
 
-	// Anchor at the current session's position in the candidate order.
+	// Anchor at the current row's position in the candidate order — including
+	// header rows, so jumping from an origin/checkout header continues from
+	// that header instead of restarting at the top. A collapsed origin header
+	// has no children in cand, so the scan simply moves on to the next group.
 	start := -1
-	if h.cursor >= 0 && h.cursor < len(h.flatItems) && !h.flatItems[h.cursor].IsRepoHeader {
-		if cur := h.flatItems[h.cursor].Session; cur != nil {
-			for i, it := range cand {
-				if it.Session != nil && it.Session.ID == cur.ID {
-					start = i
-					break
-				}
+	if h.cursor >= 0 && h.cursor < len(h.flatItems) {
+		cur := h.flatItems[h.cursor]
+		for i, it := range cand {
+			switch {
+			case cur.Session != nil && it.Session != nil && it.Session.ID == cur.Session.ID:
+				start = i
+			case cur.IsOriginHeader && it.IsOriginHeader && it.OriginKey == cur.OriginKey:
+				start = i
+			case cur.IsCheckoutHeader && it.IsCheckoutHeader && it.RepoPath == cur.RepoPath:
+				start = i
+			}
+			if start != -1 {
+				break
 			}
 		}
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/brizzai/fleet/internal/chrome"
 	"github.com/brizzai/fleet/internal/config"
 	"github.com/brizzai/fleet/internal/debuglog"
+	"github.com/brizzai/fleet/internal/discovery"
 	"github.com/brizzai/fleet/internal/git"
 	"github.com/brizzai/fleet/internal/github"
 	"github.com/brizzai/fleet/internal/hooks"
@@ -135,6 +136,11 @@ type (
 	// splashFrameMsg advances the boot-splash spinner. Self-rescheduled
 	// while !booted; not emitted after bootstrapDoneMsg.
 	splashFrameMsg time.Time
+	// discoveryMsg carries the launchpad's scan of ~/.claude/projects back to
+	// Update. Fired once, only on an empty fleet.
+	discoveryMsg struct {
+		items []discovery.Recent
+	}
 )
 
 func spinnerTickCmd() tea.Msg {
@@ -171,6 +177,12 @@ type Home struct {
 	branchDialog          *BranchCheckoutDialog
 	commandPalette        *CommandPaletteDialog
 	consentDialog         *ConsentDialog
+
+	// launchpad is the first-run experience shown when the fleet is empty:
+	// recent repos mined from Claude Code history, ready to resume.
+	// launchpadDismissed lets the user Esc out to the bare empty state.
+	launchpad          *Launchpad
+	launchpadDismissed bool
 
 	pendingWorkspaces []*PendingWorkspace // in-flight workspace creations
 	pendingForkCtx    *forkContext        // set while Shift+F worktree picker is open; consumed on pick/cancel
@@ -319,6 +331,7 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string, ident
 		branchDialog:          NewBranchCheckoutDialog(),
 		commandPalette:        NewCommandPaletteDialog(),
 		consentDialog:         NewConsentDialog(),
+		launchpad:             NewLaunchpad(),
 		bugReport:             NewBugReportDialog(),
 		previewCache:          make(map[string]string),
 		previewCacheTime:      make(map[string]time.Time),
@@ -932,6 +945,21 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.splashFrame++
 		return h, h.splashTick()
 
+	case discoveryMsg:
+		h.launchpad.SetItems(msg.items)
+		// The boot splash stayed up during the scan; reveal the UI now in one
+		// transition (launchpad if we found anything, bare empty state if not).
+		if !h.booted {
+			h.booted = true
+			go h.statusWorker()
+		}
+		if len(msg.items) > 0 {
+			analytics.Track(analytics.EventOnboardingFirstLaunch, map[string]interface{}{
+				"discovered_repos": len(msg.items),
+			})
+		}
+		return h, nil
+
 	case loadSessionsMsg:
 		if msg.err != nil {
 			h.setError(msg.err)
@@ -1031,9 +1059,12 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			repos := h.bootstrapRepoSet()
 			h.bootstrapRepos = len(repos)
 			if len(repos) == 0 {
-				// Empty fleet: no probes to wait on. Skip the splash entirely.
-				h.booted = true
-				go h.statusWorker()
+				// Empty fleet → first-run launchpad. Keep the boot splash up as
+				// the single loading page while we scan Claude history, then
+				// flip to the launchpad in one transition (see discoveryMsg).
+				// This avoids a splash → "scanning" → list flicker. booted and
+				// the status worker are deferred to discoveryMsg.
+				startupCmd = tea.Batch(h.scanDiscovery(), h.splashTick())
 			} else {
 				startupCmd = tea.Batch(h.bootstrapGitInfo(repos), h.splashTick())
 			}
@@ -1125,6 +1156,11 @@ func (h *Home) renderBody() string {
 	}
 	if h.renameDialog.IsVisible() {
 		return h.renameDialog.View()
+	}
+
+	// First-run launchpad owns the screen while the fleet is empty.
+	if h.launchpadActive() {
+		return h.launchpad.View(h.width, h.height)
 	}
 
 	var b strings.Builder
@@ -1360,6 +1396,31 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		dialog, cmd := h.renameDialog.Update(msg)
 		h.renameDialog = dialog
 		return h, cmd
+	}
+
+	// First-run launchpad: drive the recent-repos picker. Space multi-selects,
+	// Enter launches the checked set (or the cursor row). Unhandled keys
+	// (n to type a path, ?, S, q, …) fall through to the main switch below.
+	if h.launchpadActive() {
+		switch msg.String() {
+		case "j", "down":
+			h.launchpad.Move(1)
+			return h, nil
+		case "k", "up":
+			h.launchpad.Move(-1)
+			return h, nil
+		case " ":
+			h.launchpad.Toggle()
+			return h, nil
+		case "A":
+			h.launchpad.ToggleAll()
+			return h, nil
+		case "enter":
+			return h, h.launchLaunchpadSet(h.launchpad.LaunchSet())
+		case "esc":
+			h.launchpadDismissed = true
+			return h, nil
+		}
 	}
 
 	// Focus mode: forward keys to tmux session.
@@ -1756,21 +1817,80 @@ func (a attachCmd) SetStdin(r io.Reader)  {}
 func (a attachCmd) SetStdout(w io.Writer) {}
 func (a attachCmd) SetStderr(w io.Writer) {}
 
+// scanDiscovery reads the user's Claude Code history off the UI thread and
+// feeds the launchpad. Best-effort: a nil/empty result just leaves the bare
+// empty state in place.
+func (h *Home) scanDiscovery() tea.Cmd {
+	return func() tea.Msg {
+		return discoveryMsg{items: discovery.RecentRepos(8)}
+	}
+}
+
+// launchpadActive reports whether the launchpad should own the screen: a truly
+// empty fleet (no sessions, no pinned repos), not dismissed, with the scan
+// having found something. The scan completes before booted flips (the splash
+// covers it), so by the time this can return true the items are already in;
+// an empty scan steps aside for the bare empty state.
+func (h *Home) launchpadActive() bool {
+	if !h.booted || h.launchpadDismissed {
+		return false
+	}
+	if len(h.sessions) > 0 || len(h.pinnedRepos) > 0 {
+		return false
+	}
+	return h.launchpad.HasItems()
+}
+
 func (h *Home) handleSessionCreate(msg sessionCreateMsg) (tea.Model, tea.Cmd) {
 	if _, err := exec.LookPath("claude"); err != nil {
 		h.setError(fmt.Errorf("claude CLI not found — install Claude Code to create sessions"))
 		return h, nil
 	}
-	debuglog.Logger.Info("creating session", "title", msg.title, "path", msg.path)
+	return h, h.startSessionCmd(msg)
+}
+
+// startSessionCmd builds the tea.Cmd that creates and starts one session off
+// the UI thread. Shared by the new-session flow and the launchpad (which fires
+// several at once). A non-empty resumeClaudeID makes buildClaudeCmd() launch
+// `claude --resume <id>` to continue an existing conversation.
+func (h *Home) startSessionCmd(msg sessionCreateMsg) tea.Cmd {
+	debuglog.Logger.Info("creating session", "title", msg.title, "path", msg.path, "resume", msg.resumeClaudeID)
 	s := session.NewSession(msg.title, msg.path)
 	s.WorkspaceName = msg.workspaceName
-	return h, func() tea.Msg {
+	if msg.resumeClaudeID != "" {
+		s.ClaudeSessionID = msg.resumeClaudeID
+	}
+	return func() tea.Msg {
 		if err := s.Start(); err != nil {
 			debuglog.Logger.Error("session Start() failed", "title", msg.title, "path", msg.path, "err", err)
 			return sessionCreateResultMsg{err: err}
 		}
 		return sessionCreateResultMsg{session: s}
 	}
+}
+
+// launchLaunchpadSet starts every chosen recent project at once, resuming each
+// one's most recent Claude conversation. This is the launchpad's payoff:
+// rehydrate a whole working set in a single keystroke.
+func (h *Home) launchLaunchpadSet(items []discovery.Recent) tea.Cmd {
+	if len(items) == 0 {
+		return nil
+	}
+	if _, err := exec.LookPath("claude"); err != nil {
+		h.setError(fmt.Errorf("claude CLI not found — install Claude Code to create sessions"))
+		return nil
+	}
+	analytics.Track(analytics.EventOnboardingFirstSessionCreated, map[string]interface{}{"count": len(items)})
+	cmds := make([]tea.Cmd, 0, len(items))
+	for _, it := range items {
+		h.actionLog.Add("launchpad add", it.Path, true)
+		cmds = append(cmds, h.startSessionCmd(sessionCreateMsg{
+			path:           it.Path,
+			title:          it.Title,
+			resumeClaudeID: it.ClaudeSessionID,
+		}))
+	}
+	return tea.Batch(cmds...)
 }
 
 func (h *Home) handleSessionCreateResult(msg sessionCreateResultMsg) (tea.Model, tea.Cmd) {
@@ -2956,8 +3076,9 @@ func (h *Home) bootstrapGitInfo(repos []string) tea.Cmd {
 // Returns 0 before bootstrapRepos has been initialized — there's a one-frame
 // window between the first paint and loadSessionsMsg arriving where the
 // splash renders without yet knowing the repo count. The empty-fleet path
-// flips `booted=true` in the same Update tick, so the splash never appears
-// for users with no repos either way.
+// keeps the splash up (bar at 0, spinner animating) through the Claude-history
+// scan and reveals the launchpad when discoveryMsg lands — one transition, no
+// splash → scanning → list flicker.
 func (h *Home) bootProgress() float64 {
 	if h.bootstrapRepos <= 0 {
 		return 0
@@ -3794,12 +3915,13 @@ func (h *Home) jumpToSlot(slot int) (tea.Model, tea.Cmd) {
 		return h, nil
 	}
 
-	// Expand the repo group if collapsed, so the session is visible and selectable.
+	// Reveal the session: expand both its origin group and its checkout if
+	// collapsed, so a bound session folded away under either header still
+	// becomes visible and selectable. (Expanding only the checkout left a
+	// collapsed origin hiding the row — it then read as "hidden by filter".)
 	repo := session.GetRepoRoot(s.ProjectPath)
-	if !h.repoExpanded[repo] {
-		h.repoExpanded[repo] = true
-		h.rebuildFlatItems()
-	}
+	h.revealCheckout(repo)
+	h.rebuildFlatItems()
 
 	idx := -1
 	for i, item := range h.flatItems {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2328,46 +2328,81 @@ func (h *Home) collapseRepoAtCursor() {
 }
 
 // jumpToNextAttentionSession moves the cursor to the next session needing
-// attention — waiting first, then finished — cycling in on-screen order and
-// wrapping. It only considers rows that are CURRENTLY VISIBLE in the sidebar:
-// sessions inside a collapsed origin/checkout, idle-folded, or filtered out
-// are skipped, so folding a group mutes it from the jump cycle (and never
-// auto-expands it). Silent no-op when nothing visible needs attention.
+// attention — waiting first, then finished — cycling in on-screen (tree) order
+// and wrapping.
+//
+// Collapse semantics: a COLLAPSED ORIGIN is muted — its sessions are never jump
+// targets. A collapsed CHECKOUT (branch) under an expanded origin is NOT muted:
+// jump reaches its sessions and expands just that checkout to reveal the target.
+// Filtered-out sessions are skipped. Silent no-op when nothing qualifies.
 func (h *Home) jumpToNextAttentionSession() {
-	n := len(h.flatItems)
+	// Candidate order: the tree with every checkout force-expanded but origins
+	// keeping their real collapse state. So a target in a folded checkout is
+	// reachable, while one inside a folded origin stays excluded.
+	cand := h.buildJumpTree()
+	n := len(cand)
 	if n == 0 {
 		return
 	}
-	start := h.cursor
-	if start < 0 || start >= n {
-		start = 0
-	}
 
-	// findNext scans forward from the cursor (wrapping) for a visible session
-	// row of the given status.
-	findNext := func(status session.Status) int {
-		for off := 1; off <= n; off++ {
-			i := (start + off) % n
-			it := h.flatItems[i]
-			if !it.IsRepoHeader && it.Session != nil && it.Session.GetStatus() == status {
-				return i
+	// Anchor at the current session's position in the candidate order.
+	start := -1
+	if h.cursor >= 0 && h.cursor < len(h.flatItems) && !h.flatItems[h.cursor].IsRepoHeader {
+		if cur := h.flatItems[h.cursor].Session; cur != nil {
+			for i, it := range cand {
+				if it.Session != nil && it.Session.ID == cur.ID {
+					start = i
+					break
+				}
 			}
 		}
-		return -1
+	}
+
+	findNext := func(status session.Status) *session.Session {
+		for off := 1; off <= n; off++ {
+			it := cand[(start+off+n)%n] // +n keeps the index non-negative when start == -1
+			if !it.IsRepoHeader && it.Session != nil && it.Session.GetStatus() == status {
+				return it.Session
+			}
+		}
+		return nil
 	}
 
 	target := findNext(session.StatusWaiting)
-	if target < 0 {
+	if target == nil {
 		target = findNext(session.StatusFinished)
 	}
-	if target < 0 {
-		debuglog.Logger.Debug("spacejump: no visible waiting/finished target", "cursor", h.cursor)
+	if target == nil {
+		debuglog.Logger.Debug("spacejump: no waiting/finished target outside collapsed origins", "cursor", h.cursor)
 		return // Silent no-op.
 	}
 
-	debuglog.Logger.Debug("spacejump: landed", "oldCursor", h.cursor, "newCursor", target)
-	h.cursor = target
-	h.syncViewport()
+	// Reveal just the target's checkout (its origin is already expanded — a
+	// collapsed origin would have excluded it above), then land on it.
+	h.repoExpanded[session.GetRepoRoot(target.ProjectPath)] = true
+	h.rebuildFlatItems()
+	for i, it := range h.flatItems {
+		if !it.IsRepoHeader && it.Session != nil && it.Session.ID == target.ID {
+			debuglog.Logger.Debug("spacejump: landed", "targetID", target.ID, "newCursor", i)
+			h.cursor = i
+			h.syncViewport()
+			return
+		}
+	}
+}
+
+// buildJumpTree returns the sidebar tree as jump should see it: origins keep
+// their real collapse state (collapsed origins are muted), but checkouts are
+// forced expanded so a session in a folded branch is still reachable.
+func (h *Home) buildJumpTree() []SidebarItem {
+	exp := make(map[string]bool, len(h.repoExpanded))
+	for k, v := range h.repoExpanded {
+		if strings.HasPrefix(k, originExpandPrefix) {
+			exp[k] = v // keep origin collapse; drop checkout keys → default expanded
+		}
+	}
+	originOf, isWorktreeOf := h.originResolvers()
+	return BuildFlatItems(h.sessions, h.pendingWorkspaces, exp, h.filterText, h.pinnedRepos, originOf, isWorktreeOf, h.idleFolded)
 }
 
 func (h *Home) renameSelected() tea.Cmd {
@@ -3896,11 +3931,11 @@ func (h *Home) repoInfoFromSnap(snap map[string]*git.RepoInfo) *git.RepoInfo {
 
 // --- Internal helpers ---
 
-func (h *Home) rebuildFlatItems() {
-	// Build origin / worktree lookup maps from the immutable git/PR
-	// snapshot. h.gitInfo() is a lock-free atomic load — writers always
-	// publish a fresh map, so the entries we read here can't shift
-	// underneath us mid-pass.
+// originResolvers builds the origin/worktree lookup closures from the
+// immutable git/PR snapshot. h.gitInfo() is a lock-free atomic load — writers
+// always publish a fresh map, so the entries can't shift underneath us. Shared
+// by rebuildFlatItems and the jump tree so both group identically.
+func (h *Home) originResolvers() (OriginOf, IsWorktreeOf) {
 	snap := h.gitInfo()
 	originSnap := make(map[string]string, len(snap))
 	worktreeSnap := make(map[string]bool, len(snap))
@@ -3915,7 +3950,6 @@ func (h *Home) rebuildFlatItems() {
 			worktreeSnap[k] = true
 		}
 	}
-
 	originOf := func(repoRoot string) string {
 		if key, ok := originSnap[repoRoot]; ok {
 			return key
@@ -3925,7 +3959,11 @@ func (h *Home) rebuildFlatItems() {
 	isWorktreeOf := func(repoRoot string) bool {
 		return worktreeSnap[repoRoot]
 	}
+	return originOf, isWorktreeOf
+}
 
+func (h *Home) rebuildFlatItems() {
+	originOf, isWorktreeOf := h.originResolvers()
 	h.flatItems = BuildFlatItems(h.sessions, h.pendingWorkspaces, h.repoExpanded, h.filterText, h.pinnedRepos, originOf, isWorktreeOf, h.idleFolded)
 	h.sidebarDirty = true
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2327,129 +2327,47 @@ func (h *Home) collapseRepoAtCursor() {
 	h.syncViewport()
 }
 
-// jumpToNextAttentionSession cycles through sessions needing attention:
-// waiting first, then finished. Wraps around, auto-expands collapsed groups.
+// jumpToNextAttentionSession moves the cursor to the next session needing
+// attention — waiting first, then finished — cycling in on-screen order and
+// wrapping. It only considers rows that are CURRENTLY VISIBLE in the sidebar:
+// sessions inside a collapsed origin/checkout, idle-folded, or filtered out
+// are skipped, so folding a group mutes it from the jump cycle (and never
+// auto-expands it). Silent no-op when nothing visible needs attention.
 func (h *Home) jumpToNextAttentionSession() {
-	// Build ordered list of ALL sessions (same order as sidebar).
-	groups := session.GroupByRepo(h.sessions)
-	repos := make([]string, 0, len(groups))
-	for repo := range groups {
-		repos = append(repos, repo)
-	}
-	sort.Strings(repos)
-
-	type candidate struct {
-		s    *session.Session
-		repo string
-	}
-	var allSessions []candidate
-	for _, repo := range repos {
-		for _, s := range groups[repo] {
-			allSessions = append(allSessions, candidate{s: s, repo: repo})
-		}
-	}
-	if len(allSessions) == 0 {
+	n := len(h.flatItems)
+	if n == 0 {
 		return
 	}
-
-	// Find the current session's position in allSessions.
-	var currentID string
-	if h.cursor >= 0 && h.cursor < len(h.flatItems) && !h.flatItems[h.cursor].IsRepoHeader {
-		if s := h.flatItems[h.cursor].Session; s != nil {
-			currentID = s.ID
-		}
-	}
-	currentIdx := -1
-	for i, c := range allSessions {
-		if c.s.ID == currentID {
-			currentIdx = i
-			break
-		}
+	start := h.cursor
+	if start < 0 || start >= n {
+		start = 0
 	}
 
-	// findNext scans forward (wrapping) for a session with the given status.
-	findNext := func(status session.Status) *candidate {
-		n := len(allSessions)
-		start := currentIdx + 1
-		for i := 0; i < n; i++ {
-			c := &allSessions[(start+i)%n]
-			if c.s.GetStatus() == status {
-				return c
-			}
-		}
-		return nil
-	}
-
-	// Priority: waiting > finished.
-	target := findNext(session.StatusWaiting)
-	targetKind := "waiting"
-	if target == nil {
-		target = findNext(session.StatusFinished)
-		targetKind = "finished"
-	}
-
-	// visIdx returns the index of a session ID in the visible flatItems, or -1.
-	visIdx := func(id string) int {
-		for i, item := range h.flatItems {
-			if !item.IsRepoHeader && item.Session != nil && item.Session.ID == id {
+	// findNext scans forward from the cursor (wrapping) for a visible session
+	// row of the given status.
+	findNext := func(status session.Status) int {
+		for off := 1; off <= n; off++ {
+			i := (start + off) % n
+			it := h.flatItems[i]
+			if !it.IsRepoHeader && it.Session != nil && it.Session.GetStatus() == status {
 				return i
 			}
 		}
 		return -1
 	}
 
-	if target == nil {
-		debuglog.Logger.Debug("spacejump: no waiting/finished target",
-			"cursor", h.cursor, "currentID", currentID, "allSessions", len(allSessions))
+	target := findNext(session.StatusWaiting)
+	if target < 0 {
+		target = findNext(session.StatusFinished)
+	}
+	if target < 0 {
+		debuglog.Logger.Debug("spacejump: no visible waiting/finished target", "cursor", h.cursor)
 		return // Silent no-op.
 	}
 
-	// DIAGNOSTIC: capture orderings + collapse/filter state before we touch
-	// anything. allSessions is repo-path-sorted; flatItems is origin-tree
-	// sorted — when these diverge, "next" in the jump list isn't "next" on
-	// screen, which is the suspected "only works going down" bug.
-	debuglog.Logger.Debug("spacejump: target found",
-		"kind", targetKind,
-		"targetID", target.s.ID,
-		"targetRepo", target.repo,
-		"targetOrigin", h.originOf(target.repo),
-		"cursor", h.cursor,
-		"currentID", currentID,
-		"currentIdx_allSessions", currentIdx,
-		"currentVisIdx", visIdx(currentID),
-		"targetVisIdx_beforeExpand", visIdx(target.s.ID),
-		"originCollapsed", !IsExpanded(h.repoExpanded, OriginExpandKey(h.originOf(target.repo))),
-		"checkoutCollapsed", !IsExpanded(h.repoExpanded, target.repo),
-		"filterText", h.filterText,
-	)
-
-	// Expand both header levels (origin group + checkout) so the target is visible.
-	h.revealCheckout(target.repo)
-	h.rebuildFlatItems()
-
-	// Set cursor to the target session.
-	if i := visIdx(target.s.ID); i >= 0 {
-		dir := "down"
-		if i < h.cursor {
-			dir = "up"
-		}
-		debuglog.Logger.Debug("spacejump: landed",
-			"targetID", target.s.ID, "oldCursor", h.cursor, "newCursor", i, "direction", dir)
-		h.cursor = i
-		h.syncViewport()
-		return
-	}
-
-	// Target found by findNext but still absent from flatItems even after
-	// expanding both the origin and checkout keys — it's filtered out by the
-	// active filter. Cursor does NOT move.
-	debuglog.Logger.Warn("spacejump: target HIDDEN, cursor NOT moved",
-		"targetID", target.s.ID,
-		"targetRepo", target.repo,
-		"targetOrigin", h.originOf(target.repo),
-		"originCollapsed", !IsExpanded(h.repoExpanded, OriginExpandKey(h.originOf(target.repo))),
-		"filterText", h.filterText,
-	)
+	debuglog.Logger.Debug("spacejump: landed", "oldCursor", h.cursor, "newCursor", target)
+	h.cursor = target
+	h.syncViewport()
 }
 
 func (h *Home) renameSelected() tea.Cmd {

--- a/internal/ui/dialogs.go
+++ b/internal/ui/dialogs.go
@@ -12,10 +12,14 @@ import (
 )
 
 // sessionCreateMsg is sent when the user confirms creating a new session.
+// resumeClaudeID, when set, starts the session with `claude --resume <id>` so
+// the user continues an existing conversation (e.g. one begun in plain Claude
+// Code, surfaced by the launchpad) instead of a fresh one.
 type sessionCreateMsg struct {
-	path          string
-	title         string
-	workspaceName string
+	path           string
+	title          string
+	workspaceName  string
+	resumeClaudeID string
 }
 
 // forkSessionMsg is sent when the user forks an existing session.

--- a/internal/ui/jump_test.go
+++ b/internal/ui/jump_test.go
@@ -16,48 +16,48 @@ func visibleHasSession(h *Home, id string) bool {
 	return false
 }
 
-// TestJumpExpandsCollapsedOrigin: a waiting session hidden under a collapsed
-// origin group must be revealed (origin expanded) and selected when the user
-// presses Space (jump to next attention session).
-func TestJumpExpandsCollapsedOrigin(t *testing.T) {
-	idle := session.NewSession("main work", "/tmp/jt-main")
-	idle.SetStatus(session.StatusIdle)
-	waiting := session.NewSession("needs you", "/tmp/jt-wt")
-	waiting.SetStatus(session.StatusWaiting)
+// TestJumpSkipsCollapsedOrigin: Space-jump must NOT dive into a collapsed
+// origin. With a waiting session visible in one origin and another waiting
+// session hidden under a collapsed origin, jump lands on the visible one and
+// leaves the collapsed origin folded.
+func TestJumpSkipsCollapsedOrigin(t *testing.T) {
+	aMain := session.NewSession("alpha-main", "/tmp/js-a-main")
+	aMain.SetStatus(session.StatusIdle)
+	aWait := session.NewSession("alpha-wait", "/tmp/js-a-wt")
+	aWait.SetStatus(session.StatusWaiting)
+	bWait := session.NewSession("beta-wait", "/tmp/js-b")
+	bWait.SetStatus(session.StatusWaiting)
 
 	h := &Home{
-		sessions:     []*session.Session{idle, waiting},
+		sessions:     []*session.Session{aMain, aWait, bWait},
 		repoExpanded: map[string]bool{},
 		idleFolded:   map[string]bool{},
 		pinnedRepos:  map[string]bool{},
 	}
 	gi := map[string]*git.RepoInfo{
-		"/tmp/jt-main": {OriginKey: "github.com/acme/repo"},
-		"/tmp/jt-wt":   {OriginKey: "github.com/acme/repo", IsWorktreeRepo: true},
+		"/tmp/js-a-main": {OriginKey: "github.com/acme/alpha"},
+		"/tmp/js-a-wt":   {OriginKey: "github.com/acme/alpha", IsWorktreeRepo: true},
+		"/tmp/js-b":      {OriginKey: "github.com/acme/beta"},
 	}
 	h.gitInfoCache.Store(&gi)
 
-	// Collapse the shared origin group and rebuild — the waiting row is hidden.
-	originKey := OriginExpandKey("github.com/acme/repo")
-	h.repoExpanded[originKey] = false
+	// Collapse the beta origin — its waiting session is now hidden.
+	betaKey := OriginExpandKey("github.com/acme/beta")
+	h.repoExpanded[betaKey] = false
 	h.rebuildFlatItems()
-	if visibleHasSession(h, waiting.ID) {
-		t.Fatal("precondition failed: waiting session should be hidden under collapsed origin")
+	if visibleHasSession(h, bWait.ID) {
+		t.Fatal("precondition failed: beta waiting session should be hidden under collapsed origin")
 	}
 
-	// Land the cursor on the (collapsed) origin header, then jump.
 	h.cursor = 0
 	h.jumpToNextAttentionSession()
 
-	if !IsExpanded(h.repoExpanded, originKey) {
-		t.Error("jump did not expand the collapsed origin")
-	}
-	if h.cursor < 0 || h.cursor >= len(h.flatItems) {
-		t.Fatalf("cursor out of range after jump: %d (items=%d)", h.cursor, len(h.flatItems))
-	}
 	landed := h.flatItems[h.cursor].Session
-	if landed == nil || landed.ID != waiting.ID {
-		t.Errorf("jump did not land on the waiting session inside the collapsed origin")
+	if landed == nil || landed.ID != aWait.ID {
+		t.Errorf("jump should land on the visible waiting session (alpha), got %v", landed)
+	}
+	if IsExpanded(h.repoExpanded, betaKey) {
+		t.Error("jump must NOT expand the collapsed beta origin")
 	}
 }
 

--- a/internal/ui/jump_test.go
+++ b/internal/ui/jump_test.go
@@ -61,6 +61,49 @@ func TestJumpSkipsCollapsedOrigin(t *testing.T) {
 	}
 }
 
+// TestJumpEntersCollapsedCheckout: a collapsed CHECKOUT (branch) under an
+// expanded origin is NOT muted — jump reaches its waiting session and expands
+// just that checkout to reveal it.
+func TestJumpEntersCollapsedCheckout(t *testing.T) {
+	main := session.NewSession("main", "/tmp/jc-main")
+	main.SetStatus(session.StatusIdle)
+	wt := session.NewSession("wt-wait", "/tmp/jc-wt")
+	wt.SetStatus(session.StatusWaiting)
+
+	h := &Home{
+		sessions:     []*session.Session{main, wt},
+		repoExpanded: map[string]bool{},
+		idleFolded:   map[string]bool{},
+		pinnedRepos:  map[string]bool{},
+	}
+	gi := map[string]*git.RepoInfo{
+		"/tmp/jc-main": {OriginKey: "github.com/acme/repo"},
+		"/tmp/jc-wt":   {OriginKey: "github.com/acme/repo", IsWorktreeRepo: true},
+	}
+	h.gitInfoCache.Store(&gi)
+
+	// Collapse only the worktree CHECKOUT; the origin stays expanded.
+	h.repoExpanded["/tmp/jc-wt"] = false
+	h.rebuildFlatItems()
+	if visibleHasSession(h, wt.ID) {
+		t.Fatal("precondition failed: waiting session should be hidden under collapsed checkout")
+	}
+	if !IsExpanded(h.repoExpanded, OriginExpandKey("github.com/acme/repo")) {
+		t.Fatal("precondition failed: origin should be expanded")
+	}
+
+	h.cursor = 0
+	h.jumpToNextAttentionSession()
+
+	if !IsExpanded(h.repoExpanded, "/tmp/jc-wt") {
+		t.Error("jump should expand the collapsed checkout under an expanded origin")
+	}
+	if h.cursor < 0 || h.cursor >= len(h.flatItems) || h.flatItems[h.cursor].Session == nil ||
+		h.flatItems[h.cursor].Session.ID != wt.ID {
+		t.Errorf("jump should land on the waiting session inside the now-expanded checkout")
+	}
+}
+
 // TestSlotJumpExpandsCollapsedOrigin: jumping to a slot-bound session must
 // also expand a collapsed origin group, not just the checkout.
 func TestSlotJumpExpandsCollapsedOrigin(t *testing.T) {

--- a/internal/ui/jump_test.go
+++ b/internal/ui/jump_test.go
@@ -104,6 +104,49 @@ func TestJumpEntersCollapsedCheckout(t *testing.T) {
 	}
 }
 
+// TestJumpFromHeaderAnchorsAfterIt: with the cursor on an origin header, jump
+// must continue from that header (landing in its group) rather than restarting
+// at the first candidate and wrapping to an earlier origin.
+func TestJumpFromHeaderAnchorsAfterIt(t *testing.T) {
+	aWait := session.NewSession("alpha-wait", "/tmp/jh-alpha")
+	aWait.SetStatus(session.StatusWaiting)
+	bWait := session.NewSession("beta-wait", "/tmp/jh-beta")
+	bWait.SetStatus(session.StatusWaiting)
+
+	h := &Home{
+		sessions:     []*session.Session{aWait, bWait},
+		repoExpanded: map[string]bool{},
+		idleFolded:   map[string]bool{},
+		pinnedRepos:  map[string]bool{},
+	}
+	gi := map[string]*git.RepoInfo{
+		"/tmp/jh-alpha": {OriginKey: "github.com/acme/alpha"},
+		"/tmp/jh-beta":  {OriginKey: "github.com/acme/beta"},
+	}
+	h.gitInfoCache.Store(&gi)
+	h.rebuildFlatItems()
+
+	// Park the cursor on the beta origin header (it sorts after alpha).
+	betaHeader := -1
+	for i, it := range h.flatItems {
+		if it.IsOriginHeader && it.OriginKey == "github.com/acme/beta" {
+			betaHeader = i
+			break
+		}
+	}
+	if betaHeader < 0 {
+		t.Fatal("beta origin header not found in flatItems")
+	}
+	h.cursor = betaHeader
+
+	h.jumpToNextAttentionSession()
+
+	landed := h.flatItems[h.cursor].Session
+	if landed == nil || landed.ID != bWait.ID {
+		t.Errorf("jump from beta header should land on beta's waiting session, not wrap to alpha; got %v", landed)
+	}
+}
+
 // TestSlotJumpExpandsCollapsedOrigin: jumping to a slot-bound session must
 // also expand a collapsed origin group, not just the checkout.
 func TestSlotJumpExpandsCollapsedOrigin(t *testing.T) {

--- a/internal/ui/jump_test.go
+++ b/internal/ui/jump_test.go
@@ -1,0 +1,103 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/brizzai/fleet/internal/git"
+	"github.com/brizzai/fleet/internal/session"
+)
+
+func visibleHasSession(h *Home, id string) bool {
+	for _, it := range h.flatItems {
+		if !it.IsRepoHeader && it.Session != nil && it.Session.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestJumpExpandsCollapsedOrigin: a waiting session hidden under a collapsed
+// origin group must be revealed (origin expanded) and selected when the user
+// presses Space (jump to next attention session).
+func TestJumpExpandsCollapsedOrigin(t *testing.T) {
+	idle := session.NewSession("main work", "/tmp/jt-main")
+	idle.SetStatus(session.StatusIdle)
+	waiting := session.NewSession("needs you", "/tmp/jt-wt")
+	waiting.SetStatus(session.StatusWaiting)
+
+	h := &Home{
+		sessions:     []*session.Session{idle, waiting},
+		repoExpanded: map[string]bool{},
+		idleFolded:   map[string]bool{},
+		pinnedRepos:  map[string]bool{},
+	}
+	gi := map[string]*git.RepoInfo{
+		"/tmp/jt-main": {OriginKey: "github.com/acme/repo"},
+		"/tmp/jt-wt":   {OriginKey: "github.com/acme/repo", IsWorktreeRepo: true},
+	}
+	h.gitInfoCache.Store(&gi)
+
+	// Collapse the shared origin group and rebuild — the waiting row is hidden.
+	originKey := OriginExpandKey("github.com/acme/repo")
+	h.repoExpanded[originKey] = false
+	h.rebuildFlatItems()
+	if visibleHasSession(h, waiting.ID) {
+		t.Fatal("precondition failed: waiting session should be hidden under collapsed origin")
+	}
+
+	// Land the cursor on the (collapsed) origin header, then jump.
+	h.cursor = 0
+	h.jumpToNextAttentionSession()
+
+	if !IsExpanded(h.repoExpanded, originKey) {
+		t.Error("jump did not expand the collapsed origin")
+	}
+	if h.cursor < 0 || h.cursor >= len(h.flatItems) {
+		t.Fatalf("cursor out of range after jump: %d (items=%d)", h.cursor, len(h.flatItems))
+	}
+	landed := h.flatItems[h.cursor].Session
+	if landed == nil || landed.ID != waiting.ID {
+		t.Errorf("jump did not land on the waiting session inside the collapsed origin")
+	}
+}
+
+// TestSlotJumpExpandsCollapsedOrigin: jumping to a slot-bound session must
+// also expand a collapsed origin group, not just the checkout.
+func TestSlotJumpExpandsCollapsedOrigin(t *testing.T) {
+	other := session.NewSession("elsewhere", "/tmp/sj-main")
+	other.SetStatus(session.StatusIdle)
+	bound := session.NewSession("bound one", "/tmp/sj-wt")
+	bound.SetStatus(session.StatusIdle)
+
+	h := &Home{
+		sessions:        []*session.Session{other, bound},
+		repoExpanded:    map[string]bool{},
+		idleFolded:      map[string]bool{},
+		pinnedRepos:     map[string]bool{},
+		slotBindings:    map[int]string{3: bound.ID},
+		lastSlotTapSlot: -1,
+	}
+	h.rebuildSessionMap()
+	gi := map[string]*git.RepoInfo{
+		"/tmp/sj-main": {OriginKey: "github.com/acme/repo"},
+		"/tmp/sj-wt":   {OriginKey: "github.com/acme/repo", IsWorktreeRepo: true},
+	}
+	h.gitInfoCache.Store(&gi)
+
+	originKey := OriginExpandKey("github.com/acme/repo")
+	h.repoExpanded[originKey] = false
+	h.rebuildFlatItems()
+	if visibleHasSession(h, bound.ID) {
+		t.Fatal("precondition failed: bound session should be hidden under collapsed origin")
+	}
+
+	h.jumpToSlot(3)
+
+	if !IsExpanded(h.repoExpanded, originKey) {
+		t.Error("slot jump did not expand the collapsed origin")
+	}
+	if h.cursor < 0 || h.cursor >= len(h.flatItems) || h.flatItems[h.cursor].Session == nil ||
+		h.flatItems[h.cursor].Session.ID != bound.ID {
+		t.Errorf("slot jump did not land on the bound session inside the collapsed origin")
+	}
+}

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -23,7 +23,7 @@ var allKeyBindings = []KeyBinding{
 	// Session actions.
 	{Key: "Enter", BarKey: "⏎", BarDesc: "Open", Desc: "Attach / toggle group", Section: "session"},
 	{Key: "Tab", BarKey: "⇥", BarDesc: "Focus", Desc: "Focus preview / attach (swap)", Section: "session"},
-	{Key: "Space", BarKey: "␣", BarDesc: "Next", Desc: "Jump to next waiting/finished", Section: "session"},
+	{Key: "Space", BarKey: "␣", BarDesc: "Jump", Desc: "Jump to next waiting/finished", Section: "session"},
 	{Key: "← / h", Desc: "Collapse group", Section: "session"},
 	{Key: "→ / l", Desc: "Expand group", Section: "session"},
 	{Key: "a", BarKey: "a", BarDesc: "New", Desc: "New session", Section: "session"},
@@ -101,13 +101,13 @@ func HelpBarBindingsFor(ctx BarContext, enterMode string) (context, global []str
 	case BarContextSession:
 		if enterMode == "split" {
 			context = []struct{ Key, Desc string }{
-				{"⇥", "Attach"}, {"⏎", "Focus"}, {"Y", "Approve"},
-				{"d", "Del"}, {"p", "PR"},
+				{"⇥", "Attach"}, {"⏎", "Focus"}, {"␣", "Jump"},
+				{"Y", "Approve"}, {"d", "Del"}, {"p", "PR"},
 			}
 		} else {
 			context = []struct{ Key, Desc string }{
-				{"⏎", "Attach"}, {"Y", "Approve"}, {"d", "Del"},
-				{"r", "Restart"}, {"p", "PR"},
+				{"⏎", "Attach"}, {"␣", "Jump"}, {"Y", "Approve"},
+				{"d", "Del"}, {"r", "Restart"}, {"p", "PR"},
 			}
 		}
 	case BarContextCheckout:

--- a/internal/ui/launchpad.go
+++ b/internal/ui/launchpad.go
@@ -23,7 +23,6 @@ type Launchpad struct {
 	cursor   int
 	selected map[int]bool // multi-select: item indices checked for launch
 	loading  bool
-	loaded   bool
 }
 
 // NewLaunchpad returns a launchpad in its pre-scan loading state.
@@ -44,7 +43,6 @@ func (l *Launchpad) SetItems(items []discovery.Recent) {
 		l.selected[i] = true
 	}
 	l.loading = false
-	l.loaded = true
 	if l.cursor >= len(l.items) {
 		l.cursor = 0
 	}
@@ -67,9 +65,6 @@ func groupByOrigin(items []discovery.Recent) []discovery.Recent {
 	}
 	return out
 }
-
-// Loading reports whether the background scan is still running.
-func (l *Launchpad) Loading() bool { return l.loading }
 
 // HasItems reports whether discovery surfaced at least one repo.
 func (l *Launchpad) HasItems() bool { return len(l.items) > 0 }
@@ -157,20 +152,38 @@ func (l *Launchpad) View(width, height int) string {
 	b.WriteString(DimStyle.Render("Add the repos & worktrees you regularly work in."))
 	b.WriteString("\n\n")
 
-	// Fit the list to the available height. Items take 2 rows each (branch +
-	// title); origin headers and group separators add a little more, so budget
-	// conservatively at 3 rows/item.
+	// Window the list to the available height, keeping the cursor in view.
+	// Items take 2 rows each (branch + title); origin headers and group
+	// separators add a little more, so budget conservatively at 3 rows/item.
 	budget := height - 9
-	maxItems := budget / 3
-	if maxItems < 1 {
-		maxItems = 1
+	winSize := budget / 3
+	if winSize < 1 {
+		winSize = 1
 	}
-	shown := l.items
-	overflow := 0
-	if len(shown) > maxItems {
-		overflow = len(shown) - (maxItems - 1) // reserve a row for the "+N more" note
-		shown = shown[:maxItems-1]
+	// Reserve a row for the "+N more" note when the list doesn't fully fit.
+	if len(l.items) > winSize {
+		winSize--
+		if winSize < 1 {
+			winSize = 1
+		}
 	}
+	// Scroll so the cursor sits inside [start, start+winSize).
+	start := 0
+	if l.cursor >= winSize {
+		start = l.cursor - winSize + 1
+	}
+	if start > len(l.items)-winSize {
+		start = len(l.items) - winSize
+	}
+	if start < 0 {
+		start = 0
+	}
+	end := start + winSize
+	if end > len(l.items) {
+		end = len(l.items)
+	}
+	shown := l.items[start:end]
+	hidden := len(l.items) - len(shown)
 
 	originCounts := make(map[string]int)
 	for _, it := range shown {
@@ -179,6 +192,7 @@ func (l *Launchpad) View(width, height int) string {
 
 	prevOrigin := ""
 	for i, it := range shown {
+		idx := start + i // absolute index for cursor + selection lookup
 		if it.OriginKey != prevOrigin {
 			if i > 0 {
 				b.WriteString("\n") // blank row before a new origin group
@@ -187,12 +201,12 @@ func (l *Launchpad) View(width, height int) string {
 			b.WriteString("\n")
 			prevOrigin = it.OriginKey
 		}
-		b.WriteString(l.renderItem(it, i == l.cursor, l.selected[i], rowW))
+		b.WriteString(l.renderItem(it, idx == l.cursor, l.selected[idx], rowW))
 		b.WriteString("\n")
 	}
-	if overflow > 0 {
+	if hidden > 0 {
 		b.WriteString("\n")
-		b.WriteString(DimStyle.Render(fmt.Sprintf("   +%d more in your history", overflow)))
+		b.WriteString(DimStyle.Render(fmt.Sprintf("   +%d more in your history", hidden)))
 		b.WriteString("\n")
 	}
 

--- a/internal/ui/launchpad.go
+++ b/internal/ui/launchpad.go
@@ -1,0 +1,288 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/brizzai/fleet/internal/discovery"
+	"github.com/brizzai/fleet/internal/session"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Launchpad is the first-run / empty-fleet experience. Instead of an empty
+// sidebar that asks the user to type a path from memory, it lists the repos
+// they've recently used in Claude Code and lets them resume the exact
+// conversation they left — "continue, but better": now inside fleet's
+// parallel switchboard.
+//
+// It only renders when the fleet has no sessions and no pinned repos. The
+// moment a session exists, the normal sidebar takes over and the launchpad
+// never shows again.
+type Launchpad struct {
+	items    []discovery.Recent
+	cursor   int
+	selected map[int]bool // multi-select: item indices checked for launch
+	loading  bool
+	loaded   bool
+}
+
+// NewLaunchpad returns a launchpad in its pre-scan loading state.
+func NewLaunchpad() *Launchpad {
+	return &Launchpad{loading: true, selected: make(map[int]bool)}
+}
+
+// SetItems installs the discovery results and leaves the loading state. Items
+// are clustered by origin (preserving recency order) so the render groups
+// worktrees of one repo under a single origin header — and the cursor index
+// lines up with the rendered order.
+func (l *Launchpad) SetItems(items []discovery.Recent) {
+	l.items = groupByOrigin(items)
+	// Pre-check everything: onboarding's goal is to add the whole working set,
+	// so the default is "add all" and the user just unchecks what they don't want.
+	l.selected = make(map[int]bool, len(l.items))
+	for i := range l.items {
+		l.selected[i] = true
+	}
+	l.loading = false
+	l.loaded = true
+	if l.cursor >= len(l.items) {
+		l.cursor = 0
+	}
+}
+
+// groupByOrigin clusters items that share an OriginKey, keeping each origin at
+// the position of its most-recent member (input is already recency-sorted).
+func groupByOrigin(items []discovery.Recent) []discovery.Recent {
+	var order []string
+	groups := make(map[string][]discovery.Recent)
+	for _, it := range items {
+		if _, ok := groups[it.OriginKey]; !ok {
+			order = append(order, it.OriginKey)
+		}
+		groups[it.OriginKey] = append(groups[it.OriginKey], it)
+	}
+	out := make([]discovery.Recent, 0, len(items))
+	for _, k := range order {
+		out = append(out, groups[k]...)
+	}
+	return out
+}
+
+// Loading reports whether the background scan is still running.
+func (l *Launchpad) Loading() bool { return l.loading }
+
+// HasItems reports whether discovery surfaced at least one repo.
+func (l *Launchpad) HasItems() bool { return len(l.items) > 0 }
+
+// Move walks the cursor by delta, clamped to the list bounds.
+func (l *Launchpad) Move(delta int) {
+	if len(l.items) == 0 {
+		return
+	}
+	l.cursor += delta
+	if l.cursor < 0 {
+		l.cursor = 0
+	}
+	if l.cursor >= len(l.items) {
+		l.cursor = len(l.items) - 1
+	}
+}
+
+// Toggle flips the multi-select checkbox on the item under the cursor.
+func (l *Launchpad) Toggle() {
+	if l.cursor < 0 || l.cursor >= len(l.items) {
+		return
+	}
+	if l.selected[l.cursor] {
+		delete(l.selected, l.cursor)
+	} else {
+		l.selected[l.cursor] = true
+	}
+}
+
+// ToggleAll selects every item, or clears the selection if all are already on.
+func (l *Launchpad) ToggleAll() {
+	if len(l.selected) == len(l.items) {
+		l.selected = make(map[int]bool)
+		return
+	}
+	l.selected = make(map[int]bool, len(l.items))
+	for i := range l.items {
+		l.selected[i] = true
+	}
+}
+
+// SelectedCount reports how many items are checked.
+func (l *Launchpad) SelectedCount() int { return len(l.selected) }
+
+// LaunchSet returns the items to start: every checked item, or — when nothing
+// is checked — just the row under the cursor. Empty only when the list is.
+func (l *Launchpad) LaunchSet() []discovery.Recent {
+	if len(l.selected) > 0 {
+		out := make([]discovery.Recent, 0, len(l.selected))
+		for i, it := range l.items {
+			if l.selected[i] {
+				out = append(out, it)
+			}
+		}
+		return out
+	}
+	if l.cursor >= 0 && l.cursor < len(l.items) {
+		return []discovery.Recent{l.items[l.cursor]}
+	}
+	return nil
+}
+
+// View renders the launchpad centered in the viewport.
+func (l *Launchpad) View(width, height int) string {
+	cw := width - 8
+	if cw > 60 {
+		cw = 60
+	}
+	if cw < 38 {
+		cw = 38
+	}
+	// DialogStyle adds a 1×2 padding, so the usable text column is cw-4.
+	rowW := cw - 4
+
+	var b strings.Builder
+	b.WriteString(TitleStyle.Render("⬡  Welcome to fleet"))
+	b.WriteString("\n")
+
+	if l.loading {
+		b.WriteString(DimStyle.Render("Scanning your Claude Code history…"))
+		return place(width, height, DialogStyle.Width(cw).Render(b.String()))
+	}
+
+	b.WriteString(DimStyle.Render("Add the repos & worktrees you regularly work in."))
+	b.WriteString("\n\n")
+
+	// Fit the list to the available height. Items take 2 rows each (branch +
+	// title); origin headers and group separators add a little more, so budget
+	// conservatively at 3 rows/item.
+	budget := height - 9
+	maxItems := budget / 3
+	if maxItems < 1 {
+		maxItems = 1
+	}
+	shown := l.items
+	overflow := 0
+	if len(shown) > maxItems {
+		overflow = len(shown) - (maxItems - 1) // reserve a row for the "+N more" note
+		shown = shown[:maxItems-1]
+	}
+
+	originCounts := make(map[string]int)
+	for _, it := range shown {
+		originCounts[it.OriginKey]++
+	}
+
+	prevOrigin := ""
+	for i, it := range shown {
+		if it.OriginKey != prevOrigin {
+			if i > 0 {
+				b.WriteString("\n") // blank row before a new origin group
+			}
+			b.WriteString(renderLaunchpadOrigin(it.OriginKey, originCounts[it.OriginKey]))
+			b.WriteString("\n")
+			prevOrigin = it.OriginKey
+		}
+		b.WriteString(l.renderItem(it, i == l.cursor, l.selected[i], rowW))
+		b.WriteString("\n")
+	}
+	if overflow > 0 {
+		b.WriteString("\n")
+		b.WriteString(DimStyle.Render(fmt.Sprintf("   +%d more in your history", overflow)))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(l.footer(rowW))
+
+	return place(width, height, DialogStyle.Width(cw).Render(b.String()))
+}
+
+// renderLaunchpadOrigin draws a group header in fleet's sidebar idiom:
+// "▾ <origin> <count>" — accent label, dim chevron + count.
+func renderLaunchpadOrigin(originKey string, count int) string {
+	chevron := DimStyle.Render("▾")
+	name := RepoHeaderStyle.Render(labelForOrigin(originKey))
+	return fmt.Sprintf("%s %s %s", chevron, name, DimStyle.Render(fmt.Sprintf("%d", count)))
+}
+
+// renderItem draws one resumable checkout as two rows on a fixed grid so every
+// column lines up: "  <cursor> <box> <branch> … <time>" then an idle session
+// row "│ · <prompt>". cursor at col 2, checkbox col 4, branch col 6.
+func (l *Launchpad) renderItem(it discovery.Recent, isCursor, isChecked bool, w int) string {
+	cursorMark := " "
+	if isCursor {
+		cursorMark = SessionSelectionPrefix.Render("❯")
+	}
+	box := DimStyle.Render("○")
+	if isChecked {
+		box = lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Render("◉")
+	}
+
+	branch := shortBranch(it.Branch)
+	bs := BranchStyle.Italic(it.IsWorktree)
+	if isCursor {
+		bs = lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Italic(it.IsWorktree)
+	}
+
+	ago := formatTimeAgo(it.LastUsed)
+	left := "  " + cursorMark + " " + box + " " + bs.Render(branch)
+	gap := w - lipgloss.Width(left) - len(ago)
+	if gap < 1 {
+		gap = 1
+	}
+	line1 := left + strings.Repeat(" ", gap) + DimStyle.Render(ago)
+
+	// Idle session row — the prompt, drawn like the sidebar's not-running row.
+	title := truncate(it.Title, w-8)
+	line2 := "    " + DimStyle.Render("│") + " " + StatusSymbol(session.StatusIdle) + " " + DimStyle.Render(title)
+	return line1 + "\n" + line2
+}
+
+// shortBranch trims a branch to its last path segment and caps its width,
+// matching how the sidebar renders checkout branches.
+func shortBranch(branch string) string {
+	if branch == "" {
+		return "(detached)"
+	}
+	if i := strings.LastIndex(branch, "/"); i != -1 {
+		branch = branch[i+1:]
+	}
+	if len(branch) > 24 {
+		branch = branch[:23] + "…"
+	}
+	return branch
+}
+
+// footer renders a prominent "⏎ continue" call-to-action button over a row of
+// dim secondary hints, both centered in the panel.
+func (l *Launchpad) footer(w int) string {
+	n := l.SelectedCount()
+	cta := "Continue"
+	if n > 0 {
+		cta = fmt.Sprintf("Add %d & continue", n)
+	}
+	button := SessionTitleSelStyle.Render("  ⏎  " + cta + "  ")
+
+	key := func(k string) string { return HelpKeyStyle.Render(k) }
+	dim := func(s string) string { return DimStyle.Render(s) }
+	all := "all"
+	if n > 0 && n == len(l.items) {
+		all = "none"
+	}
+	hints := key("space") + dim(" toggle   ") +
+		key("A") + dim(" "+all+"   ") +
+		key("n") + dim(" path   ") +
+		key("?") + dim(" help")
+
+	return centerWithin(button, w) + "\n\n" + centerWithin(hints, w)
+}
+
+// place centers a rendered box in the viewport.
+func place(width, height int, box string) string {
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box)
+}

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -67,8 +67,12 @@ func IsExpanded(expanded map[string]bool, key string) bool {
 	return v
 }
 
+// originExpandPrefix namespaces origin keys in the shared expand map so they
+// don't collide with checkout (repo-path) keys.
+const originExpandPrefix = "origin:"
+
 // OriginExpandKey returns the map key used for a given origin.
-func OriginExpandKey(originKey string) string { return "origin:" + originKey }
+func OriginExpandKey(originKey string) string { return originExpandPrefix + originKey }
 
 // labelForOrigin strips the host prefix from an origin key, leaving just the
 // short identifier ("brizzai/fleet" → "fleet", "local:scratch" → "scratch").


### PR DESCRIPTION
## What

A first-run **launchpad** for new fleet users. When the fleet is empty, instead of a blank "No Sessions Yet" screen, fleet scans your Claude Code history (\`~/.claude/projects\`) and offers the **repos & worktrees you recently worked in** — grouped by origin with nested branches, exactly like the sidebar.

- All rows are **pre-checked**, so one \`⏎\` adds your whole working set: each repo/worktree is pinned and its last conversation resumed (\`claude --resume\`).
- \`space\` toggles a row, \`A\` selects all/none, \`n\` types a path, \`Esc\` drops to the bare empty state.
- Prominent **"⬡ Welcome to fleet"** header and a centered "⏎ Add N & continue" button.
- The boot splash stays up through the scan and reveals the launchpad in **one** transition (no splash → scanning → list flicker).

## Also

- **Jump behavior**: \`Space\` (now labelled "Jump" in the footer) cycles only through *visible* sessions and **skips collapsed origins/checkouts** — fold a group to mute it from the jump cycle. Also fixes the prior one-directional jump bug. Slot (digit) jumps still reveal a folded bound session.

## Implementation

- New \`internal/discovery\` package: scans \`~/.claude/projects\`, reads real \`cwd\`/\`gitBranch\`/first-prompt + origin from each newest transcript, filters to existing git repos, ranks by recency.
- New \`internal/ui/launchpad.go\`; wired into \`app.go\` (boot, render, key routing, multi-launch).
- Tests for discovery + jump-into/skip-collapsed; changelog fragments included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launchpad: first-run dialog showing recent projects grouped by origin, with multi-select, keyboard controls (Space toggle, A select all/none, n filter, Esc), boot splash visible while scanning
  * Resume conversations from launchpad selections

* **Improvements**
  * Jump (Space) cycles only visible sessions, skipping collapsed origin groups
  * Digit/slot navigation auto-expands origins/checkouts to reveal bound sessions
  * Footer label changed from “Space” to “Jump”

* **Bug Fixes**
  * Fixed jump sometimes moving only in one direction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->