### PR TITLE
fix(ui): flip waiting→running within ~500ms via split-cadence status worker

### DIFF
--- a/changelog/unreleased/fast-waiting-running.md
+++ b/changelog/unreleased/fast-waiting-running.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+Sessions now flip from **Waiting → Running** within ~500ms after you approve a permission, instead of lagging several seconds (or tens of seconds) when many sessions are open. No Claude hook fires on permission approval, so that transition can only be seen by scanning the session's pane — and the background worker only scanned 5 sessions every 2s, so at ~40 sessions each one was revisited just once every ~18s. The worker now re-checks active sessions (running/waiting/starting) on a fast ~500ms cadence while keeping the heavier work (git/PR refresh, idle-session sweep, auto-naming, tmux status bars) on the existing ~2s cadence. The reverse `running → waiting` flip (e.g. a sub-agent hitting a permission prompt) is just as responsive.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -37,10 +37,13 @@ type Session struct {
 	captureSf    singleflight.Group
 }
 
-// Package-level session cache: single tmux list-windows call per tick.
+// Package-level session cache: a single `tmux list-panes -a` call per tick
+// populates both maps, so per-session Exists/GetActivity/IsPaneDead lookups are
+// served from memory instead of one shell-out each.
 var (
 	sessionCacheMu   sync.RWMutex
 	sessionCacheData map[string]int64 // session_name -> window_activity timestamp
+	sessionDeadData  map[string]bool  // session_name -> pane_dead
 	sessionCacheTime time.Time
 )
 
@@ -122,7 +125,11 @@ func (s *Session) Start(command string, env ...string) error {
 	if sessionCacheData == nil {
 		sessionCacheData = make(map[string]int64)
 	}
+	if sessionDeadData == nil {
+		sessionDeadData = make(map[string]bool)
+	}
 	sessionCacheData[s.Name] = time.Now().Unix()
+	sessionDeadData[s.Name] = false
 	sessionCacheMu.Unlock()
 
 	return nil
@@ -281,8 +288,20 @@ func (s *Session) RespawnPane(command string, env ...string) error {
 	return nil
 }
 
-// IsPaneDead checks if the pane's process has exited.
+// IsPaneDead checks if the pane's process has exited. It reads the per-tick
+// batch cache (populated by RefreshSessionCache via a single `list-panes -a`)
+// when fresh, falling back to a live list-panes call for sessions the batch
+// hasn't seen yet.
 func (s *Session) IsPaneDead() bool {
+	sessionCacheMu.RLock()
+	if sessionDeadData != nil && time.Since(sessionCacheTime) < sessionCacheTTL {
+		if dead, ok := sessionDeadData[s.Name]; ok {
+			sessionCacheMu.RUnlock()
+			return dead
+		}
+	}
+	sessionCacheMu.RUnlock()
+
 	ctx, cancel := context.WithTimeout(context.Background(), listPanesTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "tmux", "list-panes", "-t", s.Name+":0.0", "-F", "#{pane_dead}").Output()
@@ -385,6 +404,7 @@ func (s *Session) Kill() error {
 	// Remove from cache.
 	sessionCacheMu.Lock()
 	delete(sessionCacheData, s.Name)
+	delete(sessionDeadData, s.Name)
 	sessionCacheMu.Unlock()
 
 	return nil
@@ -440,31 +460,123 @@ func (s *Session) CapturePane() (string, error) {
 	return result.(string), nil
 }
 
-// RefreshSessionCache makes a single tmux list-windows call and updates the global cache.
+// SeedCapture pre-fills the capture cache with content obtained out-of-band
+// (e.g. a batched capture), so a subsequent CapturePane() within captureCacheTTL
+// returns it without shelling out. Empty content is ignored — CapturePane treats
+// "" as a cache miss, so a missing/aborted batch entry falls back to a live
+// per-session capture automatically.
+func (s *Session) SeedCapture(content string) {
+	if content == "" {
+		return
+	}
+	s.cacheMu.Lock()
+	s.cacheContent = content
+	s.cacheTime = time.Now()
+	s.cacheMu.Unlock()
+}
+
+// BatchCapturePanes captures several sessions' panes in a single tmux client
+// invocation, chaining one capture-pane per name and delimiting each with a
+// high-entropy sentinel emitted by display-message. It returns name->content for
+// every session captured cleanly. A dead/missing pane aborts the tmux command
+// chain (subsequent captures never run), so callers MUST treat any name absent
+// from the result as "not captured" and fall back to a per-session capture —
+// the cache-seeding path does this for free (a cold cache → live CapturePane).
+func BatchCapturePanes(names []string) map[string]string {
+	if len(names) == 0 {
+		return nil
+	}
+	sentinel := captureSentinel()
+	args := make([]string, 0, len(names)*10)
+	for i, n := range names {
+		if i > 0 {
+			args = append(args, ";")
+		}
+		args = append(args,
+			"capture-pane", "-p", "-e", "-t", n,
+			";", "display-message", "-p", sentinel+"\t"+n)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), captureTimeout)
+	defer cancel()
+	// Output() returns whatever reached stdout before a non-zero exit, so a
+	// mid-chain abort still yields the panes captured up to that point.
+	out, err := exec.CommandContext(ctx, "tmux", args...).Output()
+	parsed := parseBatchCapture(string(out), sentinel)
+	if err != nil && len(parsed) < len(names) {
+		debuglog.Logger.Debug("tmux batch capture partial; missing sessions fall back to live capture",
+			"want", len(names), "got", len(parsed))
+	}
+	return parsed
+}
+
+// parseBatchCapture splits BatchCapturePanes stdout into name->content. Each
+// pane's raw capture bytes precede its "<sentinel>\t<name>\n" marker, so slicing
+// on the sentinel preserves content exactly (including trailing newlines and
+// ANSI escapes). Trailing bytes after the last marker — produced when the chain
+// aborted before emitting that session's marker — are dropped.
+func parseBatchCapture(stdout, sentinel string) map[string]string {
+	out := make(map[string]string)
+	token := sentinel + "\t"
+	rest := stdout
+	for {
+		idx := strings.Index(rest, token)
+		if idx < 0 {
+			break
+		}
+		content := rest[:idx]
+		rest = rest[idx+len(token):]
+		name := rest
+		if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+			name = rest[:nl]
+			rest = rest[nl+1:]
+		} else {
+			rest = ""
+		}
+		out[name] = content
+	}
+	return out
+}
+
+// captureSentinel returns a 32-hex-char nonce used to delimit batched captures.
+// The entropy makes accidental collision with real pane content negligible.
+func captureSentinel() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
+// RefreshSessionCache makes a single `tmux list-panes -a` call and updates the
+// global cache with each session's window activity and pane-dead state. One
+// call feeds Exists, GetActivity and IsPaneDead for every session, so the
+// status worker never shells out per-session for these.
 func RefreshSessionCache() {
-	cmd := exec.Command("tmux", "list-windows", "-a", "-F", "#{session_name}\t#{window_activity}")
+	cmd := exec.Command("tmux", "list-panes", "-a", "-F", "#{session_name}\t#{window_activity}\t#{pane_dead}")
 	output, err := cmd.Output()
 	if err != nil {
 		return // tmux server may not be running.
 	}
 
-	newCache := make(map[string]int64)
+	activityCache := make(map[string]int64)
+	deadCache := make(map[string]bool)
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "\t", 2)
-		if len(parts) < 2 {
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) < 3 {
 			continue
 		}
 		name := parts[0]
 		var activity int64
 		fmt.Sscanf(parts[1], "%d", &activity)
-		newCache[name] = activity
+		activityCache[name] = activity
+		deadCache[name] = parts[2] == "1"
 	}
 
 	sessionCacheMu.Lock()
