### PR TITLE
feat(ui): display settings with live preview + first-run theme onboarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,9 @@ internal/debuglog/           # slog-based debug logging to ~/.config/fleet/debug
 internal/diagnostics/diagnostics.go  # System diagnostics collector for bug reports
 internal/ui/                 # Bubble Tea TUI (app, sidebar, preview, dialogs, styles)
 internal/ui/palette.go       # Theme palette definitions (5 built-in themes)
-internal/ui/settings.go      # Settings dialog (S key)
+internal/ui/settings.go      # Settings dialog (S key) — master-detail: Appearance/Behavior categories + live preview
+internal/ui/sidebar_preview.go   # Synthetic sidebar fixtures + RenderSidebarPreview (drives Appearance preview + onboarding)
+internal/ui/onboarding.go    # First-run theme picker + annotated "how to read the sidebar" sample
 internal/ui/bugreport.go     # Bug report dialog (! key) with diagnostics, error history, action log
 internal/ui/actionlog.go     # Ring buffer tracking user actions (steps to reproduce)
 internal/ui/errors.go        # Ring buffer keeping error history (errors that flash and vanish)
@@ -114,7 +116,9 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - Session resume: captures the agent's session_id from hooks, uses `claude --resume <id>` / `codex resume <id>` on restart
 - Editor: config.editor > $EDITOR > "code" (VS Code)
 - Themes: fleet-pink (default, flagship brand accent `#dc88c0`), tokyo-night, catppuccin-mocha, rose-pine, nord, gruvbox — configurable via settings (S key)
-- Settings dialog: S key opens settings overlay, live theme preview, auto-name toggle, copy .claude toggle, auto-saves on close
+- Settings dialog: S key opens a master-detail overlay — category rail (Appearance / Behavior) on the left, that category's settings on the right; `tab` switches panes, `j/k` move, `←→`/`h/l` cycle a value, auto-saves on `esc`. The **Appearance** category renders a live mock-sidebar preview (synthetic data via `RenderSidebarPreview` → the real `RenderSidebar`, so it can't drift) and holds: Theme, Status style (icon/bar), Agent icons, Slot badges, PR badges, Dirty marker, Status pills, Header counts, Chevron style (triangle/plusminus), Density (normal/compact). Behavior holds editor, tick, auto-name, auto-update, copy .claude, enter mode, telemetry, default agent.
+- Display toggles: each Appearance toggle is a `*bool`/string config field with a default-on getter (`config.go`) feeding a package global in `styles.go` (`ShowAgentGlyphs`, `ShowStatusPills`, `ShowPRBadges`, `ShowDirtyIndicator`, `ShowSlotBadges`, `ShowHeaderCounts`, `ChevronStyle`, `SidebarDensity`) — the same pattern as `StatusIndicatorMode`. Globals are synced from config via `ApplyDisplayConfig(cfg)` in `NewHome` (startup) and after each Appearance change; the sidebar `render*` funcs read them at render time.
+- First-run onboarding: on first launch, after the analytics consent prompt, a one-time theme picker (`internal/ui/onboarding.go`, gated by `display_onboarding_seen` config flag) shows the theme cycler beside an annotated sample sidebar that teaches how to read status dots, agent glyphs, branch, worktree, dirty `*`, and PR badge. `enter` keeps the previewed theme; `s`/`esc` reverts and skips. Either way it's marked seen.
 - Bug report: `!` key opens dialog showing error history, action log, system diagnostics; `g` opens GitHub issue with pre-filled markdown via `gh issue create --web`
 - Error history: ring buffer (max 50) of errors that flash for 5s — persists for bug reporting
 - Action log: ring buffer (max 100) of user actions (attach, delete, restart, editor, approve, etc.) for "steps to reproduce"

--- a/changelog/unreleased/display-settings.md
+++ b/changelog/unreleased/display-settings.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+Settings (`S`) is now a master-detail panel with an **Appearance** category that shows a live mock-sidebar preview as you change things. Pick a theme and toggle agent icons, PR badges, the dirty marker, status pills, slot badges, header counts, chevron style, and density — each updates the preview instantly. First launch also opens a one-time theme picker with an annotated sample sidebar that teaches how to read status dots, agent glyphs, branches, worktrees, and PR badges.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,7 +45,18 @@ type Config struct {
 	// first-launch theme/onboarding screen (whether they picked a theme or
 	// skipped). When false, the TUI shows it after the consent prompt.
 	DisplayOnboardingSeen bool `json:"display_onboarding_seen,omitempty"`
+
+	// loadedFromDisk records whether Load read an existing config file. It is
+	// unexported (never serialized) and powers IsFirstRun: a brand-new install
+	// has no config.json, so this is the one signal that doesn't depend on the
+	// telemetry/consent path.
+	loadedFromDisk bool
 }
+
+// IsFirstRun reports whether this is a genuinely fresh install — no config file
+// existed when Load ran. Used to decide whether to show first-run experiences
+// (e.g. theme onboarding) on launches that skip the consent prompt.
+func (c *Config) IsFirstRun() bool { return !c.loadedFromDisk }
 
 // GetDefaultAgent returns the default coding agent for new sessions ("claude" or "codex").
 // The stored value is normalized (trimmed + lower-cased) so hand-edited configs
@@ -109,6 +120,7 @@ func Load() *Config {
 		debuglog.Logger.Info("config file not found, using defaults", "path", path)
 		return cfg
 	}
+	cfg.loadedFromDisk = true
 
 	if err := json.Unmarshal(data, cfg); err != nil {
 		debuglog.Logger.Error("failed to parse config file", "path", path, "error", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,10 +22,29 @@ type Config struct {
 	StatusIndicator    string `json:"status_indicator,omitempty"` // "icon" (default) or "bar"
 	Telemetry          *bool  `json:"telemetry,omitempty"`
 	DefaultAgent       string `json:"default_agent,omitempty"` // "claude" or "codex"
+
+	// Sidebar display toggles. All default to true (on) via the *bool nil
+	// pattern, so an unconfigured fleet renders the full vocabulary. Each is
+	// surfaced in the Appearance category of the Settings dialog and drives a
+	// package-level render flag in the ui package (see ApplyDisplayConfig).
+	ShowAgentGlyphs    *bool  `json:"show_agent_glyphs,omitempty"`    // per-session ✻/◇ agent sigil
+	ShowStatusPills    *bool  `json:"show_status_pills,omitempty"`    // header "2● 1◐" status summary
+	ShowPRBadges       *bool  `json:"show_pr_badges,omitempty"`       // "#123 ✓" PR badge on checkout headers
+	ShowDirtyIndicator *bool  `json:"show_dirty_indicator,omitempty"` // "*" dirty-worktree marker
+	ShowSlotBadges     *bool  `json:"show_slot_badges,omitempty"`     // "[N]" hotkey slot badge
+	ShowHeaderCounts   *bool  `json:"show_header_counts,omitempty"`   // session count on origin/checkout headers
+	ChevronStyle       string `json:"chevron_style,omitempty"`        // "triangle" (default ▾▸) or "plusminus" (−+)
+	SidebarDensity     string `json:"sidebar_density,omitempty"`      // "normal" (default) or "compact" (no inter-group gap)
+
 	// AnalyticsConsentSeen is true once the user has been shown the
 	// first-launch consent prompt and answered it (either way). When false,
 	// the TUI shows the prompt before initializing analytics.
 	AnalyticsConsentSeen bool `json:"analytics_consent_seen,omitempty"`
+
+	// DisplayOnboardingSeen is true once the user has been shown the
+	// first-launch theme/onboarding screen (whether they picked a theme or
+	// skipped). When false, the TUI shows it after the consent prompt.
+	DisplayOnboardingSeen bool `json:"display_onboarding_seen,omitempty"`
 }
 
 // GetDefaultAgent returns the default coding agent for new sessions ("claude" or "codex").
@@ -147,6 +166,50 @@ func (c *Config) GetStatusIndicator() string {
 		return "bar"
 	}
 	return "icon"
+}
+
+// boolDefaultTrue resolves an optional bool flag, defaulting to true when unset.
+func boolDefaultTrue(p *bool) bool {
+	if p == nil {
+		return true
+	}
+	return *p
+}
+
+// IsShowAgentGlyphs reports whether the per-session ✻/◇ agent sigil is shown (default: true).
+func (c *Config) IsShowAgentGlyphs() bool { return boolDefaultTrue(c.ShowAgentGlyphs) }
+
+// IsShowStatusPills reports whether header status-summary pills are shown (default: true).
+func (c *Config) IsShowStatusPills() bool { return boolDefaultTrue(c.ShowStatusPills) }
+
+// IsShowPRBadges reports whether PR badges are shown on checkout headers (default: true).
+func (c *Config) IsShowPRBadges() bool { return boolDefaultTrue(c.ShowPRBadges) }
+
+// IsShowDirtyIndicator reports whether the dirty "*" marker is shown (default: true).
+func (c *Config) IsShowDirtyIndicator() bool { return boolDefaultTrue(c.ShowDirtyIndicator) }
+
+// IsShowSlotBadges reports whether "[N]" hotkey slot badges are shown (default: true).
+func (c *Config) IsShowSlotBadges() bool { return boolDefaultTrue(c.ShowSlotBadges) }
+
+// IsShowHeaderCounts reports whether session counts are shown on headers (default: true).
+func (c *Config) IsShowHeaderCounts() bool { return boolDefaultTrue(c.ShowHeaderCounts) }
+
+// GetChevronStyle returns the configured header chevron style — "triangle"
+// (default ▾▸) or "plusminus" (−+).
+func (c *Config) GetChevronStyle() string {
+	if c.ChevronStyle == "plusminus" {
+		return "plusminus"
+	}
+	return "triangle"
+}
+
+// GetSidebarDensity returns the configured sidebar density — "normal" (default,
+// a blank gap between origin groups) or "compact" (no gap).
+func (c *Config) GetSidebarDensity() string {
+	if c.SidebarDensity == "compact" {
+		return "compact"
+	}
+	return "normal"
 }
 
 // IsTelemetryEnabled returns whether telemetry is enabled (default: true).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -293,3 +293,28 @@ func TestConfigOmitEmptyFields(t *testing.T) {
 		}
 	}
 }
