### PR TITLE
fix(github): dedupe PR check rollup to the latest run per check

### DIFF
--- a/changelog/unreleased/pr-ci-rollup-dedupe.md
+++ b/changelog/unreleased/pr-ci-rollup-dedupe.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+A PR's CI badge no longer shows failed when a check failed and was then re-run green on the same commit — fleet now reads only the latest run per check, matching GitHub.

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -63,6 +63,7 @@ type statusCheckEntry struct {
 	Name       string `json:"name"`
 	Status     string `json:"status"`
 	Conclusion string `json:"conclusion"`
+	StartedAt  string `json:"startedAt"` // RFC3339; used to pick the latest run when a check has several
 }
 
 // GetPRForBranch returns the PR associated with the current branch, or nil if none.
@@ -178,6 +179,35 @@ func getUnresolvedThreadCount(repoPath string, prNumber int, prURL string) int {
 	return count
 }
 
+// latestRunPerCheck collapses the rollup to the most recently started run per
+// check name. A single check can appear multiple times on one commit when its
+// workflow is re-run in place (rather than fixed by a new push) — GitHub keeps
+// every run in the rollup, including superseded ones. Without this, a check
+// that failed and was later re-run green would still mark the PR as failed.
+// This mirrors how `gh pr checks` and the GitHub UI report status.
+//
+// Ghost entries with no name (e.g. status contexts, which expose their name
+// under a different field) are dropped, matching prior behavior. On equal or
+// missing StartedAt, the later entry in rollup order wins (GitHub returns runs
+// roughly chronologically).
+func latestRunPerCheck(checks []statusCheckEntry) []statusCheckEntry {
+	latest := make(map[string]statusCheckEntry, len(checks))
+	for _, c := range checks {
+		if c.Name == "" {
+			continue
+		}
+		if prev, ok := latest[c.Name]; ok && c.StartedAt < prev.StartedAt {
+			continue // an existing, newer run wins
+		}
+		latest[c.Name] = c
+	}
+	out := make([]statusCheckEntry, 0, len(latest))
+	for _, c := range latest {
+		out = append(out, c)
+	}
+	return out
+}
+
 // deriveCIStatus determines overall CI status from status check rollup.
 // Checks whose name matches any ignorePatterns glob are dropped before rollup.
 func deriveCIStatus(checks []statusCheckEntry, ignorePatterns []string) string {
@@ -188,11 +218,7 @@ func deriveCIStatus(checks []statusCheckEntry, ignorePatterns []string) string {
 	hasFailure := false
 	hasPending := false
 
-	for _, check := range checks {
-		// Skip ghost entries with no name (null checks from GitHub API).
-		if check.Name == "" {
-			continue
-		}
+	for _, check := range latestRunPerCheck(checks) {
 		if matchesAnyPattern(check.Name, ignorePatterns) {
 			continue
 		}

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -141,6 +141,60 @@ func TestDeriveCIStatus(t *testing.T) {
 			[]string{"noisy"},
 			"SUCCESS",
 		},
+		{
+			// Re-run in place: a check failed, then a later run of the same
+			// check passed. Only the latest run should count.
+			"rerun supersedes stale failure with success",
+			[]statusCheckEntry{
+				{Name: "validate", Status: "COMPLETED", Conclusion: "FAILURE", StartedAt: "2026-06-03T13:12:50Z"},
+				{Name: "validate", Status: "COMPLETED", Conclusion: "SUCCESS", StartedAt: "2026-06-03T14:26:09Z"},
+			},
+			nil,
+			"SUCCESS",
+		},
+		{
+			"rerun supersedes stale success with failure",
+			[]statusCheckEntry{
+				{Name: "validate", Status: "COMPLETED", Conclusion: "SUCCESS", StartedAt: "2026-06-03T13:12:50Z"},
+				{Name: "validate", Status: "COMPLETED", Conclusion: "FAILURE", StartedAt: "2026-06-03T14:26:09Z"},
+			},
+			nil,
+			"FAILURE",
+		},
+		{
+			"rerun latest run still in progress -> pending",
+			[]statusCheckEntry{
+				{Name: "build", Status: "COMPLETED", Conclusion: "FAILURE", StartedAt: "2026-06-03T13:00:00Z"},
+				{Name: "build", Status: "IN_PROGRESS", Conclusion: "", StartedAt: "2026-06-03T14:00:00Z"},
+			},
+			nil,
+			"PENDING",
+		},
+		{
+			// Real PR #3510 shape: validate failed twice, was cancelled, then
+			// passed — all on the same commit. Latest run is SUCCESS.
+			"multiple reruns, latest success",
+			[]statusCheckEntry{
+				{Name: "validate", Status: "COMPLETED", Conclusion: "FAILURE", StartedAt: "2026-06-03T13:12:50Z"},
+				{Name: "validate", Status: "COMPLETED", Conclusion: "FAILURE", StartedAt: "2026-06-03T13:14:51Z"},
+				{Name: "validate", Status: "COMPLETED", Conclusion: "CANCELLED", StartedAt: "2026-06-03T14:25:53Z"},
+				{Name: "validate", Status: "COMPLETED", Conclusion: "SUCCESS", StartedAt: "2026-06-03T14:26:09Z"},
+				{Name: "secret-scan", Status: "COMPLETED", Conclusion: "SUCCESS", StartedAt: "2026-06-03T14:26:00Z"},
+			},
+			nil,
+			"SUCCESS",
+		},
+		{
+			// No timestamps (e.g. older API shape): fall back to rollup order,
+			// last entry per name wins.
+			"no startedAt falls back to last-seen success",
+			[]statusCheckEntry{
+				{Name: "validate", Status: "COMPLETED", Conclusion: "FAILURE"},
+				{Name: "validate", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			nil,
+			"SUCCESS",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

A PR's CI badge in fleet could show **failed** even when CI actually passed. When a check fails and is then **re-run in place on the same commit** (rather than fixed by a new push), GitHub keeps *every* run in the commit's `statusCheckRollup`. `deriveCIStatus` walked that list flat and tripped on the first `FAILURE`, so a stale, already-superseded failure marked the whole PR red — while `gh pr checks` and the GitHub UI (which use the latest run per check) showed green.

Real-world case: a PR whose `validate` check had 4 runs on one commit — `FAILURE`, `FAILURE`, `CANCELLED`, `SUCCESS` — rendered as ✕ CI-failed in fleet despite the latest run passing.

Only surfaces when a check is re-run *in place*; the normal "push a fix commit" flow yields a fresh rollup, which is why it looked fine on most PRs.

## Fix

`latestRunPerCheck` collapses the rollup to the most recently started run per check name (by `startedAt`, falling back to rollup order) before `deriveCIStatus` evaluates pass/fail — mirroring `gh pr checks` / the GitHub UI.

- `internal/github/pr.go` — add `StartedAt` to `statusCheckEntry`; add `latestRunPerCheck`; dedupe before the failure/pending scan.
- `internal/github/pr_test.go` — regression cases (stale failure→success, success→failure, latest-pending, the 4-run PR shape, and a no-timestamp fallback). All 4 new failure-path cases fail against the old flat logic and pass now.

`make test` green across all packages; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