-	sessionCacheData = newCache
+	sessionCacheData = activityCache
+	sessionDeadData = deadCache
 	sessionCacheTime = time.Now()
 	sessionCacheMu.Unlock()
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1,6 +1,9 @@
 package tmux
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSanitizeName(t *testing.T) {
 	tests := []struct {
@@ -82,5 +85,81 @@ func TestGenerateShortIDUniqueness(t *testing.T) {
 			t.Errorf("generateShortID() produced duplicate: %q", id)
 		}
 		seen[id] = true
+	}
+}
+
+// buildBatch reconstructs the on-the-wire stdout of a batched capture: each
+// pane's raw content followed by its "<sentinel>\t<name>\n" marker.
+func buildBatch(sentinel string, blocks ...[2]string) string {
+	var b strings.Builder
+	for _, bl := range blocks {
+		b.WriteString(bl[1]) // content bytes
+		b.WriteString(sentinel + "\t" + bl[0] + "\n")
+	}
+	return b.String()
+}
+
+func TestParseBatchCapture(t *testing.T) {
+	const sent = "deadbeefcafef00ddeadbeefcafef00d"
+
+	t.Run("preserves content bytes exactly", func(t *testing.T) {
+		contentA := "line1\n\x1b[31mred\x1b[0m\n$ \n" // trailing newline + ANSI + tab-free
+		contentB := "prompt with\ttab\nand two lines\n"
+		got := parseBatchCapture(buildBatch(sent, [2]string{"sessA", contentA}, [2]string{"sessB", contentB}), sent)
+		if got["sessA"] != contentA {
+			t.Errorf("sessA content mismatch:\n got %q\nwant %q", got["sessA"], contentA)
+		}
+		if got["sessB"] != contentB {
+			t.Errorf("sessB content mismatch:\n got %q\nwant %q", got["sessB"], contentB)
+		}
+		if len(got) != 2 {
+			t.Errorf("expected 2 entries, got %d", len(got))
+		}
+	})
+
+	t.Run("empty pane yields empty string entry", func(t *testing.T) {
+		got := parseBatchCapture(buildBatch(sent, [2]string{"empty", ""}, [2]string{"full", "x\n"}), sent)
+		if v, ok := got["empty"]; !ok || v != "" {
+			t.Errorf("expected empty present with \"\", got ok=%v v=%q", ok, v)
+		}
+		if got["full"] != "x\n" {
+			t.Errorf("full content mismatch: %q", got["full"])
+		}
+	})
+
+	t.Run("mid-chain abort drops the unterminated tail", func(t *testing.T) {
+		// sessA terminated cleanly; the chain aborted on sessB, so its capture
+		// is partial and no marker follows — sessB and sessC must be absent.
+		stdout := buildBatch(sent, [2]string{"sessA", "A-content\n"}) + "partial B output with no marker\n"
+		got := parseBatchCapture(stdout, sent)
+		if got["sessA"] != "A-content\n" {
+			t.Errorf("sessA should survive intact, got %q", got["sessA"])
+		}
+		if _, ok := got["sessB"]; ok {
+			t.Error("sessB must be absent (its marker never emitted)")
+		}
+		if len(got) != 1 {
+			t.Errorf("expected exactly 1 surviving entry, got %d", len(got))
+		}
+	})
+
+	t.Run("no markers returns empty map", func(t *testing.T) {
+		if got := parseBatchCapture("just some output, server died\n", sent); len(got) != 0 {
+			t.Errorf("expected empty map, got %v", got)
+		}
+	})
+}
+
+func TestCaptureSentinelEntropy(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		s := captureSentinel()
+		if len(s) != 32 {
+			t.Errorf("captureSentinel() = %q (len %d), want 32 hex chars", s, len(s))
+		}
+		if seen[s] {
+			t.Errorf("captureSentinel() produced duplicate: %q", s)
+		}
+		seen[s] = true
 	}
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3219,6 +3219,34 @@ func roundRobinBatch(sessions []*session.Session, processed map[string]bool, sta
 	return picked, (start + examined) % n
 }
 