+
+func TestIsFirstRun(t *testing.T) {
+	// Isolate the config path to a fresh temp HOME so no real config leaks in.
+	t.Setenv("HOME", t.TempDir())
+
+	// No config file yet → first run.
+	cfg := Load()
+	if !cfg.IsFirstRun() {
+		t.Error("Load with no config file should report IsFirstRun() == true")
+	}
+
+	// After a Save, the file exists, so a subsequent Load is not a first run.
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+	if cfg2 := Load(); cfg2.IsFirstRun() {
+		t.Error("Load with an existing config file should report IsFirstRun() == false")
+	}
+
+	// loadedFromDisk is unexported, so a hand-built Config (e.g. in other
+	// tests) is treated as a first run — the safe default.
+	if !(&Config{}).IsFirstRun() {
+		t.Error("zero-value Config should report IsFirstRun() == true")
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1484,6 +1484,15 @@ var (
 	repoRootCacheMu sync.RWMutex
 )
 
+// SeedRepoRoot pre-populates the repo-root cache so GetRepoRoot returns root for
+// projectPath without shelling out to git. Used by the sidebar preview to
+// resolve its synthetic paths hermetically (no disk access).
+func SeedRepoRoot(projectPath, root string) {
+	repoRootCacheMu.Lock()
+	repoRootCache[projectPath] = root
+	repoRootCacheMu.Unlock()
+}
+
 // GetRepoRoot returns the git repo root for a path, or the path itself if not a git repo.
 func GetRepoRoot(projectPath string) string {
 	repoRootCacheMu.RLock()

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1115,13 +1115,19 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.consentDialog.Show()
 			}
 
-			// The theme onboarding is a brand-new-user experience and follows
-			// the consent prompt (see consentResultMsg). When consent isn't
-			// shown the user is an existing/returning install — never surprise
-			// them with it (it would overwrite their theme); just remember it
-			// as seen so it doesn't pop up on a later launch either.
+			// The theme onboarding is a brand-new-user experience. When the
+			// consent prompt is shown it follows that (see consentResultMsg).
+			// When no consent prompt is shown we decide here based on whether
+			// this is a genuinely fresh install: a brand-new user who skipped
+			// consent only because they're env-opted-out of telemetry still
+			// deserves onboarding; an existing/returning install must never be
+			// surprised by it (it could overwrite their theme), so mark it seen.
 			if !h.consentDialog.IsVisible() {
-				h.markOnboardingSeen()
+				if h.cfg.IsFirstRun() {
+					h.maybeShowOnboarding()
+				} else {
+					h.markOnboardingSeen()
+				}
 			}
 		}
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -180,6 +180,7 @@ type Home struct {
 	commandPalette        *CommandPaletteDialog
 	sessionCreateDialog   *SessionCreateDialog
 	consentDialog         *ConsentDialog
+	onboardingDialog      *OnboardingDialog
 
 	// launchpad is the first-run experience shown when the fleet is empty:
 	// recent repos mined from Claude Code history, ready to resume.
@@ -313,7 +314,7 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string, ident
 	// Apply theme — PaletteByName falls back to the flagship default when
 	// cfg.Theme is empty or unknown.
 	ApplyPalette(PaletteByName(cfg.Theme))
-	StatusIndicatorMode = cfg.GetStatusIndicator()
+	ApplyDisplayConfig(cfg)
 
 	h := &Home{
 		storage:               storage,
@@ -336,6 +337,7 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string, ident
 		commandPalette:        NewCommandPaletteDialog(),
 		sessionCreateDialog:   NewSessionCreateDialog(),
 		consentDialog:         NewConsentDialog(),
+		onboardingDialog:      NewOnboardingDialog(cfg),
 		launchpad:             NewLaunchpad(),
 		bugReport:             NewBugReportDialog(),
 		previewCache:          make(map[string]string),
@@ -464,6 +466,7 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.commandPalette.SetSize(msg.Width, msg.Height)
 		h.sessionCreateDialog.SetSize(msg.Width, msg.Height)
 		h.consentDialog.SetSize(msg.Width, msg.Height)
+		h.onboardingDialog.SetSize(msg.Width, msg.Height)
 		h.bugReport.SetSize(msg.Width, msg.Height)
 		h.syncViewport()
 		return h, nil
@@ -641,6 +644,13 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// flipped) Telemetry toggle — otherwise the change only takes
 		// effect on next launch.
 		analytics.SyncEnabled(h.cfg.IsTelemetryEnabled(), h.version, h.identity)
+		// Display toggles are live, but the density flag changes BuildFlatItems
+		// output (inter-group spacer rows), so rebuild the flattened list.
+		h.rebuildFlatItems()
+		return h, nil
+
+	case onboardingClosedMsg:
+		// Theme was applied live during the picker; nothing to re-read.
 		return h, nil
 
 	case consentResultMsg:
@@ -652,17 +662,21 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if err := h.cfg.Save(); err != nil {
 			debuglog.Logger.Error("config: save after consent", "err", err)
 		}
+		var cmd tea.Cmd
 		if enabled {
 			// Worker is already running by this point — guard the read.
 			h.workerMu.Lock()
 			repoCount := len(session.GroupByRepo(h.sessions))
 			h.workerMu.Unlock()
 			h.fireStartupAnalytics(repoCount)
-			return h, nil
+		} else {
+			// Declined: emit a single anonymous decline beacon (device hash
+			// only). Guarded against env opt-out inside TrackDeclined.
+			cmd = h.fireDeclineBeacon()
 		}
-		// Declined: emit a single anonymous decline beacon (device hash only).
-		// Guarded against env opt-out inside TrackDeclined.
-		return h, h.fireDeclineBeacon()
+		// First-run theme onboarding follows the consent prompt.
+		h.maybeShowOnboarding()
+		return h, cmd
 
 	case bugReportClosedMsg:
 		return h, nil
@@ -1100,6 +1114,15 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			default:
 				h.consentDialog.Show()
 			}
+
+			// The theme onboarding is a brand-new-user experience and follows
+			// the consent prompt (see consentResultMsg). When consent isn't
+			// shown the user is an existing/returning install — never surprise
+			// them with it (it would overwrite their theme); just remember it
+			// as seen so it doesn't pop up on a later launch either.
+			if !h.consentDialog.IsVisible() {
+				h.markOnboardingSeen()
+			}
 		}
 
 		// Start listening for hook changes.
@@ -1148,6 +1171,9 @@ func (h *Home) renderBody() string {
 	// and must be the user's first interaction with the TUI.
 	if h.consentDialog.IsVisible() {
 		return h.consentDialog.View()
+	}
+	if h.onboardingDialog.IsVisible() {
+		return h.onboardingDialog.View()
 	}
 	if h.helpOverlay.IsVisible() {
 		return h.helpOverlay.View()
@@ -1362,6 +1388,11 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if h.consentDialog.IsVisible() {
 		dialog, cmd := h.consentDialog.Update(msg)
 		h.consentDialog = dialog
+		return h, cmd
+	}
+	if h.onboardingDialog.IsVisible() {
+		dialog, cmd := h.onboardingDialog.Update(msg)
+		h.onboardingDialog = dialog
 		return h, cmd
 	}
 	if h.bugReport.IsVisible() {
@@ -1882,6 +1913,28 @@ func (h *Home) launchpadActive() bool {
 		return false
 	}
 	return h.launchpad.HasItems()
+}
+
+// maybeShowOnboarding shows the one-time first-run theme/onboarding screen,
+// unless the user has already seen it. Called after the consent flow resolves
+// so the order is consent → theme onboarding → launchpad.
+func (h *Home) maybeShowOnboarding() {
+	if !h.cfg.DisplayOnboardingSeen {
+		h.onboardingDialog.Show()
+	}
+}
+
+// markOnboardingSeen records that onboarding need not appear, without showing
+// it — used for existing/returning installs so an upgrade never surprises them
+// with the first-run theme picker (which would overwrite their chosen theme).
+func (h *Home) markOnboardingSeen() {
+	if h.cfg.DisplayOnboardingSeen {
+		return
+	}
+	h.cfg.DisplayOnboardingSeen = true
+	if err := h.cfg.Save(); err != nil {
+		debuglog.Logger.Error("config: save onboarding-seen", "err", err)
+	}
 }
 
 func (h *Home) handleSessionCreate(msg sessionCreateMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/display_settings_test.go
+++ b/internal/ui/display_settings_test.go
@@ -1,0 +1,150 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/brizzai/fleet/internal/config"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// resetDisplayFlags restores the package display globals to their defaults so
+// tests don't leak state into each other.
+func resetDisplayFlags(t *testing.T) {
+	t.Helper()
+	ApplyDisplayConfig(&config.Config{})
+}
+
+func TestRenderSidebarPreview_ContainsVocabulary(t *testing.T) {
+	resetDisplayFlags(t)
+	out := RenderSidebarPreview(44, 14)
+	// Note: the sidebar shows only the last branch segment, so "feat/preview"
+	// renders as "preview" (real product behavior we deliberately preview).
+	for _, want := range []string{"fleet", "scratch", "Refactor", "#128", claudeGlyph, codexGlyph} {
+		if !strings.Contains(out, want) {
+			t.Errorf("preview missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderSidebarPreview_AgentGlyphsToggle(t *testing.T) {
+	resetDisplayFlags(t)
+	off := false
+	ApplyDisplayConfig(&config.Config{ShowAgentGlyphs: &off})
+	defer resetDisplayFlags(t)
+
+	out := RenderSidebarPreview(44, 14)
+	if strings.Contains(out, claudeGlyph) || strings.Contains(out, codexGlyph) {
+		t.Errorf("agent glyphs should be hidden when ShowAgentGlyphs is off:\n%s", out)
+	}
+}
+
+func TestRenderSidebarPreview_PRBadgeToggle(t *testing.T) {
+	resetDisplayFlags(t)
+	off := false
+	ApplyDisplayConfig(&config.Config{ShowPRBadges: &off})
+	defer resetDisplayFlags(t)
+
+	out := RenderSidebarPreview(44, 14)
+	if strings.Contains(out, "#128") {
+		t.Errorf("PR badge should be hidden when ShowPRBadges is off:\n%s", out)
+	}
+}
+
+func TestChevronGlyphStyles(t *testing.T) {
+	resetDisplayFlags(t)
+	defer resetDisplayFlags(t)
+
+	ChevronStyle = "triangle"
+	if got := chevronGlyph(true); got != "▾" {
+		t.Errorf("triangle expanded = %q, want ▾", got)
+	}
+	ChevronStyle = "plusminus"
+	if got := chevronGlyph(false); got != "+" {
+		t.Errorf("plusminus collapsed = %q, want +", got)
+	}
+}
+
+func TestSettingsDialog_AppearanceViewAndToggle(t *testing.T) {
+	resetDisplayFlags(t)
+	defer resetDisplayFlags(t)
+
+	cfg := &config.Config{}
+	d := NewSettingsDialog(cfg)
+	d.SetSize(140, 40)
+	d.Show()
+
+	// Appearance is the default category and renders without panicking.
+	if v := d.View(); v == "" {
+		t.Fatal("settings View() returned empty")
+	}
+
+	// Dive into the detail pane and flip the first toggle-style row (Agent
+	// icons sits after the THEME subheader + Theme + Status style rows).
+	d.focus = focusDetail
+	for i, r := range d.curRows() {
+		if r.label == "Agent icons" {
+			d.rowCursor = i
+		}
+	}
+	d.cycleCurrent(1)
+	if cfg.IsShowAgentGlyphs() {
+		t.Error("cycling Agent icons should have turned it off")
+	}
+	if ShowAgentGlyphs {
+		t.Error("toggling Agent icons should sync the render global live")
+	}
+}
+
+func TestSettingsDialog_BehaviorHasNoThemeRow(t *testing.T) {
+	resetDisplayFlags(t)
+	defer resetDisplayFlags(t)
+
+	d := NewSettingsDialog(&config.Config{})
+	d.SetSize(140, 40)
+	d.Show()
+	// Move to Behavior category.
+	d.categoryCursor = 1
+	for _, r := range d.curRows() {
+		if r.label == "Theme" {
+			t.Error("Theme should live under Appearance, not Behavior")
+		}
+	}
+}
+
+func TestOnboardingDialog_ConfirmAndSkip(t *testing.T) {
+	resetDisplayFlags(t)
+	defer resetDisplayFlags(t)
+
+	// Confirm path: picks a non-default theme and marks onboarding seen.
+	cfg := &config.Config{}
+	d := NewOnboardingDialog(cfg)
+	d.SetSize(120, 40)
+	d.Show()
+	if v := d.View(); !strings.Contains(v, "Welcome to fleet") {
+		t.Fatalf("onboarding View() missing title:\n%s", v)
+	}
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyRight}) // advance theme
+	wantTheme := BuiltinPalettes[1].Name
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cfg.Theme != wantTheme {
+		t.Errorf("confirm set theme %q, want %q", cfg.Theme, wantTheme)
+	}
+	if !cfg.DisplayOnboardingSeen {
+		t.Error("confirm should mark DisplayOnboardingSeen")
+	}
+
+	// Skip path: reverts to the original theme but still marks seen.
+	cfg2 := &config.Config{Theme: "nord"}
+	d2 := NewOnboardingDialog(cfg2)
+	d2.SetSize(120, 40)
+	d2.Show()
+	d2, _ = d2.Update(tea.KeyMsg{Type: tea.KeyRight})
+	d2, _ = d2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if cfg2.Theme != "nord" {
+		t.Errorf("skip should revert theme to nord, got %q", cfg2.Theme)
+	}
+	if !cfg2.DisplayOnboardingSeen {
+		t.Error("skip should still mark DisplayOnboardingSeen")
+	}
+}

--- a/internal/ui/display_settings_test.go
+++ b/internal/ui/display_settings_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/brizzai/fleet/internal/config"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // resetDisplayFlags restores the package display globals to their defaults so
@@ -23,6 +24,62 @@ func TestRenderSidebarPreview_ContainsVocabulary(t *testing.T) {
 	for _, want := range []string{"fleet", "scratch", "Refactor", "#128", claudeGlyph, codexGlyph} {
 		if !strings.Contains(out, want) {
 			t.Errorf("preview missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderSidebarPreview_CalloutRowAlignment guards the preview's flattened
+// row order. The onboarding annotated sample (renderAnnotatedSample) pins
+// teaching callouts to fixed row indices, so the preview must keep emitting the
+// expected row at each of those indices. The preview rows are produced by the
+// real BuildFlatItems, so this also catches drift from the live sidebar.
+func TestRenderSidebarPreview_CalloutRowAlignment(t *testing.T) {
+	resetDisplayFlags(t)
+	defer resetDisplayFlags(t)
+
+	lines := strings.Split(RenderSidebarPreview(44, 14), "\n")
+	want := []struct {
+		row int
+		sub string
+	}{
+		{1, "#128"},              // ← branch · PR approved
+		{2, "Refactor sidebar"},  // ← running · Claude
+		{3, "Add test coverage"}, // ← waiting · Codex
+		{4, "preview"},           // ← worktree · dirty
+		{5, "Fix flaky preview"}, // ← finished · hotkey [1]
+	}
+	for _, w := range want {
+		got := ""
+		if w.row < len(lines) {
+			got = lines[w.row]
+		}
+		if !strings.Contains(got, w.sub) {
+			t.Errorf("preview row %d should contain %q; got %q\nfull:\n%s",
+				w.row, w.sub, got, strings.Join(lines, "\n"))
+		}
+	}
+}
+
+// TestSettingsDialog_FitsTerminal locks the regression fix: the modal must
+// never render wider or taller than the terminal, including narrow panes where
+// the old dialog clamped its width. lipgloss.Place pads every line to the
+// terminal width, so any line wider than w means the box overflowed.
+func TestSettingsDialog_FitsTerminal(t *testing.T) {
+	resetDisplayFlags(t)
+	defer resetDisplayFlags(t)
+
+	d := NewSettingsDialog(&config.Config{})
+	d.Show()
+	for _, dim := range []struct{ w, h int }{{40, 30}, {50, 20}, {60, 24}, {80, 30}, {140, 40}} {
+		d.SetSize(dim.w, dim.h)
+		lines := strings.Split(d.View(), "\n")
+		if len(lines) > dim.h {
+			t.Errorf("at %dx%d the modal is %d rows tall (overflows)", dim.w, dim.h, len(lines))
+		}
+		for _, line := range lines {
+			if lw := lipgloss.Width(line); lw > dim.w {
+				t.Errorf("at %dx%d a rendered line is %d cols wide (overflows):\n%q", dim.w, dim.h, lw, line)
+			}
 		}
 	}
 }

--- a/internal/ui/display_settings_test.go
+++ b/internal/ui/display_settings_test.go
@@ -126,7 +126,8 @@ func TestOnboardingDialog_ConfirmAndSkip(t *testing.T) {
 	}
 	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyRight}) // advance theme
 	wantTheme := BuiltinPalettes[1].Name
-	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	// Update mutates the shared cfg pointer; we assert on cfg, not the return.
+	_, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	if cfg.Theme != wantTheme {
 		t.Errorf("confirm set theme %q, want %q", cfg.Theme, wantTheme)
 	}
@@ -140,7 +141,7 @@ func TestOnboardingDialog_ConfirmAndSkip(t *testing.T) {
 	d2.SetSize(120, 40)
 	d2.Show()
 	d2, _ = d2.Update(tea.KeyMsg{Type: tea.KeyRight})
-	d2, _ = d2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	_, _ = d2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
 	if cfg2.Theme != "nord" {
 		t.Errorf("skip should revert theme to nord, got %q", cfg2.Theme)
 	}

--- a/internal/ui/onboarding.go
+++ b/internal/ui/onboarding.go
@@ -1,0 +1,179 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/brizzai/fleet/internal/analytics"
+	"github.com/brizzai/fleet/internal/config"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// onboardingClosedMsg is emitted when the first-run onboarding screen closes
+// (whether the user confirmed a theme or skipped).
+type onboardingClosedMsg struct{}
+
+// OnboardingDialog is the one-time first-run screen: a theme picker beside an
+// annotated sample sidebar that teaches how to read the real one. It persists
+// the chosen theme + DisplayOnboardingSeen, so it appears only once.
+type OnboardingDialog struct {
+	visible     bool
+	width       int
+	height      int
+	cfg         *config.Config
+	themeCursor int
+	origTheme   string
+}
+
+// NewOnboardingDialog creates the onboarding dialog.
+func NewOnboardingDialog(cfg *config.Config) *OnboardingDialog {
+	return &OnboardingDialog{cfg: cfg}
+}
+
+func (d *OnboardingDialog) Show() {
+	d.visible = true
+	d.origTheme = d.cfg.Theme
+	d.themeCursor = 0
+	for i, p := range BuiltinPalettes {
+		if p.Name == d.cfg.Theme {
+			d.themeCursor = i
+			break
+		}
+	}
+}
+
+func (d *OnboardingDialog) Hide()           { d.visible = false }
+func (d *OnboardingDialog) IsVisible() bool { return d.visible }
+func (d *OnboardingDialog) SetSize(w, h int) {
+	d.width = w
+	d.height = h
+}
+
+// Update handles key events. ←/→ preview a theme live; enter confirms; s/esc
+// skips (reverting to the original theme). Both exits mark onboarding seen.
+func (d *OnboardingDialog) Update(msg tea.Msg) (*OnboardingDialog, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return d, nil
+	}
+	switch keyMsg.String() {
+	case "left", "h":
+		d.themeCursor = (d.themeCursor + len(BuiltinPalettes) - 1) % len(BuiltinPalettes)
+		d.applyCursorTheme()
+	case "right", "l":
+		d.themeCursor = (d.themeCursor + 1) % len(BuiltinPalettes)
+		d.applyCursorTheme()
+	case "enter":
+		return d.finish(true)
+	case "s", "S", "esc":
+		return d.finish(false)
+	}
+	return d, nil
+}
+
+// applyCursorTheme previews the cursor's theme live and records it on cfg.
+func (d *OnboardingDialog) applyCursorTheme() {
+	d.cfg.Theme = BuiltinPalettes[d.themeCursor].Name
+	ApplyPalette(BuiltinPalettes[d.themeCursor])
+}
+
+// finish persists the result and closes. On skip, the original theme is restored.
+func (d *OnboardingDialog) finish(confirmed bool) (*OnboardingDialog, tea.Cmd) {
+	if confirmed {
+		d.cfg.Theme = BuiltinPalettes[d.themeCursor].Name
+		analytics.Track(analytics.EventThemeChanged, map[string]interface{}{"theme": d.cfg.Theme})
+	} else {
+		d.cfg.Theme = d.origTheme
+		ApplyPalette(PaletteByName(d.origTheme))
+	}
+	d.cfg.DisplayOnboardingSeen = true
+	_ = d.cfg.Save()
+	d.Hide()
+	return d, func() tea.Msg { return onboardingClosedMsg{} }
+}
+
+func (d *OnboardingDialog) View() string {
+	var b strings.Builder
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorBrand)
+	b.WriteString(titleStyle.Render("⬡  Welcome to fleet"))
+	b.WriteString("\n\n")
+
+	sub := lipgloss.NewStyle().Foreground(ColorText)
+	b.WriteString(sub.Render("Pick a theme — and here's how to read your sidebar."))
+	b.WriteString("\n")
+	b.WriteString(DimStyle.Render("Change everything later in Settings (S)."))
+	b.WriteString("\n\n")
+
+	// Theme cycler.
+	name := PaletteDisplayName(BuiltinPalettes[d.themeCursor].Name)
+	arrow := lipgloss.NewStyle().Foreground(ColorAccent)
+	val := lipgloss.NewStyle().Bold(true).Foreground(ColorText)
+	b.WriteString("Theme:  " + arrow.Render("‹") + " " + val.Render(name) + " " + arrow.Render("›"))
+	b.WriteString("   ")
+	b.WriteString(DimStyle.Render(themeDots(d.themeCursor, len(BuiltinPalettes))))
+	b.WriteString("\n\n")
+
+	// Annotated sample sidebar.
+	b.WriteString(renderAnnotatedSample(34))
+	b.WriteString("\n\n")
+
+	// Footer.
+	footer := lipgloss.NewStyle().Foreground(ColorTextDim).
+		Render("←→ theme   enter continue   s skip")
+	b.WriteString(footer)
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorBrand).
+		Padding(1, 2)
+	box := boxStyle.Render(b.String())
+
+	return lipgloss.Place(d.width, d.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+// themeDots renders a "● ○ ○ ○ ○ ○" position indicator for the theme cycler.
+func themeDots(idx, n int) string {
+	var parts []string
+	for i := 0; i < n; i++ {
+		if i == idx {
+			parts = append(parts, "●")
+		} else {
+			parts = append(parts, "○")
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// renderAnnotatedSample renders the synthetic sidebar with teaching callouts
+// pointing at representative rows. Row indices match previewItems() ordering at
+// normal density, so the sample must be rendered tall enough to avoid scroll
+// indicators shifting the rows.
+func renderAnnotatedSample(width int) string {
+	callouts := map[int]string{
+		1: "← branch · PR approved",
+		2: "← running · Claude",
+		3: "← waiting · Codex",
+		4: "← worktree · dirty",
+		5: "← finished · hotkey [1]",
+	}
+	sidebar := RenderSidebarPreview(width, 11)
+	lines := strings.Split(sidebar, "\n")
+	dim := lipgloss.NewStyle().Foreground(ColorTextDim)
+
+	var b strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		lw := lipgloss.Width(line)
+		if lw < width {
+			line += strings.Repeat(" ", width-lw)
+		}
+		if c, ok := callouts[i]; ok {
+			line += "  " + dim.Render(c)
+		}
+		b.WriteString(line)
+	}
+	return b.String()
+}

--- a/internal/ui/onboarding.go
+++ b/internal/ui/onboarding.go
@@ -146,9 +146,9 @@ func themeDots(idx, n int) string {
 }
 
 // renderAnnotatedSample renders the synthetic sidebar with teaching callouts
-// pointing at representative rows. Row indices match previewItems() ordering at
-// normal density, so the sample must be rendered tall enough to avoid scroll
-// indicators shifting the rows.
+// pointing at representative rows. Row indices match the RenderSidebarPreview
+// fixture's ordering at normal density, so the sample must be rendered tall
+// enough to avoid scroll indicators shifting the rows.
 func renderAnnotatedSample(width int) string {
 	callouts := map[int]string{
 		1: "← branch · PR approved",

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -14,29 +14,66 @@ import (
 type settingsClosedMsg struct{}
 
 var (
-	editorPresets = []string{"code", "cursor", "vim", "nvim", "nano", "emacs", "zed"}
-	tickPresets   = []int{1, 2, 3, 5, 10}
+	editorPresets   = []string{"code", "cursor", "vim", "nvim", "nano", "emacs", "zed"}
+	tickPresets     = []int{1, 2, 3, 5, 10}
+	statusStyleSet  = []string{"icon", "bar"}
+	chevronStyleSet = []string{"triangle", "plusminus"}
+	densitySet      = []string{"normal", "compact"}
+	enterModeSet    = []string{"attach", "split"}
+	defaultAgentSet = []string{"claude", "codex"}
 )
 
-// SettingsDialog provides a UI for configuring fleet settings.
+// settingsFocus tracks which pane (category rail or detail list) has the cursor.
+type settingsFocus int
+
+const (
+	focusCategories settingsFocus = iota
+	focusDetail
+)
+
+// settingRow is one line in a category's detail pane. A subheader row is a
+// non-interactive group label that cursor navigation skips.
+type settingRow struct {
+	label     string
+	subheader bool
+	value     func(c *config.Config) string    // display value (interactive rows only)
+	cycle     func(d *SettingsDialog, dir int) // mutate cfg + live-apply (interactive rows only)
+}
+
+// settingsCategory is a left-rail entry with its detail rows. showPreview marks
+// the category that renders the live sidebar preview alongside its settings.
+type settingsCategory struct {
+	name        string
+	showPreview bool
+	rows        []settingRow
+}
+
+// SettingsDialog provides a master-detail UI for configuring fleet settings:
+// categories on the left, the selected category's settings on the right, and a
+// live mock-sidebar preview for the Appearance category.
 type SettingsDialog struct {
-	visible   bool
-	width     int
-	height    int
-	cursor    int // 0=theme, 1=editor, 2=tick
-	cfg       *config.Config
-	origTheme string
+	visible        bool
+	width          int
+	height         int
+	cfg            *config.Config
+	origTheme      string
+	categories     []settingsCategory
+	categoryCursor int
+	rowCursor      int
+	focus          settingsFocus
 }
 
 // NewSettingsDialog creates a settings dialog.
 func NewSettingsDialog(cfg *config.Config) *SettingsDialog {
-	return &SettingsDialog{cfg: cfg}
+	return &SettingsDialog{cfg: cfg, categories: buildSettingsCategories()}
 }
 
 func (d *SettingsDialog) Show() {
 	d.visible = true
-	d.cursor = 0
 	d.origTheme = d.cfg.Theme
+	d.categoryCursor = 0
+	d.focus = focusCategories
+	d.rowCursor = d.firstSelectableRow(0)
 }
 
 func (d *SettingsDialog) Hide()           { d.visible = false }
@@ -46,6 +83,44 @@ func (d *SettingsDialog) SetSize(w, h int) {
 	d.height = h
 }
 
+func (d *SettingsDialog) curRows() []settingRow { return d.categories[d.categoryCursor].rows }
+
+// maxBlockHeight is the tallest the detail/rail/preview block needs to be across
+// every category. Using a single constant keeps the modal a fixed height as the
+// user switches categories.
+func (d *SettingsDialog) maxBlockHeight() int {
+	h := len(d.categories) // rail height
+	for _, c := range d.categories {
+		if len(c.rows) > h {
+			h = len(c.rows)
+		}
+	}
+	return h
+}
+
+// firstSelectableRow returns the first non-subheader row index of a category.
+func (d *SettingsDialog) firstSelectableRow(cat int) int {
+	for i, r := range d.categories[cat].rows {
+		if !r.subheader {
+			return i
+		}
+	}
+	return 0
+}
+
+// nextSelectableRow steps the row cursor past subheaders in the given direction.
+func (d *SettingsDialog) nextSelectableRow(cur, dir int) int {
+	rows := d.curRows()
+	next := cur + dir
+	for next >= 0 && next < len(rows) {
+		if !rows[next].subheader {
+			return next
+		}
+		next += dir
+	}
+	return cur
+}
+
 // Update handles key events for the settings dialog.
 func (d *SettingsDialog) Update(msg tea.Msg) (*SettingsDialog, tea.Cmd) {
 	keyMsg, ok := msg.(tea.KeyMsg)
@@ -53,167 +128,171 @@ func (d *SettingsDialog) Update(msg tea.Msg) (*SettingsDialog, tea.Cmd) {
 		return d, nil
 	}
 
-	numRows := 10 // theme, status-style, editor, tick, auto-name, auto-update, copy-claude, enter-mode, telemetry, default-agent
 	switch keyMsg.String() {
-	case "j", "down":
-		d.cursor = (d.cursor + 1) % numRows
-	case "k", "up":
-		d.cursor = (d.cursor + numRows - 1) % numRows
-	case "l", "right":
-		d.cycleValue(1)
-	case "h", "left":
-		d.cycleValue(-1)
 	case "esc", "q":
-		// Save config and close.
 		_ = d.cfg.Save()
 		d.Hide()
 		return d, func() tea.Msg { return settingsClosedMsg{} }
+
+	case "tab", "shift+tab":
+		if d.focus == focusCategories {
+			d.focus = focusDetail
+			d.rowCursor = d.firstSelectableRow(d.categoryCursor)
+		} else {
+			d.focus = focusCategories
+		}
+
+	case "j", "down":
+		if d.focus == focusCategories {
+			d.categoryCursor = (d.categoryCursor + 1) % len(d.categories)
+			d.rowCursor = d.firstSelectableRow(d.categoryCursor)
+		} else {
+			d.rowCursor = d.nextSelectableRow(d.rowCursor, 1)
+		}
+
+	case "k", "up":
+		if d.focus == focusCategories {
+			d.categoryCursor = (d.categoryCursor + len(d.categories) - 1) % len(d.categories)
+			d.rowCursor = d.firstSelectableRow(d.categoryCursor)
+		} else {
+			d.rowCursor = d.nextSelectableRow(d.rowCursor, -1)
+		}
+
+	case "l", "right", "enter":
+		if d.focus == focusCategories {
+			// Dive from the rail into the detail list.
+			d.focus = focusDetail
+			d.rowCursor = d.firstSelectableRow(d.categoryCursor)
+		} else {
+			d.cycleCurrent(1)
+		}
+
+	case "h", "left":
+		if d.focus == focusDetail {
+			d.cycleCurrent(-1)
+		}
 	}
 
 	return d, nil
 }
 
-func (d *SettingsDialog) cycleValue(dir int) {
-	switch d.cursor {
-	case 0: // Theme
-		names := make([]string, len(BuiltinPalettes))
-		for i, p := range BuiltinPalettes {
-			names[i] = p.Name
-		}
-		current := d.cfg.Theme
-		if current == "" {
-			current = DefaultPaletteName
-		}
-		idx := indexOf(names, current)
-		idx = (idx + dir + len(names)) % len(names)
-		d.cfg.Theme = names[idx]
-		ApplyPalette(PaletteByName(d.cfg.Theme))
-		analytics.Track(analytics.EventThemeChanged, map[string]interface{}{"theme": d.cfg.Theme})
-
-	case 1: // Status style (icon / bar)
-		if d.cfg.GetStatusIndicator() == "icon" {
-			d.cfg.StatusIndicator = "bar"
-		} else {
-			d.cfg.StatusIndicator = "icon"
-		}
-		StatusIndicatorMode = d.cfg.GetStatusIndicator()
-
-	case 2: // Editor
-		current := d.cfg.GetEditor()
-		idx := indexOf(editorPresets, current)
-		if idx < 0 {
-			idx = 0
-		}
-		idx = (idx + dir + len(editorPresets)) % len(editorPresets)
-		d.cfg.Editor = editorPresets[idx]
-
-	case 3: // Tick interval
-		current := d.cfg.TickIntervalSec
-		if current <= 0 {
-			current = 2
-		}
-		idx := indexOfInt(tickPresets, current)
-		if idx < 0 {
-			idx = 1 // default to 2s
-		}
-		idx = (idx + dir + len(tickPresets)) % len(tickPresets)
-		d.cfg.TickIntervalSec = tickPresets[idx]
-
-	case 4: // Auto-name
-		enabled := d.cfg.IsAutoNameEnabled()
-		enabled = !enabled
-		d.cfg.AutoNameSessions = &enabled
-
-	case 5: // Auto-update
-		enabled := d.cfg.IsAutoUpdateEnabled()
-		enabled = !enabled
-		d.cfg.AutoUpdate = &enabled
-
-	case 6: // Copy Claude settings
-		enabled := d.cfg.IsCopyClaudeSettingsEnabled()
-		enabled = !enabled
-		d.cfg.CopyClaudeSettings = &enabled
-
-	case 7: // Enter mode
-		if d.cfg.GetEnterMode() == "attach" {
-			d.cfg.EnterMode = "split"
-		} else {
-			d.cfg.EnterMode = "attach"
-		}
-
-	case 8: // Telemetry
-		enabled := d.cfg.IsTelemetryEnabled()
-		enabled = !enabled
-		d.cfg.Telemetry = &enabled
-
-	case 9: // Default agent
-		if d.cfg.GetDefaultAgent() == "codex" {
-			d.cfg.DefaultAgent = "claude"
-		} else {
-			d.cfg.DefaultAgent = "codex"
-		}
+// cycleCurrent applies the focused detail row's cycle function.
+func (d *SettingsDialog) cycleCurrent(dir int) {
+	rows := d.curRows()
+	if d.rowCursor < 0 || d.rowCursor >= len(rows) {
+		return
 	}
+	r := rows[d.rowCursor]
+	if r.subheader || r.cycle == nil {
+		return
+	}
+	r.cycle(d, dir)
 }
 
 // View renders the settings dialog.
 func (d *SettingsDialog) View() string {
+	railW := 14
+	detailW := 36
+
+	rail := d.renderRail()
+	detail := d.renderDetail()
+	// Constant block height across all categories so the modal doesn't grow or
+	// shrink vertically when switching between Appearance and Behavior.
+	blockH := d.maxBlockHeight()
+
+	cat := d.categories[d.categoryCursor]
+
+	// The preview column's presence depends only on the terminal width, not on
+	// the selected category, so the modal keeps a constant size. Categories
+	// that don't use the preview leave that region blank rather than collapsing.
+	previewW := 0
+	// box chrome (~8) + rail + two rules (3 each) + detail.
+	avail := d.width - 8 - railW - 3 - detailW - 3
+	if avail >= 24 {
+		previewW = min(avail, 44)
+	}
+
+	railCol := padBlock(rail, railW, blockH)
+	detailCol := padBlock(detail, detailW, blockH)
+	rule := verticalRule(blockH)
+
+	// Fixed content width: always reserve room for the preview column when it
+	// fits the terminal, even on Behavior (whose right region is just blank).
+	contentW := railW + 3 + detailW
+	if previewW > 0 {
+		contentW += 3 + previewW
+	}
+
+	var body string
+	if previewW > 0 && cat.showPreview {
+		previewCol := padBlock(d.renderPreviewColumn(previewW, blockH), previewW, blockH)
+		body = lipgloss.JoinHorizontal(lipgloss.Top, railCol, rule, detailCol, rule, previewCol)
+	} else {
+		body = lipgloss.JoinHorizontal(lipgloss.Top, railCol, rule, detailCol)
+	}
+	// Pad to the fixed content size so the bordered box never changes width.
+	body = padBlock(body, contentW, blockH)
+
+	// Controls footer.
+	hint := "tab panes   ↑↓ move   ←→ change   esc save"
+	controls := lipgloss.NewStyle().Foreground(ColorTextDim).Render(hint)
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
+	title := titleStyle.Render("Settings")
+
+	content := title + "\n\n" + body + "\n\n" + controls
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorAccent).
+		Padding(1, 2)
+	box := boxStyle.Render(content)
+
+	return lipgloss.Place(d.width, d.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+// renderRail renders the category list (left pane).
+func (d *SettingsDialog) renderRail() string {
 	var b strings.Builder
-
-	type row struct {
-		label string
-		value string
+	for i, c := range d.categories {
+		selected := i == d.categoryCursor
+		label := c.name
+		var style lipgloss.Style
+		switch {
+		case selected && d.focus == focusCategories:
+			style = lipgloss.NewStyle().Bold(true).Foreground(ColorBg).Background(ColorAccent)
+			label = " " + label
+		case selected:
+			style = lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
+			label = " " + label
+		default:
+			style = lipgloss.NewStyle().Foreground(ColorTextDim)
+			label = " " + label
+		}
+		b.WriteString(style.Render(label))
+		if i < len(d.categories)-1 {
+			b.WriteString("\n")
+		}
 	}
+	return b.String()
+}
 
-	theme := d.cfg.Theme
-	if theme == "" {
-		theme = DefaultPaletteName
-	}
-
-	autoNameValue := "on"
-	if !d.cfg.IsAutoNameEnabled() {
-		autoNameValue = "off"
-	}
-
-	autoUpdateValue := "on"
-	if !d.cfg.IsAutoUpdateEnabled() {
-		autoUpdateValue = "off"
-	}
-
-	copyClaudeValue := "on"
-	if !d.cfg.IsCopyClaudeSettingsEnabled() {
-		copyClaudeValue = "off"
-	}
-
-	telemetryValue := "on"
-	if !d.cfg.IsTelemetryEnabled() {
-		telemetryValue = "off"
-	}
-
-	agentValue := "Claude"
-	if d.cfg.GetDefaultAgent() == "codex" {
-		agentValue = "Codex"
-	}
-
-	rows := []row{
-		{"Theme", PaletteDisplayName(theme)},
-		{"Status style", d.cfg.GetStatusIndicator()},
-		{"Editor", d.cfg.GetEditor()},
-		{"Tick (sec)", fmt.Sprintf("%d", d.cfg.TickIntervalSec)},
-		{"Auto-name", autoNameValue},
-		{"Auto-update", autoUpdateValue},
-		{"Copy .claude", copyClaudeValue},
-		{"Enter mode", d.cfg.GetEnterMode()},
-		{"Telemetry", telemetryValue},
-		{"Default agent", agentValue},
-	}
-
+// renderDetail renders the selected category's settings rows (right pane).
+func (d *SettingsDialog) renderDetail() string {
+	var b strings.Builder
+	rows := d.curRows()
 	for i, r := range rows {
-		selected := i == d.cursor
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		if r.subheader {
+			b.WriteString(lipgloss.NewStyle().Foreground(ColorTextDim).Bold(true).Render(r.label))
+			continue
+		}
 
-		labelStyle := lipgloss.NewStyle().Width(14).Align(lipgloss.Right)
-		var arrowStyle lipgloss.Style
-		var valueStyle lipgloss.Style
-
+		selected := d.focus == focusDetail && i == d.rowCursor
+		labelStyle := lipgloss.NewStyle().Width(13).Align(lipgloss.Left)
+		var arrowStyle, valueStyle lipgloss.Style
 		if selected {
 			labelStyle = labelStyle.Foreground(ColorAccent).Bold(true)
 			arrowStyle = lipgloss.NewStyle().Foreground(ColorAccent)
@@ -223,50 +302,240 @@ func (d *SettingsDialog) View() string {
 			arrowStyle = lipgloss.NewStyle().Foreground(ColorTextDim)
 			valueStyle = lipgloss.NewStyle().Foreground(ColorTextDim)
 		}
-
-		line := labelStyle.Render(r.label) + "   " +
+		val := ""
+		if r.value != nil {
+			val = r.value(d.cfg)
+		}
+		line := labelStyle.Render(r.label) + "  " +
 			arrowStyle.Render("◂") + " " +
-			valueStyle.Render(r.value) + " " +
+			valueStyle.Render(val) + " " +
 			arrowStyle.Render("▸")
 		b.WriteString(line)
+	}
+	return b.String()
+}
 
-		if i < len(rows)-1 {
-			b.WriteString("\n")
+// renderPreviewColumn renders the live mock sidebar plus a caption + legend.
+func (d *SettingsDialog) renderPreviewColumn(w, h int) string {
+	caption := lipgloss.NewStyle().Foreground(ColorTextDim).Bold(true).Render("Preview")
+	legend := lipgloss.NewStyle().Foreground(ColorTextDim).Render("● run ◐ wait ✕ err · ✻◇ agent")
+	// caption (1) + blank (1) + sidebar + legend (1).
+	sidebarH := h - 3
+	if sidebarH < 4 {
+		sidebarH = 4
+	}
+	sidebar := RenderSidebarPreview(w, sidebarH)
+	return caption + "\n\n" + sidebar + "\n" + legend
+}
+
+// --- column layout helpers ---
+
+// padBlock pads/truncates a multiline block to exactly w columns × h rows.
+func padBlock(s string, w, h int) string {
+	lines := strings.Split(s, "\n")
+	out := make([]string, h)
+	for i := 0; i < h; i++ {
+		line := ""
+		if i < len(lines) {
+			line = lines[i]
+		}
+		lw := lipgloss.Width(line)
+		if lw < w {
+			line += strings.Repeat(" ", w-lw)
+		}
+		out[i] = line
+	}
+	return strings.Join(out, "\n")
+}
+
+// verticalRule returns a dim vertical separator h rows tall.
+func verticalRule(h int) string {
+	bar := lipgloss.NewStyle().Foreground(ColorBorder).Render("│")
+	lines := make([]string, h)
+	for i := range lines {
+		lines[i] = " " + bar + " "
+	}
+	return strings.Join(lines, "\n")
+}
+
+// --- category / row definitions ---
+
+func buildSettingsCategories() []settingsCategory {
+	onOff := func(b bool) string {
+		if b {
+			return "On"
+		}
+		return "Off"
+	}
+	toggle := func(get func(*config.Config) bool, set func(*config.Config, bool), live bool) settingRow {
+		return settingRow{
+			value: func(c *config.Config) string { return onOff(get(c)) },
+			cycle: func(d *SettingsDialog, _ int) {
+				set(d.cfg, !get(d.cfg))
+				if live {
+					ApplyDisplayConfig(d.cfg)
+				}
+			},
 		}
 	}
 
-	// Divider.
-	dividerWidth := 34
-	b.WriteString("\n")
-	b.WriteString(lipgloss.NewStyle().Foreground(ColorBorder).Render(strings.Repeat("─", dividerWidth)))
-	b.WriteString("\n")
-
-	// Controls.
-	controls := lipgloss.NewStyle().Foreground(ColorTextDim).Render("↑↓ select   ←→ change   esc save")
-	b.WriteString(controls)
-
-	// Dialog box.
-	dialogWidth := 50
-	if dialogWidth > d.width-4 {
-		dialogWidth = d.width - 4
+	appearance := settingsCategory{
+		name:        "Appearance",
+		showPreview: true,
+		rows: []settingRow{
+			{label: "THEME", subheader: true},
+			{
+				label: "Theme",
+				value: func(c *config.Config) string {
+					name := c.Theme
+					if name == "" {
+						name = DefaultPaletteName
+					}
+					return PaletteDisplayName(name)
+				},
+				cycle: cycleTheme,
+			},
+			{
+				label: "Status style",
+				value: func(c *config.Config) string { return c.GetStatusIndicator() },
+				cycle: func(d *SettingsDialog, dir int) {
+					d.cfg.StatusIndicator = cycleString(d.cfg.GetStatusIndicator(), statusStyleSet, dir)
+					ApplyDisplayConfig(d.cfg)
+				},
+			},
+			{label: "ICONS", subheader: true},
+			withLabel("Agent icons", toggle(
+				(*config.Config).IsShowAgentGlyphs,
+				func(c *config.Config, v bool) { c.ShowAgentGlyphs = &v }, true)),
+			withLabel("Slot badges", toggle(
+				(*config.Config).IsShowSlotBadges,
+				func(c *config.Config, v bool) { c.ShowSlotBadges = &v }, true)),
+			{label: "GIT", subheader: true},
+			withLabel("PR badges", toggle(
+				(*config.Config).IsShowPRBadges,
+				func(c *config.Config, v bool) { c.ShowPRBadges = &v }, true)),
+			withLabel("Dirty marker", toggle(
+				(*config.Config).IsShowDirtyIndicator,
+				func(c *config.Config, v bool) { c.ShowDirtyIndicator = &v }, true)),
+			withLabel("Status pills", toggle(
+				(*config.Config).IsShowStatusPills,
+				func(c *config.Config, v bool) { c.ShowStatusPills = &v }, true)),
+			withLabel("Header counts", toggle(
+				(*config.Config).IsShowHeaderCounts,
+				func(c *config.Config, v bool) { c.ShowHeaderCounts = &v }, true)),
+			{label: "LAYOUT", subheader: true},
+			{
+				label: "Chevron",
+				value: func(c *config.Config) string { return c.GetChevronStyle() },
+				cycle: func(d *SettingsDialog, dir int) {
+					d.cfg.ChevronStyle = cycleString(d.cfg.GetChevronStyle(), chevronStyleSet, dir)
+					ApplyDisplayConfig(d.cfg)
+				},
+			},
+			{
+				label: "Density",
+				value: func(c *config.Config) string { return c.GetSidebarDensity() },
+				cycle: func(d *SettingsDialog, dir int) {
+					d.cfg.SidebarDensity = cycleString(d.cfg.GetSidebarDensity(), densitySet, dir)
+					ApplyDisplayConfig(d.cfg)
+				},
+			},
+		},
 	}
-	if dialogWidth < 30 {
-		dialogWidth = 30
+
+	behavior := settingsCategory{
+		name: "Behavior",
+		rows: []settingRow{
+			{
+				label: "Editor",
+				value: func(c *config.Config) string { return c.GetEditor() },
+				cycle: func(d *SettingsDialog, dir int) {
+					d.cfg.Editor = cycleString(d.cfg.GetEditor(), editorPresets, dir)
+				},
+			},
+			{
+				label: "Tick (sec)",
+				value: func(c *config.Config) string { return fmt.Sprintf("%d", c.TickIntervalSec) },
+				cycle: func(d *SettingsDialog, dir int) {
+					cur := d.cfg.TickIntervalSec
+					if cur <= 0 {
+						cur = 2
+					}
+					idx := indexOfInt(tickPresets, cur)
+					if idx < 0 {
+						idx = 1
+					}
+					d.cfg.TickIntervalSec = tickPresets[(idx+dir+len(tickPresets))%len(tickPresets)]
+				},
+			},
+			withLabel("Auto-name", toggle(
+				(*config.Config).IsAutoNameEnabled,
+				func(c *config.Config, v bool) { c.AutoNameSessions = &v }, false)),
+			withLabel("Auto-update", toggle(
+				(*config.Config).IsAutoUpdateEnabled,
+				func(c *config.Config, v bool) { c.AutoUpdate = &v }, false)),
+			withLabel("Copy .claude", toggle(
+				(*config.Config).IsCopyClaudeSettingsEnabled,
+				func(c *config.Config, v bool) { c.CopyClaudeSettings = &v }, false)),
+			{
+				label: "Enter mode",
+				value: func(c *config.Config) string { return c.GetEnterMode() },
+				cycle: func(d *SettingsDialog, dir int) {
+					d.cfg.EnterMode = cycleString(d.cfg.GetEnterMode(), enterModeSet, dir)
+				},
+			},
+			withLabel("Telemetry", toggle(
+				(*config.Config).IsTelemetryEnabled,
+				func(c *config.Config, v bool) { c.Telemetry = &v }, false)),
+			{
+				label: "Default agent",
+				value: func(c *config.Config) string {
+					if c.GetDefaultAgent() == "codex" {
+						return "Codex"
+					}
+					return "Claude"
+				},
+				cycle: func(d *SettingsDialog, dir int) {
+					d.cfg.DefaultAgent = cycleString(d.cfg.GetDefaultAgent(), defaultAgentSet, dir)
+				},
+			},
+		},
 	}
 
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
-	title := titleStyle.Render("Settings")
+	return []settingsCategory{appearance, behavior}
+}
 
-	boxStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ColorAccent).
-		Padding(1, 2).
-		Width(dialogWidth)
+// withLabel attaches a label to a row built by the generic toggle helper.
+func withLabel(label string, r settingRow) settingRow {
+	r.label = label
+	return r
+}
 
-	content := title + "\n\n" + b.String()
-	box := boxStyle.Render(content)
+func cycleTheme(d *SettingsDialog, dir int) {
+	names := make([]string, len(BuiltinPalettes))
+	for i, p := range BuiltinPalettes {
+		names[i] = p.Name
+	}
+	current := d.cfg.Theme
+	if current == "" {
+		current = DefaultPaletteName
+	}
+	idx := indexOf(names, current)
+	if idx < 0 {
+		idx = 0
+	}
+	d.cfg.Theme = names[(idx+dir+len(names))%len(names)]
+	ApplyPalette(PaletteByName(d.cfg.Theme))
+	analytics.Track(analytics.EventThemeChanged, map[string]interface{}{"theme": d.cfg.Theme})
+}
 
-	return lipgloss.Place(d.width, d.height, lipgloss.Center, lipgloss.Center, box)
+// cycleString returns the preset reached by stepping dir from cur (wrapping).
+func cycleString(cur string, presets []string, dir int) string {
+	idx := indexOf(presets, cur)
+	if idx < 0 {
+		idx = 0
+	}
+	return presets[(idx+dir+len(presets))%len(presets)]
 }
 
 func indexOf(slice []string, val string) int {

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -191,8 +191,23 @@ func (d *SettingsDialog) cycleCurrent(dir int) {
 
 // View renders the settings dialog.
 func (d *SettingsDialog) View() string {
-	railW := 14
+	const (
+		railW  = 14
+		ruleW  = 3 // " │ " vertical separator between columns
+		chrome = 6 // rounded border (2) + horizontal padding (2×2)
+	)
+
+	// The detail column flexes with the terminal so the modal fits narrow panes
+	// (the old dialog clamped its width the same way); the floor keeps values
+	// readable. detailW + railW + ruleW never exceeds the content area, so the
+	// bordered box stays within d.width.
 	detailW := 36
+	if fit := d.width - chrome - railW - ruleW; fit < detailW {
+		detailW = fit
+	}
+	if detailW < 20 {
+		detailW = 20
+	}
 
 	rail := d.renderRail()
 	detail := d.renderDetail()
@@ -202,13 +217,11 @@ func (d *SettingsDialog) View() string {
 
 	cat := d.categories[d.categoryCursor]
 
-	// The preview column's presence depends only on the terminal width, not on
-	// the selected category, so the modal keeps a constant size. Categories
-	// that don't use the preview leave that region blank rather than collapsing.
+	// The preview column appears only when there's room left beyond the rail,
+	// both rules, and the detail column — so the modal keeps a constant size and
+	// narrow terminals simply omit it (rather than overflowing).
 	previewW := 0
-	// box chrome (~8) + rail + two rules (3 each) + detail.
-	avail := d.width - 8 - railW - 3 - detailW - 3
-	if avail >= 24 {
+	if avail := d.width - chrome - railW - ruleW - detailW - ruleW; avail >= 24 {
 		previewW = min(avail, 44)
 	}
 
@@ -218,9 +231,9 @@ func (d *SettingsDialog) View() string {
 
 	// Fixed content width: always reserve room for the preview column when it
 	// fits the terminal, even on Behavior (whose right region is just blank).
-	contentW := railW + 3 + detailW
+	contentW := railW + ruleW + detailW
 	if previewW > 0 {
-		contentW += 3 + previewW
+		contentW += ruleW + previewW
 	}
 
 	var body string
@@ -247,6 +260,9 @@ func (d *SettingsDialog) View() string {
 		BorderForeground(ColorAccent).
 		Padding(1, 2)
 	box := boxStyle.Render(content)
+	// Safety net for extreme sizes: never exceed the terminal, so a too-small
+	// window truncates the modal rather than wrap-corrupting the surrounding UI.
+	box = lipgloss.NewStyle().MaxWidth(d.width).MaxHeight(d.height).Render(box)
 
 	return lipgloss.Place(d.width, d.height, lipgloss.Center, lipgloss.Center, box)
 }
@@ -330,22 +346,10 @@ func (d *SettingsDialog) renderPreviewColumn(w, h int) string {
 
 // --- column layout helpers ---
 
-// padBlock pads/truncates a multiline block to exactly w columns × h rows.
+// padBlock pads/truncates a multiline block to exactly w columns × h rows,
+// reusing the shared panel-sizing helpers (ensureExactHeight/ensureExactWidth).
 func padBlock(s string, w, h int) string {
-	lines := strings.Split(s, "\n")
-	out := make([]string, h)
-	for i := 0; i < h; i++ {
-		line := ""
-		if i < len(lines) {
-			line = lines[i]
-		}
-		lw := lipgloss.Width(line)
-		if lw < w {
-			line += strings.Repeat(" ", w-lw)
-		}
-		out[i] = line
-	}
-	return strings.Join(out, "\n")
+	return ensureExactWidth(ensureExactHeight(s, h), w)
 }
 
 // verticalRule returns a dim vertical separator h rows tall.

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -213,8 +213,9 @@ func BuildFlatItems(
 
 		// Visual breathing space between origin groups — one blank row
 		// before every origin except the first. Marked IsSpacer so cursor
-		// nav skips it and it renders as a blank line.
-		if len(items) > 0 {
+		// nav skips it and it renders as a blank line. Suppressed in compact
+		// density, where groups sit flush.
+		if len(items) > 0 && SidebarDensity != "compact" {
 			items = append(items, SidebarItem{IsSpacer: true})
 		}
 
@@ -471,18 +472,23 @@ func renderStatusSummaryOpts(counts map[session.Status]int, alwaysShowCount bool
 // The blank row inserted before each non-first origin (see BuildFlatItems)
 // carries the section break on its own; no trailing rule needed.
 func renderOriginHeader(item SidebarItem, width int, selected bool) string {
-	chevron := "▸"
-	if item.Expanded {
-		chevron = "▾"
+	chevron := chevronGlyph(item.Expanded)
+	countStr := ""
+	if ShowHeaderCounts {
+		countStr = fmt.Sprintf("%d", item.SessionCount)
 	}
-	countStr := fmt.Sprintf("%d", item.SessionCount)
-	summary := renderStatusSummary(item.StatusCounts)
+	summary := ""
+	if ShowStatusPills {
+		summary = renderStatusSummary(item.StatusCounts)
+	}
 
 	if selected {
 		icon := SessionSelectionPrefix.Render(chevron)
 		name := SessionTitleSelStyle.Render(" " + item.OriginLabel + " ")
-		count := SessionStatusSelStyle.Render(countStr)
-		out := fmt.Sprintf("%s %s %s", icon, name, count)
+		out := fmt.Sprintf("%s %s", icon, name)
+		if countStr != "" {
+			out += " " + SessionStatusSelStyle.Render(countStr)
+		}
 		if summary != "" {
 			out += "  " + summary
 		}
@@ -490,8 +496,10 @@ func renderOriginHeader(item SidebarItem, width int, selected bool) string {
 	}
 	icon := DimStyle.Render(chevron)
 	name := RepoHeaderStyle.Render(item.OriginLabel)
-	count := DimStyle.Render(countStr)
-	out := fmt.Sprintf("%s %s %s", icon, name, count)
+	out := fmt.Sprintf("%s %s", icon, name)
+	if countStr != "" {
+		out += " " + DimStyle.Render(countStr)
+	}
 	if summary != "" {
 		out += "  " + summary
 	}
@@ -518,14 +526,11 @@ func renderCheckoutHeader(item SidebarItem, repoInfo *git.RepoInfo, width int, s
 	label := branch
 
 	dirty := ""
-	if repoInfo.IsDirty {
+	if ShowDirtyIndicator && repoInfo.IsDirty {
 		dirty = " *"
 	}
 
-	chevron := "▸"
-	if item.Expanded {
-		chevron = "▾"
-	}
+	chevron := chevronGlyph(item.Expanded)
 
 	// Worktree distinction: italicize the branch label instead of a `wt·`
 	// prefix. Zero extra width; eye picks out worktrees from main clones at
@@ -536,11 +541,14 @@ func renderCheckoutHeader(item SidebarItem, repoInfo *git.RepoInfo, width int, s
 	}
 
 	prBadge := ""
-	if repoInfo.PR != nil {
+	if ShowPRBadges && repoInfo.PR != nil {
 		prBadge = " " + renderPRBadge(repoInfo.PR, selected)
 	}
 
-	summary := renderStatusSummary(item.StatusCounts)
+	summary := ""
+	if ShowStatusPills {
+		summary = renderStatusSummary(item.StatusCounts)
+	}
 	summarySuffix := ""
 	if summary != "" {
 		summarySuffix = "  " + summary
@@ -551,8 +559,10 @@ func renderCheckoutHeader(item SidebarItem, repoInfo *git.RepoInfo, width int, s
 		// Selection bg is one contiguous span over title + dirty + PR badge,
 		// so the highlighted row reads as a single pill instead of two boxes.
 		inner := " " + label + dirty
-		if prText := prBadgeText(repoInfo.PR); prText != "" {
-			inner += " " + prText
+		if ShowPRBadges {
+			if prText := prBadgeText(repoInfo.PR); prText != "" {
+				inner += " " + prText
+			}
 		}
 		inner += " "
 		return fmt.Sprintf("  %s %s", icon, SessionTitleSelStyle.Italic(repoInfo.IsWorktreeRepo).Render(inner)) + summarySuffix
@@ -570,10 +580,7 @@ func renderCheckoutHeader(item SidebarItem, repoInfo *git.RepoInfo, width int, s
 // a git repo — just the folder name in dim, no branch glyph or PR badge.
 func renderCheckoutHeaderNonGit(item SidebarItem, selected bool) string {
 	name := filepath.Base(item.RepoPath)
-	chevron := "▸"
-	if item.Expanded {
-		chevron = "▾"
-	}
+	chevron := chevronGlyph(item.Expanded)
 	if selected {
 		icon := SessionSelectionPrefix.Render(chevron)
 		nameStyled := SessionTitleSelStyle.Render(" " + name + " ")
@@ -588,17 +595,26 @@ func renderCheckoutHeaderNonGit(item SidebarItem, selected bool) string {
 func renderSessionItem(s *session.Session, width int, selected bool, slot int) string {
 	status := s.GetStatus()
 	symbolRaw := StatusSymbolRaw(status)
-	glyphRaw := agentGlyph(s.Agent)
 	title := s.Title
 
+	// Agent glyph (✻/◇) is optional — when shown it occupies a glyph + a space.
+	glyphRaw := ""
+	if ShowAgentGlyphs {
+		glyphRaw = agentGlyph(s.Agent)
+	}
+
 	slotRaw := ""
-	if slot >= 0 && slot <= 9 {
+	if ShowSlotBadges && slot >= 0 && slot <= 9 {
 		slotRaw = fmt.Sprintf(" [%d]", slot)
 	}
 
-	// Reserve: 2 leading spaces + "│ " guide + 1 selection prefix + symbol +
-	// space + agent glyph + space + slot.
-	maxTitleLen := width - 13 - len(slotRaw)
+	// Reserve: leading indent + status symbol + selection padding + slot, plus
+	// the agent glyph and its trailing space when it's shown (2 cells).
+	reserve := 13
+	if glyphRaw == "" {
+		reserve = 11
+	}
+	maxTitleLen := width - reserve - len(slotRaw)
 	if maxTitleLen < 10 {
 		maxTitleLen = 10
 	}
@@ -607,23 +623,32 @@ func renderSessionItem(s *session.Session, width int, selected bool, slot int) s
 	// actually truncates.
 	title = ansi.Truncate(title, maxTitleLen, "…")
 
+	// glyphSel is "<glyph> " (with trailing space) when shown, else "".
+	glyphSel := ""
+	if glyphRaw != "" {
+		glyphSel = glyphRaw + " "
+	}
+
 	// Selection: the inverted-background title carries the "you are here"
 	// signal on its own — no leading ▶ arrow (it collided with the chevron
 	// glyph used for collapsed headers). Bg fill spans symbol + agent glyph +
 	// title + slot in one continuous render so the row reads as a single pill.
 	if selected {
-		row := " " + symbolRaw + " " + glyphRaw + " " + title + slotRaw + " "
+		row := " " + symbolRaw + " " + glyphSel + title + slotRaw + " "
 		return fmt.Sprintf("   %s", SessionTitleSelStyle.Render(row))
 	}
 
 	styledSymbol := StatusSymbol(status)
-	styledGlyph := AgentGlyphStyle.Render(glyphRaw)
 	styledTitle := TitleStyleForStatus(status).Render(title)
 	styledSlot := ""
 	if slotRaw != "" {
 		styledSlot = SlotBadgeDimStyle.Render(slotRaw)
 	}
-	return fmt.Sprintf("    %s %s %s%s", styledSymbol, styledGlyph, styledTitle, styledSlot)
+	if glyphRaw != "" {
+		styledGlyph := AgentGlyphStyle.Render(glyphRaw)
+		return fmt.Sprintf("    %s %s %s%s", styledSymbol, styledGlyph, styledTitle, styledSlot)
+	}
+	return fmt.Sprintf("    %s %s%s", styledSymbol, styledTitle, styledSlot)
 }
 
 // Agent glyphs mark which coding agent a session runs — a quiet, dim,

--- a/internal/ui/sidebar_preview.go
+++ b/internal/ui/sidebar_preview.go
@@ -1,0 +1,143 @@
+package ui
+
+import (
+	"github.com/brizzai/fleet/internal/agent"
+	"github.com/brizzai/fleet/internal/git"
+	"github.com/brizzai/fleet/internal/github"
+	"github.com/brizzai/fleet/internal/session"
+)
+
+// This file powers the live sidebar preview shown in the Appearance settings
+// category and the first-run onboarding. It renders the *real* RenderSidebar
+// over a small fixed set of synthetic data, so the preview reflects every
+// display toggle and theme change automatically and can never drift from the
+// actual sidebar. The mock paths are identity keys only — nothing touches disk.
+
+const (
+	mockRepoMain    = "/preview/fleet"
+	mockRepoFeat    = "/preview/fleet-feat"
+	mockRepoScratch = "/preview/scratch"
+
+	// Session IDs are referenced by the slot-binding map so the finished
+	// session renders its "[1]" badge.
+	mockSessFinished = "preview-finished"
+)
+
+// mockPreviewSession builds a synthetic session. Only the exported fields the
+// renderer reads are set; the zero-value mutex is safe for GetStatus().
+func mockPreviewSession(id, title string, a agent.Type, st session.Status, path string) *session.Session {
+	return &session.Session{
+		ID:          id,
+		Title:       title,
+		Agent:       a,
+		Status:      st,
+		ProjectPath: path,
+	}
+}
+
+// previewSessions returns the synthetic sessions backing the preview rows.
+func previewSessions() []*session.Session {
+	return []*session.Session{
+		mockPreviewSession("preview-running", "Refactor sidebar", agent.Claude, session.StatusRunning, mockRepoMain),
+		mockPreviewSession("preview-waiting", "Add test coverage", agent.Codex, session.StatusWaiting, mockRepoMain),
+		mockPreviewSession(mockSessFinished, "Fix flaky preview", agent.Claude, session.StatusFinished, mockRepoFeat),
+		mockPreviewSession("preview-idle", "Scratch notes", agent.Claude, session.StatusIdle, mockRepoScratch),
+	}
+}
+
+// previewGitInfo returns synthetic per-checkout git info: an approved PR on the
+// main checkout, a dirty worktree, and a plain scratch repo.
+func previewGitInfo() map[string]*git.RepoInfo {
+	return map[string]*git.RepoInfo{
+		mockRepoMain: {
+			Branch: "main",
+			PR:     &github.PR{Number: 128, State: "OPEN", ReviewDecision: "APPROVED", CIStatus: "SUCCESS"},
+		},
+		mockRepoFeat: {
+			Branch:         "feat/preview",
+			IsDirty:        true,
+			IsWorktreeRepo: true,
+		},
+		mockRepoScratch: {
+			Branch: "main",
+		},
+	}
+}
+
+// previewSlots binds the finished session to slot 1 so the "[1]" badge renders.
+func previewSlots() map[int]string {
+	return map[int]string{1: mockSessFinished}
+}
+
+// counts is a tiny helper for building a header's per-status breakdown.
+func counts(pairs ...any) map[session.Status]int {
+	m := make(map[session.Status]int)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		m[pairs[i].(session.Status)] = pairs[i+1].(int)
+	}
+	return m
+}
+
+// previewItems builds the flattened sidebar rows by hand (rather than via
+// BuildFlatItems, which would touch the filesystem resolving repo roots). The
+// density toggle is honored here the same way BuildFlatItems honors it: the
+// inter-origin spacer is dropped in compact mode.
+func previewItems() []SidebarItem {
+	sess := previewSessions()
+	items := []SidebarItem{
+		// Origin: fleet (2 checkouts; running + waiting + finished across them).
+		{
+			IsRepoHeader: true, IsOriginHeader: true,
+			OriginKey: "brizzai/fleet", OriginLabel: "fleet", Expanded: true,
+			SessionCount: 2,
+			StatusCounts: counts(session.StatusRunning, 1, session.StatusWaiting, 1, session.StatusFinished, 1),
+		},
+		// Checkout: main (PR #128 approved).
+		{
+			IsRepoHeader: true, IsCheckoutHeader: true,
+			OriginKey: "brizzai/fleet", RepoPath: mockRepoMain, Expanded: true,
+			SessionCount: 2,
+			StatusCounts: counts(session.StatusRunning, 1, session.StatusWaiting, 1),
+		},
+		{OriginKey: "brizzai/fleet", RepoPath: mockRepoMain, Session: sess[0]}, // running · Claude
+		{OriginKey: "brizzai/fleet", RepoPath: mockRepoMain, Session: sess[1]}, // waiting · Codex
+		// Checkout: feat/preview worktree (dirty).
+		{
+			IsRepoHeader: true, IsCheckoutHeader: true,
+			OriginKey: "brizzai/fleet", RepoPath: mockRepoFeat, Expanded: true,
+			SessionCount: 1,
+			StatusCounts: counts(session.StatusFinished, 1),
+		},
+		{OriginKey: "brizzai/fleet", RepoPath: mockRepoFeat, Session: sess[2]}, // finished · Claude · slot [1]
+	}
+
+	if SidebarDensity != "compact" {
+		items = append(items, SidebarItem{IsSpacer: true})
+	}
+
+	items = append(items,
+		// Origin: scratch (one idle session — idle is omitted from pills).
+		SidebarItem{
+			IsRepoHeader: true, IsOriginHeader: true,
+			OriginKey: "local:scratch", OriginLabel: "scratch", Expanded: true,
+			SessionCount: 1,
+			StatusCounts: counts(session.StatusIdle, 1),
+		},
+		SidebarItem{
+			IsRepoHeader: true, IsCheckoutHeader: true,
+			OriginKey: "local:scratch", RepoPath: mockRepoScratch, Expanded: true,
+			SessionCount: 1,
+			StatusCounts: counts(session.StatusIdle, 1),
+		},
+		SidebarItem{OriginKey: "local:scratch", RepoPath: mockRepoScratch, Session: sess[3]}, // idle · Claude
+	)
+	return items
+}
+
+// RenderSidebarPreview renders the synthetic sidebar at the given size using the
+// real render path, so it honors the active palette and every display flag.
+// cursor is -1 (nothing selected) to keep the sample neutral for reading.
+func RenderSidebarPreview(width, height int) string {
+	items := previewItems()
+	return RenderSidebar(items, previewSessions(), previewGitInfo(), previewSlots(), -1, 0, width, height)
+}

--- a/internal/ui/sidebar_preview.go
+++ b/internal/ui/sidebar_preview.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"sync"
+
 	"github.com/brizzai/fleet/internal/agent"
 	"github.com/brizzai/fleet/internal/git"
 	"github.com/brizzai/fleet/internal/github"
@@ -8,136 +10,77 @@ import (
 )
 
 // This file powers the live sidebar preview shown in the Appearance settings
-// category and the first-run onboarding. It renders the *real* RenderSidebar
-// over a small fixed set of synthetic data, so the preview reflects every
-// display toggle and theme change automatically and can never drift from the
-// actual sidebar. The mock paths are identity keys only — nothing touches disk.
+// category and the first-run onboarding. It feeds a small fixed set of synthetic
+// data through the *real* BuildFlatItems flattening and RenderSidebar render
+// path, so both the row structure (grouping, counts, inter-group spacers) and
+// the rendering (active palette, every display toggle, density) come from
+// production code and can't drift from the actual sidebar. The synthetic paths
+// are pre-seeded into the repo-root cache, so nothing shells out to git or
+// touches disk.
 
 const (
 	mockRepoMain    = "/preview/fleet"
 	mockRepoFeat    = "/preview/fleet-feat"
 	mockRepoScratch = "/preview/scratch"
 
-	// Session IDs are referenced by the slot-binding map so the finished
-	// session renders its "[1]" badge.
+	// Session ID referenced by the slot-binding map so the finished session
+	// renders its "[1]" badge.
 	mockSessFinished = "preview-finished"
 )
 
-// mockPreviewSession builds a synthetic session. Only the exported fields the
-// renderer reads are set; the zero-value mutex is safe for GetStatus().
-func mockPreviewSession(id, title string, a agent.Type, st session.Status, path string) *session.Session {
-	return &session.Session{
-		ID:          id,
-		Title:       title,
-		Agent:       a,
-		Status:      st,
-		ProjectPath: path,
+// Synthetic preview fixture, built once. The data never changes between frames
+// (only the display flags / palette do, and those are read at render time), so
+// there's no reason to reallocate it on every render. The same session slice
+// backs both BuildFlatItems and RenderSidebar, so item.Session pointers match
+// the sessions argument.
+var (
+	previewFixtureOnce sync.Once
+	previewSess        []*session.Session
+	previewGit         map[string]*git.RepoInfo
+	previewSlotMap     map[int]string
+)
+
+func buildPreviewFixture() {
+	mock := func(id, title string, a agent.Type, st session.Status, path string) *session.Session {
+		return &session.Session{ID: id, Title: title, Agent: a, Status: st, ProjectPath: path}
+	}
+	previewSess = []*session.Session{
+		mock("preview-running", "Refactor sidebar", agent.Claude, session.StatusRunning, mockRepoMain),
+		mock("preview-waiting", "Add test coverage", agent.Codex, session.StatusWaiting, mockRepoMain),
+		mock(mockSessFinished, "Fix flaky preview", agent.Claude, session.StatusFinished, mockRepoFeat),
+		mock("preview-idle", "Scratch notes", agent.Claude, session.StatusIdle, mockRepoScratch),
+	}
+	previewGit = map[string]*git.RepoInfo{
+		mockRepoMain:    {Branch: "main", PR: &github.PR{Number: 128, State: "OPEN", ReviewDecision: "APPROVED", CIStatus: "SUCCESS"}},
+		mockRepoFeat:    {Branch: "feat/preview", IsDirty: true, IsWorktreeRepo: true},
+		mockRepoScratch: {Branch: "main"},
+	}
+	previewSlotMap = map[int]string{1: mockSessFinished}
+
+	// Resolve each synthetic checkout to itself so BuildFlatItems' GetRepoRoot
+	// lookups hit the cache instead of shelling out to git.
+	for _, p := range []string{mockRepoMain, mockRepoFeat, mockRepoScratch} {
+		session.SeedRepoRoot(p, p)
 	}
 }
 
-// previewSessions returns the synthetic sessions backing the preview rows.
-func previewSessions() []*session.Session {
-	return []*session.Session{
-		mockPreviewSession("preview-running", "Refactor sidebar", agent.Claude, session.StatusRunning, mockRepoMain),
-		mockPreviewSession("preview-waiting", "Add test coverage", agent.Codex, session.StatusWaiting, mockRepoMain),
-		mockPreviewSession(mockSessFinished, "Fix flaky preview", agent.Claude, session.StatusFinished, mockRepoFeat),
-		mockPreviewSession("preview-idle", "Scratch notes", agent.Claude, session.StatusIdle, mockRepoScratch),
+// previewOriginOf groups the two fleet checkouts under one origin; scratch falls
+// through to a local origin (BuildFlatItems synthesizes "local:scratch").
+func previewOriginOf(repo string) string {
+	if repo == mockRepoMain || repo == mockRepoFeat {
+		return "brizzai/fleet"
 	}
+	return ""
 }
 
-// previewGitInfo returns synthetic per-checkout git info: an approved PR on the
-// main checkout, a dirty worktree, and a plain scratch repo.
-func previewGitInfo() map[string]*git.RepoInfo {
-	return map[string]*git.RepoInfo{
-		mockRepoMain: {
-			Branch: "main",
-			PR:     &github.PR{Number: 128, State: "OPEN", ReviewDecision: "APPROVED", CIStatus: "SUCCESS"},
-		},
-		mockRepoFeat: {
-			Branch:         "feat/preview",
-			IsDirty:        true,
-			IsWorktreeRepo: true,
-		},
-		mockRepoScratch: {
-			Branch: "main",
-		},
-	}
-}
+func previewIsWorktreeOf(repo string) bool { return repo == mockRepoFeat }
 
-// previewSlots binds the finished session to slot 1 so the "[1]" badge renders.
-func previewSlots() map[int]string {
-	return map[int]string{1: mockSessFinished}
-}
-
-// counts is a tiny helper for building a header's per-status breakdown.
-func counts(pairs ...any) map[session.Status]int {
-	m := make(map[session.Status]int)
-	for i := 0; i+1 < len(pairs); i += 2 {
-		m[pairs[i].(session.Status)] = pairs[i+1].(int)
-	}
-	return m
-}
-
-// previewItems builds the flattened sidebar rows by hand (rather than via
-// BuildFlatItems, which would touch the filesystem resolving repo roots). The
-// density toggle is honored here the same way BuildFlatItems honors it: the
-// inter-origin spacer is dropped in compact mode.
-func previewItems() []SidebarItem {
-	sess := previewSessions()
-	items := []SidebarItem{
-		// Origin: fleet (2 checkouts; running + waiting + finished across them).
-		{
-			IsRepoHeader: true, IsOriginHeader: true,
-			OriginKey: "brizzai/fleet", OriginLabel: "fleet", Expanded: true,
-			SessionCount: 2,
-			StatusCounts: counts(session.StatusRunning, 1, session.StatusWaiting, 1, session.StatusFinished, 1),
-		},
-		// Checkout: main (PR #128 approved).
-		{
-			IsRepoHeader: true, IsCheckoutHeader: true,
-			OriginKey: "brizzai/fleet", RepoPath: mockRepoMain, Expanded: true,
-			SessionCount: 2,
-			StatusCounts: counts(session.StatusRunning, 1, session.StatusWaiting, 1),
-		},
-		{OriginKey: "brizzai/fleet", RepoPath: mockRepoMain, Session: sess[0]}, // running · Claude
-		{OriginKey: "brizzai/fleet", RepoPath: mockRepoMain, Session: sess[1]}, // waiting · Codex
-		// Checkout: feat/preview worktree (dirty).
-		{
-			IsRepoHeader: true, IsCheckoutHeader: true,
-			OriginKey: "brizzai/fleet", RepoPath: mockRepoFeat, Expanded: true,
-			SessionCount: 1,
-			StatusCounts: counts(session.StatusFinished, 1),
-		},
-		{OriginKey: "brizzai/fleet", RepoPath: mockRepoFeat, Session: sess[2]}, // finished · Claude · slot [1]
-	}
-
-	if SidebarDensity != "compact" {
-		items = append(items, SidebarItem{IsSpacer: true})
-	}
-
-	items = append(items,
-		// Origin: scratch (one idle session — idle is omitted from pills).
-		SidebarItem{
-			IsRepoHeader: true, IsOriginHeader: true,
-			OriginKey: "local:scratch", OriginLabel: "scratch", Expanded: true,
-			SessionCount: 1,
-			StatusCounts: counts(session.StatusIdle, 1),
-		},
-		SidebarItem{
-			IsRepoHeader: true, IsCheckoutHeader: true,
-			OriginKey: "local:scratch", RepoPath: mockRepoScratch, Expanded: true,
-			SessionCount: 1,
-			StatusCounts: counts(session.StatusIdle, 1),
-		},
-		SidebarItem{OriginKey: "local:scratch", RepoPath: mockRepoScratch, Session: sess[3]}, // idle · Claude
-	)
-	return items
-}
-
-// RenderSidebarPreview renders the synthetic sidebar at the given size using the
-// real render path, so it honors the active palette and every display flag.
-// cursor is -1 (nothing selected) to keep the sample neutral for reading.
+// RenderSidebarPreview renders the synthetic sidebar at the given size through
+// the real BuildFlatItems + RenderSidebar path, so it honors the active palette,
+// every display flag, and the density toggle. cursor is -1 (nothing selected) to
+// keep the sample neutral for reading.
 func RenderSidebarPreview(width, height int) string {
-	items := previewItems()
-	return RenderSidebar(items, previewSessions(), previewGitInfo(), previewSlots(), -1, 0, width, height)
+	previewFixtureOnce.Do(buildPreviewFixture)
+	items := BuildFlatItems(previewSess, nil, nil, "", nil, previewOriginOf, previewIsWorktreeOf, nil)
+	return RenderSidebar(items, previewSess, previewGit, previewSlotMap, -1, 0, width, height)
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strings"
 
+	"github.com/brizzai/fleet/internal/config"
 	"github.com/brizzai/fleet/internal/session"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
@@ -368,6 +369,51 @@ func RenderFocusedPanelTitle(title string, width int) string {
 var StatusIndicatorMode = "icon"
 
 const StatusBarChar = "┃"
+
+// Sidebar display flags. These mirror StatusIndicatorMode: package-level vars
+// read by the sidebar render funcs, synced from config by ApplyDisplayConfig
+// (called in NewHome at startup and after any Appearance settings change). They
+// default to the "everything on" rendering so an unconfigured fleet is unchanged.
+var (
+	ShowAgentGlyphs    = true       // per-session ✻/◇ agent sigil
+	ShowStatusPills    = true       // header "2● 1◐" status summary
+	ShowPRBadges       = true       // "#123 ✓" PR badge on checkout headers
+	ShowDirtyIndicator = true       // "*" dirty-worktree marker
+	ShowSlotBadges     = true       // "[N]" hotkey slot badge
+	ShowHeaderCounts   = true       // session count on origin/checkout headers
+	ChevronStyle       = "triangle" // "triangle" (▾▸) or "plusminus" (−+)
+	SidebarDensity     = "normal"   // "normal" (gap between groups) or "compact"
+)
+
+// ApplyDisplayConfig syncs all sidebar display flags from config. Must be called
+// on the main goroutine (Bubble Tea Update/View), like ApplyPalette.
+func ApplyDisplayConfig(cfg *config.Config) {
+	StatusIndicatorMode = cfg.GetStatusIndicator()
+	ShowAgentGlyphs = cfg.IsShowAgentGlyphs()
+	ShowStatusPills = cfg.IsShowStatusPills()
+	ShowPRBadges = cfg.IsShowPRBadges()
+	ShowDirtyIndicator = cfg.IsShowDirtyIndicator()
+	ShowSlotBadges = cfg.IsShowSlotBadges()
+	ShowHeaderCounts = cfg.IsShowHeaderCounts()
+	ChevronStyle = cfg.GetChevronStyle()
+	SidebarDensity = cfg.GetSidebarDensity()
+}
+
+// chevronGlyph returns the expand/collapse marker for a header, honoring the
+// configured ChevronStyle. Both glyphs in each style are width-1 so columns
+// stay aligned regardless of choice.
+func chevronGlyph(expanded bool) string {
+	if ChevronStyle == "plusminus" {
+		if expanded {
+			return "−" // U+2212 minus sign (width-1, aligns with "+")
+		}
+		return "+"
+	}
+	if expanded {
+		return "▾"
+	}
+	return "▸"
+}
 
 // StatusSymbol returns a styled status indicator.
 func StatusSymbol(status session.Status) string {


### PR DESCRIPTION
## What

Turns Settings (`S`) into a **master-detail panel** with a **live mock-sidebar preview**, and adds a one-time **first-run theme onboarding** that teaches how to read the sidebar.

### Settings dialog
- Category rail (**Appearance** / **Behavior**) on the left, that category's settings on the right.
- The **Appearance** category renders a live preview that reflects every change instantly. It reuses the *real* `RenderSidebar` over synthetic fixtures (`RenderSidebarPreview`), so the preview can never drift from the actual sidebar.
- New display toggles: **agent icons** (`✻`/`◇`), **status style** (icon/bar), **PR badges**, **dirty marker**, **status pills**, **slot badges**, **header counts**, **chevron style** (triangle/plusminus), **density** (normal/compact).
- Each toggle is a default-on config field → a package render flag (same pattern as the existing `StatusIndicatorMode`), synced via `ApplyDisplayConfig` in `NewHome` and after every Appearance change.
- `tab` switches panes · `j/k` move · `←→`/`h/l` cycle · `esc` auto-saves. The modal keeps a constant size across categories (Behavior leaves the preview region blank rather than resizing).

### First-run theme onboarding
- After the consent prompt, brand-new users get a theme picker beside an **annotated sample sidebar** teaching status dots, agent glyphs, branch, worktree, dirty `*`, and PR badge.
- `enter` keeps the previewed theme; `s`/`esc` reverts and skips. Gated by a new `display_onboarding_seen` config flag.
- **Existing/returning installs are silently marked seen** — an upgrade never surprises them with the picker or overwrites their theme. The existing discovery launchpad is unchanged and still follows onboarding.

## Files
- New: `internal/ui/sidebar_preview.go`, `internal/ui/onboarding.go`, `internal/ui/display_settings_test.go`
- Modified: `internal/ui/{settings,sidebar,styles,app}.go`, `internal/config/config.go`
- Docs: `CLAUDE.md`, changelog fragment

## Test plan
- `make build` ✅ · `make test` (with `-race`) ✅ — new smoke tests cover the preview, toggle gates, master-detail nav, and onboarding confirm/skip.
- Manual: `S → Appearance` toggles update the preview live and persist; first-run flow (throwaway `$HOME`) shows consent → theme onboarding → launchpad; existing installs see no onboarding and keep their theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned Settings dialog with categorized master-detail layout and live appearance preview updates
  * Added first-run onboarding flow featuring interactive theme selection with annotated UI guide
  * New display customization options: toggle agent glyphs, status indicators, PR badges, dirty marker, and header counts; adjust sidebar density and chevron style

* **Tests**
  * Added comprehensive test coverage for display settings, sidebar preview rendering, and onboarding interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->