### PR TITLE
feat(ui): show draft PRs with a distinct dimmed ◌ badge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Attach uses PTY with Ctrl+Q intercept for clean detach (creack/pty + golang.org/x/term)
 - Repo headers show branch name (), dirty indicator (*), and PR badge (#N)
 - Git info refreshes every 2s (branch/dirty), PR info every 60s via `gh` CLI
-- PR badge: green ✓ (approved+CI passed), yellow (pending), red ✕ (CI fail) / ↩ (changes requested or unresolved threads), purple ⇡ (merged), hidden (closed)
+- PR badge: green ✓ (approved+CI passed), yellow (pending), red ✕ (CI fail) / ↩ (changes requested or unresolved threads), purple ⇡ (merged), gray ◌ (draft; ✕ appended on CI fail), hidden (closed)
 - PR info includes unresolved review thread count via GitHub GraphQL API
 - `gh` CLI optional — PR info hidden if not installed
 - Preview strips OSC-8 hyperlink sequences to prevent dotted underline artifacts

--- a/changelog/unreleased/draft-pr-badge.md
+++ b/changelog/unreleased/draft-pr-badge.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+Draft PRs now show a dimmed `◌ #N` badge so they stand out from ready PRs awaiting review (which look the same yellow `#N`). A failing CI check still surfaces as `◌ #N ✕`.

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -40,6 +40,7 @@ type PR struct {
 	CIStatus          string // SUCCESS, FAILURE, PENDING, ""
 	UnresolvedThreads int    // count of unresolved review threads
 	HasConflicts      bool   // true when GitHub reports merge conflicts
+	IsDraft           bool   // true while the PR is a draft (not ready for review)
 }
 
 // IsGHAvailable checks if the gh CLI is installed and accessible.
@@ -57,6 +58,7 @@ type ghPRResponse struct {
 	ReviewDecision    string             `json:"reviewDecision"`
 	StatusCheckRollup []statusCheckEntry `json:"statusCheckRollup"`
 	Mergeable         string             `json:"mergeable"` // MERGEABLE, CONFLICTING, UNKNOWN
+	IsDraft           bool               `json:"isDraft"`
 }
 
 type statusCheckEntry struct {
@@ -82,7 +84,7 @@ func GetPRForBranch(repoPath, branch string, ignorePatterns []string) (*PR, erro
 	debuglog.Logger.Debug("PR fetch: start", "path", repoPath, "branch", branch)
 
 	cmd := exec.Command("gh", "pr", "view", branch,
-		"--json", "number,title,url,state,reviewDecision,statusCheckRollup,mergeable",
+		"--json", "number,title,url,state,reviewDecision,statusCheckRollup,mergeable,isDraft",
 	)
 	cmd.Dir = repoPath
 	var stderr bytes.Buffer
@@ -116,6 +118,7 @@ func GetPRForBranch(repoPath, branch string, ignorePatterns []string) (*PR, erro
 		CIStatus:          deriveCIStatus(resp.StatusCheckRollup, ignorePatterns),
 		UnresolvedThreads: getUnresolvedThreadCount(repoPath, resp.Number, resp.URL),
 		HasConflicts:      resp.Mergeable == "CONFLICTING",
+		IsDraft:           resp.IsDraft,
 	}
 
 	debuglog.Logger.Debug("PR fetch: ok", "path", repoPath, "branch", branch, "pr", pr.Number, "state", pr.State, "ci", pr.CIStatus)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3552,15 +3552,10 @@ func (h *Home) buildTmuxStatusBarOpts(s *session.Session, info *git.RepoInfo) tm
 		if info.PR != nil {
 			if txt := previewPRSummary(info.PR); txt != "" {
 				prSummary = txt
-				switch {
-				case info.PR.State == "MERGED":
-					prColor = string(ColorPurple)
-				case info.PR.CIStatus == "FAILURE" || info.PR.ReviewDecision == "CHANGES_REQUESTED" || info.PR.UnresolvedThreads > 0 || info.PR.HasConflicts:
-					prColor = string(ColorRed)
-				case info.PR.ReviewDecision == "APPROVED" && info.PR.CIStatus == "SUCCESS":
-					prColor = string(ColorGreen)
-				default:
-					prColor = string(ColorYellow)
+				// Reuse the sidebar/preview badge color logic so draft, merged,
+				// fail, approved, and pending stay consistent across the UI.
+				if c, ok := prBadgeStyle(info.PR).GetForeground().(lipgloss.Color); ok {
+					prColor = string(c)
 				}
 			}
 		}

--- a/internal/ui/preview.go
+++ b/internal/ui/preview.go
@@ -151,6 +151,9 @@ func previewPRSummary(pr *github.PR) string {
 	}
 
 	var details []string
+	if pr.IsDraft {
+		details = append(details, "draft")
+	}
 	if pr.CIStatus == "FAILURE" {
 		details = append(details, "CI failing")
 	}

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -688,6 +688,14 @@ func prBadgeText(pr *github.PR) string {
 	if pr.State == "MERGED" {
 		return badge + " ⇡"
 	}
+	if pr.IsDraft {
+		// Draft = work-in-progress: dotted-circle prefix marks it, CI failure
+		// still surfaces, but review/approval glyphs don't apply to a draft.
+		if pr.CIStatus == "FAILURE" {
+			return "◌ " + badge + " ✕"
+		}
+		return "◌ " + badge
+	}
 	var icons string
 	if pr.CIStatus == "FAILURE" {
 		icons += "✕"
@@ -714,6 +722,9 @@ func prBadgeStyle(pr *github.PR) lipgloss.Style {
 	}
 	if pr.State == "MERGED" {
 		return PRMergedStyle
+	}
+	if pr.IsDraft {
+		return PRDraftStyle
 	}
 	ciFail := pr.CIStatus == "FAILURE"
 	changesReq := pr.ReviewDecision == "CHANGES_REQUESTED"

--- a/internal/ui/sidebar_test.go
+++ b/internal/ui/sidebar_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/brizzai/fleet/internal/agent"
+	"github.com/brizzai/fleet/internal/github"
 	"github.com/brizzai/fleet/internal/session"
 )
 
@@ -192,5 +193,30 @@ func TestRenderSessionItem_AgentGlyph(t *testing.T) {
 				t.Errorf("%s (selected=%v): output unexpectedly contains %q glyph: %q", tc.name, selected, tc.notWant, out)
 			}
 		}
+	}
+}
+
+func TestPRBadge_Draft(t *testing.T) {
+	draft := &github.PR{Number: 133, State: "OPEN", IsDraft: true}
+	if got := prBadgeText(draft); got != "◌ #133" {
+		t.Errorf("draft badge: got %q, want %q", got, "◌ #133")
+	}
+	if got := prBadgeStyle(draft).GetForeground(); got != PRDraftStyle.GetForeground() {
+		t.Errorf("draft badge color = %v, want PRDraftStyle (dim)", got)
+	}
+
+	// CI failure still surfaces on a draft; review/approval glyphs do not.
+	draftFail := &github.PR{Number: 135, State: "OPEN", IsDraft: true, CIStatus: "FAILURE"}
+	if got := prBadgeText(draftFail); got != "◌ #135 ✕" {
+		t.Errorf("failing-draft badge: got %q, want %q", got, "◌ #135 ✕")
+	}
+
+	// Approval on a draft is ignored — no ✓, stays gray.
+	draftApproved := &github.PR{Number: 137, State: "OPEN", IsDraft: true, ReviewDecision: "APPROVED", CIStatus: "SUCCESS"}
+	if got := prBadgeText(draftApproved); got != "◌ #137" {
+		t.Errorf("approved-draft badge: got %q, want %q", got, "◌ #137")
+	}
+	if got := prBadgeStyle(draftApproved).GetForeground(); got != PRDraftStyle.GetForeground() {
+		t.Errorf("approved-draft badge color = %v, want PRDraftStyle (dim), not green", got)
 	}
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -118,6 +118,7 @@ var (
 	PRFailStyle    = lipgloss.NewStyle().Foreground(ColorRed)
 	PRPendingStyle = lipgloss.NewStyle().Foreground(ColorYellow)
 	PRMergedStyle  = lipgloss.NewStyle().Foreground(ColorPurple)
+	PRDraftStyle   = lipgloss.NewStyle().Foreground(ColorTextDim)
 
 	// Slot badge style (RTS-style quick-access hotkey).
 	SlotBadgeStyle = lipgloss.NewStyle().Foreground(ColorOrange).Bold(true)
@@ -188,6 +189,7 @@ func ApplyPalette(p Palette) {
 	PRFailStyle = lipgloss.NewStyle().Foreground(ColorRed)
 	PRPendingStyle = lipgloss.NewStyle().Foreground(ColorYellow)
 	PRMergedStyle = lipgloss.NewStyle().Foreground(ColorPurple)
+	PRDraftStyle = lipgloss.NewStyle().Foreground(ColorTextDim)
 
 	SlotBadgeStyle = lipgloss.NewStyle().Foreground(ColorOrange).Bold(true)
 	SlotBadgeDimStyle = lipgloss.NewStyle().Foreground(ColorTextDim)


### PR DESCRIPTION
## What & why

A draft PR was indistinguishable from a ready-but-pending one in the sidebar. Drafts can't normally be approved and carry no review decision, so the badge fell through to the **yellow `#N`** "pending" case — the exact same badge as a real PR finished and waiting on review/CI. No signal told you which was WIP.

## Change

Draft PRs now render in **muted gray** with a dotted-circle **`◌` prefix** → `◌ #133`. Draft is a *readiness* dimension (not *health*), so it takes over the most salient channel — color — matching how GitHub greys out drafts. CI failure still surfaces (`◌ #135 ✕`); review/approval glyphs are suppressed (they don't apply to drafts). The preview panel spells it out: `PR #133 (draft)`.

`◌` (U+25CC) is width-1 from Geometric Shapes — same block as the status dots — so column alignment holds in base mono fonts.

## Details

- `internal/github/pr.go` — fetch `isDraft` from `gh pr view`; new `IsDraft` field on `PR`/`ghPRResponse`. No SQLite migration (PR cache is JSON; new bool defaults to `false` on old rows).
- `internal/ui/styles.go` — new `PRDraftStyle` (dim), wired into the var block + `ApplyPalette`.
- `internal/ui/sidebar.go` — draft branch in `prBadgeText()` / `prBadgeStyle()` (after the `MERGED` check).
- `internal/ui/preview.go` — `(draft)` in `previewPRSummary()`.
- `internal/ui/sidebar_test.go` — `TestPRBadge_Draft` (text, CI-fail, approved-draft edge case, color).
- `CLAUDE.md` + changelog fragment.

## Verification

`make build` ✓, `make fmt` ✓, `make test` (race) — all packages pass.

Manual: on a branch run `gh pr create --draft`, launch `fleet`, confirm the header shows dim `◌ #N`; `gh pr ready` then refresh (PR info polls ~60s) and confirm it flips to the normal badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft pull requests now display with a distinctive dimmed badge (◌ `#N`) and include "draft" in PR title summaries
  * Failed CI checks on draft PRs are indicated with a ✕ symbol
  * Tmux/status-bar PR color now matches the badge styling

* **Documentation**
  * Updated PR badge legend to include draft PR state

* **Tests**
  * Added tests covering draft PR badge rendering scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->