### PR TITLE
fix(site): make the landing page mobile-friendly

### DIFF
--- a/site/components/landing/Features.tsx
+++ b/site/components/landing/Features.tsx
@@ -71,7 +71,7 @@ export function Features() {
     <section
       style={{
         maxWidth: 1100,
-        margin: "5rem auto 4rem",
+        margin: "clamp(3rem, 9vw, 5rem) auto clamp(2.5rem, 7vw, 4rem)",
         padding: "0 1.25rem",
       }}
     >

--- a/site/components/landing/Hero.tsx
+++ b/site/components/landing/Hero.tsx
@@ -17,7 +17,7 @@ export function Hero() {
       className="fleet-hero"
       style={{
         position: "relative",
-        padding: "5rem 1.25rem 2rem",
+        padding: "clamp(3rem, 11vw, 5rem) 1.25rem 2rem",
         display: "flex",
         flexDirection: "column",
         alignItems: "center",

--- a/site/components/landing/InstallTabs.tsx
+++ b/site/components/landing/InstallTabs.tsx
@@ -38,7 +38,7 @@ export function InstallTabs() {
     <section
       style={{
         maxWidth: 760,
-        margin: "5rem auto 5rem",
+        margin: "clamp(3rem, 9vw, 5rem) auto clamp(3rem, 9vw, 5rem)",
         padding: "0 1.25rem",
         textAlign: "center",
       }}

--- a/site/components/tui-demo/TuiDemo.tsx
+++ b/site/components/tui-demo/TuiDemo.tsx
@@ -25,12 +25,22 @@ import { nextScriptEvent, startingToRunningEvent } from "./script";
 const TICK_MS = 100;
 const SCRIPT_INTERVAL_MS = 1364;
 
+// On narrow/touch screens the side-by-side cockpit can't fit at full size, so
+// we render it at this fixed design width and CSS-scale the whole thing down to
+// the available width — a faithful, compact mini-cockpit instead of a clipped one.
+const DESIGN_WIDTH = 640;
+
 export function TuiDemo() {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
   const [spinnerFrame, setSpinnerFrame] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
   const stateRef = useRef<DemoState>(state);
   stateRef.current = state;
+  // Mirrors `autoOnly` for the script ticker (which has a stable empty-deps
+  // closure and can't read the latest state value directly).
+  const autoOnlyRef = useRef(false);
 
   // Spinner ticker
   useEffect(() => {
@@ -51,7 +61,7 @@ export function TuiDemo() {
       if (cancelled) return;
       const now = Date.now();
       if (!isScriptPaused(stateRef.current, now)) {
-        const ev = nextScriptEvent(stateRef.current);
+        const ev = nextScriptEvent(stateRef.current, autoOnlyRef.current);
         if (ev) dispatch({ type: "script_event", event: ev });
       }
       // ±35% jitter around SCRIPT_INTERVAL_MS
@@ -88,6 +98,7 @@ export function TuiDemo() {
 
   // Detect touch / narrow viewport: auto-play only mode
   const [autoOnly, setAutoOnly] = useState(false);
+  autoOnlyRef.current = autoOnly;
   useEffect(() => {
     const mq = window.matchMedia("(max-width: 720px), (pointer: coarse)");
     const apply = () => setAutoOnly(mq.matches);
@@ -95,6 +106,30 @@ export function TuiDemo() {
     mq.addEventListener("change", apply);
     return () => mq.removeEventListener("change", apply);
   }, []);
+
+  // Scale-to-fit: in auto-only mode, shrink the fixed-width cockpit so it always
+  // fits the available width (no horizontal clipping). Desktop renders untouched.
+  const [scale, setScale] = useState(1);
+  const [fitHeight, setFitHeight] = useState<number | null>(null);
+  useEffect(() => {
+    if (!autoOnly) {
+      setScale(1);
+      setFitHeight(null);
+      return;
+    }
+    const measure = () => {
+      const avail = wrapRef.current?.clientWidth ?? DESIGN_WIDTH;
+      const s = Math.min(1, avail / DESIGN_WIDTH);
+      const h = cardRef.current?.offsetHeight ?? 0;
+      setScale(s);
+      setFitHeight(h > 0 ? h * s : null);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    if (wrapRef.current) ro.observe(wrapRef.current);
+    if (cardRef.current) ro.observe(cardRef.current);
+    return () => ro.disconnect();
+  }, [autoOnly]);
 
   const handleFocus = useCallback(() => {
     if (autoOnly) return;
@@ -222,11 +257,12 @@ export function TuiDemo() {
 
   return (
     <div
+      ref={wrapRef}
       style={{
         position: "relative",
-        margin: "5rem auto 0",
+        margin: "clamp(2.5rem, 9vw, 5rem) auto 0",
         maxWidth: 1100,
-        overflow: "visible",
+        overflow: autoOnly ? "hidden" : "visible",
       }}
     >
       {/* Focus aura — large blurred pink+purple glow behind the demo */}
@@ -247,7 +283,17 @@ export function TuiDemo() {
         }}
       />
       {hint && <ComicHint hint={hint} onClick={handleFocus} dimmed={state.focused} />}
+      {/* Fit container: collapses the layout box to the scaled height on mobile so
+          the transformed (visually-smaller) cockpit leaves no empty space below. */}
       <div
+        style={
+          autoOnly
+            ? { height: fitHeight ?? undefined, overflow: "hidden" }
+            : undefined
+        }
+      >
+      <div
+        ref={cardRef}
         style={{
           position: "relative",
           zIndex: 1,
@@ -262,6 +308,14 @@ export function TuiDemo() {
             : "0 30px 80px -30px rgba(0,0,0,0.6), 0 0 60px -20px rgba(244,143,177,0.25)",
           transition:
             "box-shadow 0.45s ease, border-color 0.45s ease",
+          ...(autoOnly
+            ? {
+                width: DESIGN_WIDTH,
+                marginInline: "auto",
+                transform: scale < 1 ? `scale(${scale})` : undefined,
+                transformOrigin: "top left",
+              }
+            : {}),
         }}
       >
       {/* macOS-style chrome bar */}
@@ -332,6 +386,7 @@ export function TuiDemo() {
 
       <Footer focused={state.focused && !autoOnly} />
       </div>
+      </div>
 
       {!autoOnly && <CoachBanner step={state.coachStep} />}
 
@@ -400,41 +455,6 @@ function ComicHint({
       >
         {hint}
       </div>
-
-      {/* Curved arrow pointing down into the demo */}
-      <svg
-        width="86"
-        height="68"
-        viewBox="0 0 86 68"
-        fill="none"
-        style={{
-          filter: "drop-shadow(0 2px 6px rgba(244,143,177,0.45))",
-          marginRight: 26,
-          marginTop: -2,
-        }}
-      >
-        <defs>
-          <marker
-            id="fleet-arrow-head"
-            viewBox="0 0 12 12"
-            refX="9"
-            refY="6"
-            markerWidth="7"
-            markerHeight="7"
-            orient="auto-start-reverse"
-          >
-            <path d="M 0 0 L 12 6 L 0 12 z" fill="#f48fb1" />
-          </marker>
-        </defs>
-        <path
-          d="M76 4 C 70 24, 44 30, 22 58"
-          fill="none"
-          stroke="#f48fb1"
-          strokeWidth="2.6"
-          strokeLinecap="round"
-          markerEnd="url(#fleet-arrow-head)"
-        />
-      </svg>
     </div>
   );
 }

--- a/site/components/tui-demo/script.ts
+++ b/site/components/tui-demo/script.ts
@@ -74,14 +74,55 @@ const RECIPES: Array<{
   },
 ];
 
-export function nextScriptEvent(state: DemoState): ScriptEvent | null {
+/**
+ * Extra recipes used only in self-driving mode (touch / narrow screens, where
+ * there's no user to approve). Without these the base recipes drain every
+ * session into `waiting` and the demo stalls. These close the loop — auto-
+ * approving and reviving sessions — so the mobile demo keeps a lively mix of
+ * running / waiting / finished instead of flatlining on waiting.
+ */
+const SELF_DRIVE_RECIPES: typeof RECIPES = [
+  // waiting → running (auto-approve — the SPACE→ENTER a desktop user would do)
+  {
+    weight: 30,
+    make: (sessions, now) => {
+      const c = sessions.filter((s) => s.status === "waiting" && fresh(s, now));
+      if (!c.length) return null;
+      return { kind: "flip_status", sessionId: rng(c).id, to: "running" };
+    },
+  },
+  // finished → running (a follow-up prompt lands)
+  {
+    weight: 12,
+    make: (sessions, now) => {
+      const c = sessions.filter((s) => s.status === "finished" && fresh(s, now));
+      if (!c.length) return null;
+      return { kind: "flip_status", sessionId: rng(c).id, to: "running" };
+    },
+  },
+  // idle → running (kick off new work)
+  {
+    weight: 9,
+    make: (sessions, now) => {
+      const c = sessions.filter((s) => s.status === "idle" && fresh(s, now));
+      if (!c.length) return null;
+      return { kind: "flip_status", sessionId: rng(c).id, to: "running" };
+    },
+  },
+];
+
+export function nextScriptEvent(
+  state: DemoState,
+  selfDrive = false,
+): ScriptEvent | null {
   const sessions = state.repos.flatMap((r) => r.sessions);
   if (!sessions.length) return null;
   const now = Date.now();
 
   // Materialize only viable events (recipe + concrete event with a real target).
+  const recipes = selfDrive ? [...RECIPES, ...SELF_DRIVE_RECIPES] : RECIPES;
   const viable: Array<{ weight: number; event: ScriptEvent }> = [];
-  for (const recipe of RECIPES) {
+  for (const recipe of recipes) {
     const event = recipe.make(sessions, now);
     if (event) viable.push({ weight: recipe.weight, event });
   }


### PR DESCRIPTION
## What

Makes the marketing landing page usable on phones. The fixes are scoped entirely to `site/`.

### TUI demo (the main problem)
The interactive cockpit is a fixed side-by-side grid of `white-space: pre` monospace content with `overflow: hidden`, so on a phone the preview column was crushed and the terminal text got sliced off the right edge.

- On narrow/touch viewports the cockpit now renders at a fixed design width and a measured `ResizeObserver` + `transform: scale()` shrinks the whole thing to fit exactly — a faithful, compact mini-cockpit instead of a clipped one. A height-collapsing wrapper keeps the layout box tidy. **Desktop renders byte-for-byte as before** (scale = 1, no transform).
- **Self-driving auto-play on mobile:** the auto-play script only moved `running` sessions *outward* (→ waiting/finished). On desktop the user closes that loop with SPACE→ENTER, but with no keyboard the demo drained into an all-`waiting` standstill. Added `SELF_DRIVE_RECIPES` (active only in auto-only mode) that auto-approve `waiting`→`running` and revive `finished`/`idle`→`running`, weighted to keep a lively running/waiting/finished mix. The desktop SPACE→ENTER coaching flow is untouched.
- Removed the comic arrow that pointed into the demo.

### Spacing
- Swapped hard `5rem`/`4rem` section gaps (Hero, Features, InstallTabs, demo top margin) for `clamp(...)` so the page tightens on small screens; desktop unchanged.

## Testing
- `npm run build` — clean static export, 17 pages.
- `tsc --noEmit` — passes.
- Verified in-browser at narrow/device-toolbar widths: no clipping, no horizontal scroll, demo cycles through all states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile/touch mode with automatic viewport scaling for the interactive TUI demo, dynamically adapting layout to available screen dimensions while maintaining usability.

* **Style**
  * Enhanced responsive spacing across multiple landing sections (Hero, Features, Installation tabs) with adaptive scaling for improved presentation on mobile and tablet devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->