+// seedActiveCaptures captures every given session's pane in one batched tmux
+// call and seeds each session's capture cache, collapsing N per-session
+// capture-pane shell-outs into a single invocation on the hot ~500ms fast path.
+// Sessions the batch omits keep a cold cache and capture individually inside
+// UpdateStatus, so coverage is never lost — only the batch speedup.
+func (h *Home) seedActiveCaptures(active []*session.Session) {
+	if len(active) < 2 {
+		return // a single session saves nothing over its own direct capture
+	}
+	byName := make(map[string]*session.Session, len(active))
+	names := make([]string, 0, len(active))
+	for _, s := range active {
+		ts := s.GetTmuxSession()
+		if ts == nil {
+			continue
+		}
+		byName[ts.Name] = s
+		names = append(names, ts.Name)
+	}
+	for name, content := range tmux.BatchCapturePanes(names) {
+		if s := byName[name]; s != nil {
+			if ts := s.GetTmuxSession(); ts != nil {
+				ts.SeedCapture(content)
+			}
+		}
+	}
+}
+
 func (h *Home) statusWorkerCycle() {
 	// Recover from panics to keep the worker alive.
 	defer func() {
@@ -3248,12 +3276,14 @@ func (h *Home) statusWorkerCycle() {
 		return
 	}
 
-	// Refresh the tmux activity cache every cycle. This is a single
-	// `tmux list-windows -a` call — O(1) in session count, not O(N) — and the
-	// 3s/10s running/finished hold heuristics in UpdateStatus read its data on
-	// the fast (~500ms) path too. Gating it to the 2s heavy cadence would let
-	// those windows read activity up to ~2s stale, shrinking the 3s hold to
-	// ~1s and flipping busy sessions to finished prematurely.
+	// Refresh the tmux activity + pane-dead cache every cycle. This is a single
+	// `tmux list-panes -a` call — O(1) in session count, not O(N) — and feeds
+	// Exists/GetActivity/IsPaneDead for every session, so per-session
+	// UpdateStatus calls below never shell out for those. It also keeps the
+	// 3s/10s running/finished hold heuristics fresh on the fast (~500ms) path;
+	// gating it to the 2s heavy cadence would let them read activity up to ~2s
+	// stale, shrinking the 3s hold to ~1s and flipping busy sessions to finished
+	// prematurely.
 	tmux.RefreshSessionCache()
 
 	// 3. Sync hook status (fast: in-memory map lookups).
@@ -3348,7 +3378,14 @@ drainPriority:
 	// round-robin — up to ceil(N/statusRoundRobin)*tickInterval behind at high
 	// session counts (≈18s at N=43). Idle/finished stay on the round-robin
 	// below; their important transitions (→running) ride the hook priority queue.
-	for _, s := range fastPassSessions(sessions, processed) {
+	// Batch-capture the active sessions' panes in a single tmux invocation and
+	// seed each capture cache, so the per-session UpdateStatus calls below read
+	// warm caches instead of each shelling out to capture-pane. Sessions the
+	// batch misses (a dead pane aborts the chain) keep a cold cache and fall
+	// back to a live capture inside UpdateStatus.
+	active := fastPassSessions(sessions, processed)
+	h.seedActiveCaptures(active)
+	for _, s := range active {
 		if h.updateAndPersistStatus(s) {
 			changedBars = append(changedBars, s)
 		}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3166,6 +3166,33 @@ func (h *Home) enqueuePriorityUpdates(ids []string) {
 	}
 }
 
+// heavyCycleDue reports whether the worker should run its heavy ~2s pass this
+// cycle. A zero lastHeavy (fresh worker) is always due, so the first cycle runs
+// full init.
+func heavyCycleDue(lastHeavy, now time.Time) bool {
+	return now.Sub(lastHeavy) >= tickInterval
+}
+
+// fastPassSessions returns the active sessions the ~500ms fast pass should
+// pane-recheck — Running/Waiting/Starting — skipping any already handled by the
+// priority queue this cycle. These states transition via pane content (no hook
+// fires when a permission is approved), so they must not wait for the 2s
+// round-robin. Idle/Finished/Error stay on the round-robin; their →running
+// transitions ride the hook priority queue.
+func fastPassSessions(sessions []*session.Session, processed map[string]bool) []*session.Session {
+	var active []*session.Session
+	for _, s := range sessions {
+		if processed[s.ID] {
+			continue
+		}
+		switch s.GetStatus() {
+		case session.StatusRunning, session.StatusWaiting, session.StatusStarting:
+			active = append(active, s)
+		}
+	}
+	return active
+}
+
 func (h *Home) statusWorkerCycle() {
 	// Recover from panics to keep the worker alive.
 	defer func() {
@@ -3180,7 +3207,7 @@ func (h *Home) statusWorkerCycle() {
 	// re-checks) runs every invocation (~activeStatusInterval) so waiting<->
 	// running flips — which fire no Claude hook on permission approval —
 	// surface within ~500ms instead of starving on the 2s round-robin.
-	heavy := time.Since(h.lastHeavyCycleAt) >= tickInterval
+	heavy := heavyCycleDue(h.lastHeavyCycleAt, time.Now())
 	if heavy {
 		h.lastHeavyCycleAt = time.Now()
 		// Refresh tmux session cache (blocking but in background). Only the
@@ -3285,15 +3312,9 @@ drainPriority:
 	// round-robin — up to ceil(N/statusRoundRobin)*tickInterval behind at high
 	// session counts (≈18s at N=43). Idle/finished stay on the round-robin
 	// below; their important transitions (→running) ride the hook priority queue.
-	for _, s := range sessions {
-		if processed[s.ID] {
-			continue
-		}
-		switch s.GetStatus() {
-		case session.StatusRunning, session.StatusWaiting, session.StatusStarting:
-			h.updateAndPersistStatus(s)
-			processed[s.ID] = true
-		}
+	for _, s := range fastPassSessions(sessions, processed) {
+		h.updateAndPersistStatus(s)
+		processed[s.ID] = true
 	}
 
 	// Everything below is heavy work — only on the ~2s cadence.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3136,7 +3136,9 @@ func (h *Home) syncHookStatuses(sessions []*session.Session) []string {
 
 // updateAndPersistStatus runs a full UpdateStatus() on the session and persists
 // the result to storage if the status changed. Called from the worker goroutine.
-func (h *Home) updateAndPersistStatus(s *session.Session) {
+// Returns true if the status changed (so callers can repaint just the sessions
+// that flipped).
+func (h *Home) updateAndPersistStatus(s *session.Session) bool {
 	oldStatus := s.GetStatus()
 	s.UpdateStatus()
 	newStatus := s.GetStatus()
@@ -3144,7 +3146,9 @@ func (h *Home) updateAndPersistStatus(s *session.Session) {
 		if err := h.storage.UpdateStatus(s.ID, string(newStatus)); err != nil {
 			debuglog.Logger.Error("storage: UpdateStatus", "id", s.ID, "status", newStatus, "err", err)
 		}
+		return true
 	}
+	return false
 }
 
 // enqueuePriorityUpdates pushes session IDs into the worker's priority queue
@@ -3193,6 +3197,28 @@ func fastPassSessions(sessions []*session.Session, processed map[string]bool) []
 	return active
 }
 
+// roundRobinBatch returns up to `budget` sessions not already handled this cycle,
+// scanning forward from `start` (wrapping), and the cursor to resume from next
+// cycle. The cursor advances only past sessions actually examined — not by a
+// fixed window — so when the list is dominated by active (already-processed)
+// sessions the scan still reaches the idle/finished sessions instead of stepping
+// over them and starving them of their periodic pane re-check.
+func roundRobinBatch(sessions []*session.Session, processed map[string]bool, start, budget int) (picked []*session.Session, next int) {
+	n := len(sessions)
+	if n == 0 {
+		return nil, start
+	}
+	examined := 0
+	for examined < n && len(picked) < budget {
+		idx := (start + examined) % n
+		examined++
+		if s := sessions[idx]; !processed[s.ID] {
+			picked = append(picked, s)
+		}
+	}
+	return picked, (start + examined) % n
+}
+
 func (h *Home) statusWorkerCycle() {
 	// Recover from panics to keep the worker alive.
 	defer func() {
@@ -3201,19 +3227,15 @@ func (h *Home) statusWorkerCycle() {
 		}
 	}()
 
-	// Heavy work (tmux cache refresh, full round-robin over idle sessions,
-	// git/PR fan-out, auto-naming, status-bar repaint) runs at most every
-	// tickInterval. The fast path (priority hook updates + active-session pane
-	// re-checks) runs every invocation (~activeStatusInterval) so waiting<->
-	// running flips — which fire no Claude hook on permission approval —
-	// surface within ~500ms instead of starving on the 2s round-robin.
+	// Heavy work (full round-robin over idle sessions, git/PR fan-out,
+	// auto-naming, full status-bar repaint) runs at most every tickInterval.
+	// The fast path (priority hook updates + active-session pane re-checks)
+	// runs every invocation (~activeStatusInterval) so waiting<->running flips
+	// — which fire no Claude hook on permission approval — surface within
+	// ~500ms instead of starving on the 2s round-robin.
 	heavy := heavyCycleDue(h.lastHeavyCycleAt, time.Now())
 	if heavy {
 		h.lastHeavyCycleAt = time.Now()
-		// Refresh tmux session cache (blocking but in background). Only the
-		// 3s/10s running/finished hold heuristics read its activity data, and
-		// they tolerate ≤2s staleness; the waiting→running path never reads it.
-		tmux.RefreshSessionCache()
 	}
 
 	// Take a snapshot of sessions under lock.
@@ -3225,6 +3247,14 @@ func (h *Home) statusWorkerCycle() {
 	if len(sessions) == 0 {
 		return
 	}
+
+	// Refresh the tmux activity cache every cycle. This is a single
+	// `tmux list-windows -a` call — O(1) in session count, not O(N) — and the
+	// 3s/10s running/finished hold heuristics in UpdateStatus read its data on
+	// the fast (~500ms) path too. Gating it to the 2s heavy cadence would let
+	// those windows read activity up to ~2s stale, shrinking the 3s hold to
+	// ~1s and flipping busy sessions to finished prematurely.
+	tmux.RefreshSessionCache()
 
 	// 3. Sync hook status (fast: in-memory map lookups).
 	h.syncHookStatuses(sessions)
@@ -3298,11 +3328,17 @@ drainPriority:
 		}
 	}
 	processed := make(map[string]bool, len(priorityIDs))
+	// Sessions whose status flipped on the fast (non-heavy) path; their tmux
+	// status bars are repainted immediately below so the in-pane pill tracks
+	// the sidebar within ~500ms instead of lagging until the next heavy cycle.
+	var changedBars []*session.Session
 	for _, s := range sessions {
 		if !priorityIDs[s.ID] {
 			continue
 		}
-		h.updateAndPersistStatus(s)
+		if h.updateAndPersistStatus(s) {
+			changedBars = append(changedBars, s)
+		}
 		processed[s.ID] = true
 	}
 
@@ -3313,29 +3349,30 @@ drainPriority:
 	// session counts (≈18s at N=43). Idle/finished stay on the round-robin
 	// below; their important transitions (→running) ride the hook priority queue.
 	for _, s := range fastPassSessions(sessions, processed) {
-		h.updateAndPersistStatus(s)
+		if h.updateAndPersistStatus(s) {
+			changedBars = append(changedBars, s)
+		}
 		processed[s.ID] = true
 	}
 
-	// Everything below is heavy work — only on the ~2s cadence.
+	// Everything below is heavy work — only on the ~2s cadence. On fast cycles
+	// repaint just the status bars whose session flipped, then bail.
+	// refreshTmuxStatusBars is cache-guarded, so the next heavy cycle's full
+	// repaint won't redundantly re-apply these.
 	if !heavy {
+		if len(changedBars) > 0 {
+			h.refreshTmuxStatusBars(changedBars)
+		}
 		return
 	}
 
-	// 5. Round-robin status updates (pane capture — blocking), skipping already-processed.
-	count := statusRoundRobin
-	if count > len(sessions) {
-		count = len(sessions)
-	}
-	for i := 0; i < count; i++ {
-		idx := (h.statusRRIndex + i) % len(sessions)
-		s := sessions[idx]
-		if processed[s.ID] {
-			continue
-		}
+	// 5. Round-robin status updates (pane capture — blocking) over the sessions
+	// not already handled this cycle, capped at statusRoundRobin real updates.
+	batch, next := roundRobinBatch(sessions, processed, h.statusRRIndex, statusRoundRobin)
+	for _, s := range batch {
 		h.updateAndPersistStatus(s)
 	}
-	h.statusRRIndex = (h.statusRRIndex + count) % len(sessions)
+	h.statusRRIndex = next
 
 	// 5. Git+PR refresh: fan out across all session repos in parallel,
 	// bounded to 4 concurrent goroutines so the subprocess load stays

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	tickInterval           = 2 * time.Second
+	activeStatusInterval   = 500 * time.Millisecond // fast pane re-check for active sessions
 	previewTickInterval    = 500 * time.Millisecond
 	previewCacheTTL        = 500 * time.Millisecond
 	layoutBreakpointSingle = 50
@@ -198,7 +199,8 @@ type Home struct {
 	idleFolded       map[string]bool // checkout path -> idle sessions folded ("z" key)
 	previewCache     map[string]string
 	previewCacheTime map[string]time.Time
-	statusRRIndex    int // round-robin index for status updates
+	statusRRIndex    int       // round-robin index for status updates
+	lastHeavyCycleAt time.Time // wall-clock gate: heavy worker work runs at most every tickInterval
 
 	// lastTmuxStatusBar tracks the most recent (status, theme) tuple applied
 	// to each session's tmux status bar so the worker can skip no-op
@@ -3068,7 +3070,7 @@ func (h *Home) splashTick() tea.Cmd {
 // statusWorker runs in its own goroutine, performing all blocking I/O
 // (tmux, git, gh) outside the Bubble Tea Update() loop.
 func (h *Home) statusWorker() {
-	ticker := time.NewTicker(tickInterval)
+	ticker := time.NewTicker(activeStatusInterval)
 	defer ticker.Stop()
 
 	for {
@@ -3172,10 +3174,22 @@ func (h *Home) statusWorkerCycle() {
 		}
 	}()
 
-	// 1. Refresh tmux session cache (blocking but in background).
-	tmux.RefreshSessionCache()
+	// Heavy work (tmux cache refresh, full round-robin over idle sessions,
+	// git/PR fan-out, auto-naming, status-bar repaint) runs at most every
+	// tickInterval. The fast path (priority hook updates + active-session pane
+	// re-checks) runs every invocation (~activeStatusInterval) so waiting<->
+	// running flips — which fire no Claude hook on permission approval —
+	// surface within ~500ms instead of starving on the 2s round-robin.
+	heavy := time.Since(h.lastHeavyCycleAt) >= tickInterval
+	if heavy {
+		h.lastHeavyCycleAt = time.Now()
+		// Refresh tmux session cache (blocking but in background). Only the
+		// 3s/10s running/finished hold heuristics read its activity data, and
+		// they tolerate ≤2s staleness; the waiting→running path never reads it.
+		tmux.RefreshSessionCache()
+	}
 
-	// 2. Take a snapshot of sessions under lock.
+	// Take a snapshot of sessions under lock.
 	h.workerMu.Lock()
 	sessions := make([]*session.Session, len(h.sessions))
 	copy(sessions, h.sessions)
@@ -3188,9 +3202,9 @@ func (h *Home) statusWorkerCycle() {
 	// 3. Sync hook status (fast: in-memory map lookups).
 	h.syncHookStatuses(sessions)
 
-	// 3b. Auto-name: generate title for ONE session per cycle.
+	// 3b. Auto-name: generate title for ONE session per cycle (heavy cadence).
 	// Priority: manual (R key) > custom-title > ai-title > last prompt heuristic.
-	if h.cfg.IsAutoNameEnabled() {
+	if heavy && h.cfg.IsAutoNameEnabled() {
 		for _, s := range sessions {
 			if s.ManuallyRenamed {
 				continue
@@ -3263,6 +3277,28 @@ drainPriority:
 		}
 		h.updateAndPersistStatus(s)
 		processed[s.ID] = true
+	}
+
+	// Fast active-session pass (every cycle): re-check Running/Waiting/Starting
+	// sessions. These transition via pane content (no hook fires when the user
+	// approves a permission), so without this they'd only refresh on the ~2s
+	// round-robin — up to ceil(N/statusRoundRobin)*tickInterval behind at high
+	// session counts (≈18s at N=43). Idle/finished stay on the round-robin
+	// below; their important transitions (→running) ride the hook priority queue.
+	for _, s := range sessions {
+		if processed[s.ID] {
+			continue
+		}
+		switch s.GetStatus() {
+		case session.StatusRunning, session.StatusWaiting, session.StatusStarting:
+			h.updateAndPersistStatus(s)
+			processed[s.ID] = true
+		}
+	}
+
+	// Everything below is heavy work — only on the ~2s cadence.
+	if !heavy {
+		return
 	}
 
 	// 5. Round-robin status updates (pane capture — blocking), skipping already-processed.

--- a/internal/ui/worker_cadence_test.go
+++ b/internal/ui/worker_cadence_test.go
@@ -53,6 +53,79 @@ func TestFastPassSessionsSelectsActiveStates(t *testing.T) {
 	}
 }
 
+// TestRoundRobinBatchReachesIdleSessions pins the anti-starvation contract: the
+// fast pass marks all active sessions processed, so the round-robin must still
+// reach the idle/finished sessions instead of letting a fixed-width window land
+// entirely on already-processed sessions and step the cursor past the idle ones.
+func TestRoundRobinBatchReachesIdleSessions(t *testing.T) {
+	mk := func(title string, st session.Status) *session.Session {
+		s := session.NewSession(title, "/tmp/"+title)
+		s.SetStatus(st)
+		return s
+	}
+
+	// 8 sessions: indices 0-4 active (processed by the fast pass), 5-7 idle.
+	// With statusRoundRobin=5 and the old fixed-window logic, the window 0..4
+	// would be entirely processed → zero idle sessions updated, cursor jumps to
+	// 5, and the idle sessions only get checked the cycle after.
+	var sessions []*session.Session
+	processed := map[string]bool{}
+	for i := 0; i < 5; i++ {
+		s := mk("active", session.StatusRunning)
+		sessions = append(sessions, s)
+		processed[s.ID] = true
+	}
+	idleIDs := map[string]bool{}
+	for i := 0; i < 3; i++ {
+		s := mk("idle", session.StatusIdle)
+		sessions = append(sessions, s)
+		idleIDs[s.ID] = true
+	}
+
+	batch, next := roundRobinBatch(sessions, processed, 0, statusRoundRobin)
+
+	if len(batch) != 3 {
+		t.Fatalf("expected all 3 idle sessions picked in one batch, got %d", len(batch))
+	}
+	for _, s := range batch {
+		if !idleIDs[s.ID] {
+			t.Errorf("round-robin picked a non-idle/processed session %q (%s)", s.Title, s.GetStatus())
+		}
+	}
+	// Cursor advanced past every examined session (all 8), wrapping to 0.
+	if next != 0 {
+		t.Errorf("expected cursor to wrap to 0 after examining all 8 sessions, got %d", next)
+	}
+}
+
+// TestRoundRobinBatchCapsAndResumes verifies the budget cap and that the cursor
+// resumes mid-list so successive cycles cover every session.
+func TestRoundRobinBatchCapsAndResumes(t *testing.T) {
+	mk := func() *session.Session {
+		s := session.NewSession("s", "/tmp/s")
+		s.SetStatus(session.StatusIdle)
+		return s
+	}
+	var sessions []*session.Session
+	for i := 0; i < 12; i++ {
+		sessions = append(sessions, mk())
+	}
+	processed := map[string]bool{}
+
+	batch, next := roundRobinBatch(sessions, processed, 0, statusRoundRobin)
+	if len(batch) != statusRoundRobin {
+		t.Fatalf("expected budget-capped batch of %d, got %d", statusRoundRobin, len(batch))
+	}
+	if next != statusRoundRobin {
+		t.Errorf("expected cursor at %d, got %d", statusRoundRobin, next)
+	}
+	// Next cycle resumes where the last left off.
+	batch2, _ := roundRobinBatch(sessions, processed, next, statusRoundRobin)
+	if batch2[0].ID != sessions[statusRoundRobin].ID {
+		t.Errorf("expected second batch to resume at index %d", statusRoundRobin)
+	}
+}
+
 // TestHeavyCycleDue verifies the wall-clock gate that throttles the worker's
 // heavy ~2s work while the fast pass runs every ~500ms tick.
 func TestHeavyCycleDue(t *testing.T) {

--- a/internal/ui/worker_cadence_test.go
+++ b/internal/ui/worker_cadence_test.go
@@ -1,0 +1,73 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/brizzai/fleet/internal/session"
+)
+
+// TestFastPassSessionsSelectsActiveStates pins the core contract of the
+// split-cadence worker: only Running/Waiting/Starting sessions ride the ~500ms
+// fast pass (they transition via pane content — no hook fires when a permission
+// is approved), Idle/Finished/Error stay on the 2s round-robin, and a session
+// already handled by the priority queue this cycle is not processed twice.
+func TestFastPassSessionsSelectsActiveStates(t *testing.T) {
+	mk := func(title string, st session.Status) *session.Session {
+		s := session.NewSession(title, "/tmp/"+title)
+		s.SetStatus(st)
+		return s
+	}
+
+	running := mk("run", session.StatusRunning)
+	waiting := mk("wait", session.StatusWaiting)
+	starting := mk("start", session.StatusStarting)
+	idle := mk("idle", session.StatusIdle)
+	finished := mk("fin", session.StatusFinished)
+	errored := mk("err", session.StatusError)
+	alreadyDone := mk("already", session.StatusWaiting) // active, but priority-processed
+
+	sessions := []*session.Session{running, waiting, starting, idle, finished, errored, alreadyDone}
+	processed := map[string]bool{alreadyDone.ID: true}
+
+	got := fastPassSessions(sessions, processed)
+
+	gotIDs := make(map[string]bool, len(got))
+	for _, s := range got {
+		gotIDs[s.ID] = true
+	}
+
+	for _, want := range []*session.Session{running, waiting, starting} {
+		if !gotIDs[want.ID] {
+			t.Errorf("expected active session %q (%s) in fast pass", want.Title, want.GetStatus())
+		}
+	}
+	for _, dont := range []*session.Session{idle, finished, errored, alreadyDone} {
+		if gotIDs[dont.ID] {
+			t.Errorf("did not expect session %q (%s, processed=%v) in fast pass",
+				dont.Title, dont.GetStatus(), processed[dont.ID])
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("expected exactly 3 fast-pass sessions, got %d", len(got))
+	}
+}
+
+// TestHeavyCycleDue verifies the wall-clock gate that throttles the worker's
+// heavy ~2s work while the fast pass runs every ~500ms tick.
+func TestHeavyCycleDue(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+
+	// Fresh worker (zero lastHeavy) is always due, so the first cycle runs full init.
+	if !heavyCycleDue(time.Time{}, base) {
+		t.Error("zero lastHeavy should be due (first cycle must run heavy)")
+	}
+	// Within tickInterval → not due: a fast-only cycle, heavy work throttled.
+	if heavyCycleDue(base, base.Add(tickInterval-time.Millisecond)) {
+		t.Error("sub-tickInterval gap should not be due")
+	}
+	// >= tickInterval later → due.
+	if !heavyCycleDue(base, base.Add(tickInterval)) {
+		t.Error(">= tickInterval gap should be due")
+	}
+}


### PR DESCRIPTION
## Problem

With many sessions open, a session's **Waiting → Running** flip after you approve a permission lagged badly — measured at 5–50s in `~/.config/fleet/debug.log` (`old=waiting new=running` events with `hookAge` of 5.18s, 52.4s, 2m43s) at ~43 sessions.

**Root cause:** No Claude hook fires when a permission is *approved* (`hook_handler.go` maps only `UserPromptSubmit/Stop/PermissionRequest/Notification/SessionStart/SessionEnd`). So `waiting → running` can only be discovered by **pane capture**. But the worker's round-robin updated just `statusRoundRobin=5` sessions per `tickInterval=2s` cycle, so each session was revisited only every `ceil(N/5)×2s` ≈ **18s at N=43**. Hook-driven transitions (idle→running, running→waiting) already felt instant because they ride the priority queue — only the hookless approval path starved.

## Fix

Split `statusWorkerCycle()` into two cadences (single-file change in `internal/ui/app.go`):

- **Fast (~500ms, every tick):** snapshot → sync hook statuses → drain priority queue → **pane re-check every active session** (Running/Waiting/Starting).
- **Heavy (~2s, wall-clock gated by `lastHeavyCycleAt`):** tmux cache refresh, auto-naming, round-robin over the remaining idle/finished sessions, git/PR fan-out, tmux status bars — unchanged in behavior and cost.

Active sessions are marked `processed`, so the round-robin naturally sweeps only the hook-covered idle/finished states. The reverse `running → waiting` flip (sub-agent hitting a permission prompt) is now equally responsive.

## Why it's safe

- Render was never the bottleneck: the sidebar reads live `s.GetStatus()` and the existing 500ms `previewTick` already repaints every 500ms — no UI plumbing added.
- All status cooldown timers (`session.go` 10s/15s/3s) are `time.Since`-based, so sampling 4× more often only detects changes sooner.
- Single worker goroutine, sequential — no new concurrency. If a fast pass ever exceeds 500ms it self-throttles (Go ticker drops ticks; heavy gate still fires on wall-clock).

## Result

`waiting → running` surfaces in **~0.5–1s, flat regardless of session count** (was 5–50s at 43 sessions).

## Test plan

- `make build` ✅ and `make test` ✅ (scheduling-only change; `internal/session` / `internal/hooks` detection tests unaffected).
- Manual: build with `-X main.version=dev`, open many sessions, approve a permission, confirm the sidebar flips in ~0.5–1s; `debug.log` shows the `content changed while waiting, assuming running` line ~0.5–1s after approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Sessions now transition from Waiting to Running state within approximately 500ms after permission approval, significantly reducing wait times when managing multiple sessions.
  * Improved responsiveness for reverse transitions (Running to Waiting) when permission prompts occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->