### PR TITLE
fix(status): adopt rotated Claude session ids so finished sessions don't stick on "running"

### DIFF
--- a/changelog/unreleased/fix-rotated-session-stuck-running.md
+++ b/changelog/unreleased/fix-rotated-session-stuck-running.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Sessions no longer get stuck showing "running" after Claude rotates its session id mid-conversation (compaction, /clear, or continue).

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -206,32 +206,48 @@ func CopyClaudeForkTranscript(parentSessionID, parentProjectPath, destProjectPat
 	return nil
 }
 
-// rotationHandoffWindow bounds how far apart a rotated session's first transcript
-// entry and the previous (owner) session's last entry may be while still counting
-// as a continuation. Claude Code's session-id rotations (compaction, /clear,
-// continue) hand off within milliseconds; the window absorbs clock/flush skew but
-// stays far tighter than the gap a concurrent nested child shows.
+// rotationHandoffWindow bounds how far apart a /clear-rotated session's first
+// transcript entry and the previous (owner) session's last entry may be while
+// still counting as a continuation. A /clear hands off within milliseconds; the
+// window absorbs clock/flush skew but stays far tighter than the gap a concurrent
+// nested child shows. (Linked rotations — continue/resume/fork — use the
+// deterministic uuid signal below instead, which has no time dependence.)
 const rotationHandoffWindow = 10 * time.Second
 
 // isSessionRotation reports whether newSessionID is ownerSessionID's conversation
 // continued under a fresh id (a Claude session-id rotation) rather than a separate
 // nested child claude that merely inherited the same FLEET_INSTANCE_ID.
 //
-// The signal is transcript continuity: a rotation's new transcript begins right
-// where the owner's ends, so the new file's first entry and the owner file's last
-// entry land within rotationHandoffWindow of each other. A concurrent child starts
-// mid-way through the owner's life and the owner keeps appending past it, so the
-// two never line up.
+// Claude rotates a session id three ways, and they leave different traces:
+//   - continue / resume / fork: the new transcript opens with a
+//     `compact_boundary`/`summary` entry whose `logicalParentUuid` points at the
+//     prior session's tail uuid. Preserved history means the new file's first
+//     timestamp is OLD (minutes-to-days before the handoff), so we match the
+//     uuid against the owner transcript instead — deterministic, time-independent,
+//     and a nested child can't match (its link, if any, points at its own parent).
+//   - /clear: a fresh conversation (first user entry `parentUuid:null`, no link)
+//     that hands off instantly, so the new file's first entry lands within
+//     rotationHandoffWindow of the owner's last entry.
+//   - in-place compaction keeps the same session id, so it never reaches here.
 //
-// When either transcript can't be read we return false — the safe default, since
-// wrongly adopting a real nested child would clobber the owner's status and resume
-// id.
+// When transcripts can't be read we return false — the safe default, since
+// wrongly adopting a real nested child would clobber the owner's status and
+// resume id.
 func isSessionRotation(projectPath, ownerSessionID, newSessionID string) bool {
 	if projectPath == "" || ownerSessionID == "" || newSessionID == "" {
 		return false
 	}
-	newFirst := firstTranscriptTimestamp(ClaudeTranscriptPath(newSessionID, projectPath))
-	ownerLast := lastTranscriptTimestamp(ClaudeTranscriptPath(ownerSessionID, projectPath))
+	newPath := ClaudeTranscriptPath(newSessionID, projectPath)
+	ownerPath := ClaudeTranscriptPath(ownerSessionID, projectPath)
+
+	// Primary: deterministic parent link (continue/resume/fork).
+	if link := transcriptParentLink(newPath); link != "" && transcriptContainsUUID(ownerPath, link) {
+		return true
+	}
+
+	// Fallback: instant timestamp handoff (/clear).
+	newFirst := firstTranscriptTimestamp(newPath)
+	ownerLast := lastTranscriptTimestamp(ownerPath)
 	if newFirst.IsZero() || ownerLast.IsZero() {
 		return false
 	}
@@ -240,6 +256,74 @@ func isSessionRotation(projectPath, ownerSessionID, newSessionID string) bool {
 		delta = -delta
 	}
 	return delta <= rotationHandoffWindow
+}
+
+// transcriptParentLink returns the logicalParentUuid of the first
+// compact_boundary/summary entry in the transcript at path — the link a
+// continue/resume/fork rotation records to its parent session's tail uuid — or
+// "" if the transcript opens with no such entry (a /clear-fresh or brand-new
+// session). Only the first such entry matters: later compact_boundary entries in
+// the same file are in-place compactions that link within this file.
+func transcriptParentLink(path string) string {
+	if path == "" {
+		return ""
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, "logicalParentUuid") {
+			continue
+		}
+		var entry struct {
+			Type              string `json:"type"`
+			Subtype           string `json:"subtype"`
+			LogicalParentUUID string `json:"logicalParentUuid"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.LogicalParentUUID != "" && (entry.Subtype == "compact_boundary" || entry.Type == "summary") {
+			return entry.LogicalParentUUID
+		}
+	}
+	return ""
+}
+
+// transcriptContainsUUID reports whether any entry in the transcript at path
+// carries the given uuid. Used to confirm a child's logicalParentUuid actually
+// belongs to the owner transcript (vs a nested child's own parent).
+func transcriptContainsUUID(path, uuid string) bool {
+	if path == "" || uuid == "" {
+		return false
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, uuid) {
+			continue
+		}
+		var entry struct {
+			UUID string `json:"uuid"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err == nil && entry.UUID == uuid {
+			return true
+		}
+	}
+	return false
 }
 
 // firstTranscriptTimestamp returns the timestamp of the earliest timestamped JSONL

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -279,7 +279,9 @@ func scanTranscriptTimestamp(path string, last bool) time.Time {
 		if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Timestamp == "" {
 			continue
 		}
-		ts, err := time.Parse(time.RFC3339, entry.Timestamp)
+		// RFC3339Nano: Claude transcripts stamp millisecond precision (e.g.
+		// "...:04.226Z"). The layout also parses entries with no fractional part.
+		ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp)
 		if err != nil {
 			continue
 		}

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // claudeProjectDirReplacer mirrors Claude Code's per-cwd transcript dir naming.
@@ -203,4 +204,89 @@ func CopyClaudeForkTranscript(parentSessionID, parentProjectPath, destProjectPat
 		return fmt.Errorf("rename temp to dest: %w", err)
 	}
 	return nil
+}
+
+// rotationHandoffWindow bounds how far apart a rotated session's first transcript
+// entry and the previous (owner) session's last entry may be while still counting
+// as a continuation. Claude Code's session-id rotations (compaction, /clear,
+// continue) hand off within milliseconds; the window absorbs clock/flush skew but
+// stays far tighter than the gap a concurrent nested child shows.
+const rotationHandoffWindow = 10 * time.Second
+
+// isSessionRotation reports whether newSessionID is ownerSessionID's conversation
+// continued under a fresh id (a Claude session-id rotation) rather than a separate
+// nested child claude that merely inherited the same FLEET_INSTANCE_ID.
+//
+// The signal is transcript continuity: a rotation's new transcript begins right
+// where the owner's ends, so the new file's first entry and the owner file's last
+// entry land within rotationHandoffWindow of each other. A concurrent child starts
+// mid-way through the owner's life and the owner keeps appending past it, so the
+// two never line up.
+//
+// When either transcript can't be read we return false — the safe default, since
+// wrongly adopting a real nested child would clobber the owner's status and resume
+// id.
+func isSessionRotation(projectPath, ownerSessionID, newSessionID string) bool {
+	if projectPath == "" || ownerSessionID == "" || newSessionID == "" {
+		return false
+	}
+	newFirst := firstTranscriptTimestamp(ClaudeTranscriptPath(newSessionID, projectPath))
+	ownerLast := lastTranscriptTimestamp(ClaudeTranscriptPath(ownerSessionID, projectPath))
+	if newFirst.IsZero() || ownerLast.IsZero() {
+		return false
+	}
+	delta := newFirst.Sub(ownerLast)
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta <= rotationHandoffWindow
+}
+
+// firstTranscriptTimestamp returns the timestamp of the earliest timestamped JSONL
+// entry in the transcript at path, or the zero time if it's missing/unreadable or
+// has no timestamped entries.
+func firstTranscriptTimestamp(path string) time.Time { return scanTranscriptTimestamp(path, false) }
+
+// lastTranscriptTimestamp returns the timestamp of the latest timestamped JSONL
+// entry in the transcript at path, or the zero time. It scans the whole file;
+// transcripts are small and this runs only on the rare session-id-change path.
+func lastTranscriptTimestamp(path string) time.Time { return scanTranscriptTimestamp(path, true) }
+
+// scanTranscriptTimestamp walks the JSONL transcript at path and returns the
+// first (last=false) or last (last=true) entry timestamp it can parse.
+func scanTranscriptTimestamp(path string, last bool) time.Time {
+	if path == "" {
+		return time.Time{}
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return time.Time{}
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max line
+
+	var result time.Time
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, `"timestamp"`) {
+			continue
+		}
+		var entry struct {
+			Timestamp string `json:"timestamp"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Timestamp == "" {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339, entry.Timestamp)
+		if err != nil {
+			continue
+		}
+		if !last {
+			return ts
+		}
+		result = ts
+	}
+	return result
 }

--- a/internal/session/ownership_test.go
+++ b/internal/session/ownership_test.go
@@ -1,0 +1,97 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTranscript writes a minimal Claude JSONL transcript with the given entry
+// timestamps under the HOME-rooted projects dir for projectPath, mirroring how
+// Claude Code lays out ~/.claude/projects/<encoded-cwd>/<session>.jsonl.
+func writeTranscript(t *testing.T, projectPath, sessionID string, stamps ...time.Time) {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".claude", "projects", ClaudeProjectDirName(projectPath))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	for _, ts := range stamps {
+		b.WriteString(`{"type":"user","timestamp":"`)
+		b.WriteString(ts.UTC().Format(time.RFC3339Nano))
+		b.WriteString(`"}` + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, sessionID+".jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUpdateHookStatusAdoptsRotatedSession reproduces the stuck-running bug: when
+// Claude rotates its session id mid-life (compaction/clear/continue), the new
+// transcript continues the old one within milliseconds. The new id's hooks must
+// be adopted, not dropped as foreign — otherwise the in-memory hook freezes at
+// the old session's last event and the resume id goes stale.
+func TestUpdateHookStatusAdoptsRotatedSession(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	proj := t.TempDir()
+
+	base := time.Now().Add(-time.Hour).UTC()
+	ownerEnd := base.Add(30 * time.Minute)
+	// Owner ends; the rotated transcript begins a hair before the owner's last
+	// entry (the real handoff is sub-millisecond and slightly out of order).
+	writeTranscript(t, proj, "owner-aaa", base, ownerEnd)
+	writeTranscript(t, proj, "rot-bbb", ownerEnd.Add(-2*time.Millisecond), ownerEnd.Add(10*time.Minute))
+
+	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
+
+	// Owner claims ownership.
+	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "owner-aaa", UpdatedAt: time.Now()})
+	if got := s.GetHookStatus(); got != "waiting" {
+		t.Fatalf("owner hook not applied: hook=%q", got)
+	}
+
+	// Rotated session reports finished — must be adopted (continuation).
+	changed := s.UpdateHookStatus(&HookStatus{Status: "finished", SessionID: "rot-bbb", UpdatedAt: time.Now()})
+	if !changed {
+		t.Errorf("rotated hook should register as changed")
+	}
+	if got := s.GetHookStatus(); got != "finished" {
+		t.Errorf("rotated hook not adopted: hook=%q, want finished", got)
+	}
+	if s.ClaudeSessionID != "rot-bbb" {
+		t.Errorf("resume id not updated to rotated session: %q, want rot-bbb", s.ClaudeSessionID)
+	}
+}
+
+// TestUpdateHookStatusIgnoresNestedChild guards the other side: a concurrent
+// nested child claude (eval harness) starts mid-way through the owner's life and
+// the owner keeps writing past it. Its transcript does not continue the owner's,
+// so its hooks must still be ignored.
+func TestUpdateHookStatusIgnoresNestedChild(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	proj := t.TempDir()
+
+	base := time.Now().Add(-time.Hour).UTC()
+	writeTranscript(t, proj, "owner-aaa", base, base.Add(time.Hour)) // long-lived owner
+	writeTranscript(t, proj, "child-bbb", base.Add(30*time.Minute), base.Add(31*time.Minute))
+
+	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
+	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-aaa", UpdatedAt: time.Now()})
+
+	// Child reports dead — must be ignored; owner state preserved.
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "child-bbb", UpdatedAt: time.Now()}); changed {
+		t.Errorf("nested child hook should be ignored (changed=true)")
+	}
+	if got := s.GetHookStatus(); got != "running" {
+		t.Errorf("owner hook clobbered by nested child: hook=%q, want running", got)
+	}
+	if s.ClaudeSessionID != "owner-aaa" {
+		t.Errorf("resume id clobbered by nested child: %q, want owner-aaa", s.ClaudeSessionID)
+	}
+}

--- a/internal/session/ownership_test.go
+++ b/internal/session/ownership_test.go
@@ -33,10 +33,10 @@ func writeTranscript(t *testing.T, projectPath, sessionID string, stamps ...time
 }
 
 // TestUpdateHookStatusAdoptsRotatedSession reproduces the stuck-running bug: when
-// Claude rotates its session id mid-life (compaction/clear/continue), the new
-// transcript continues the old one within milliseconds. The new id's hooks must
-// be adopted, not dropped as foreign — otherwise the in-memory hook freezes at
-// the old session's last event and the resume id goes stale.
+// Claude /clear starts a fresh conversation under a new id that hands off within
+// milliseconds (no parent link). The new id's hooks must be adopted via the
+// timestamp-proximity signal, not dropped as foreign — otherwise the in-memory
+// hook freezes at the old session's last event and the resume id goes stale.
 func TestUpdateHookStatusAdoptsRotatedSession(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	proj := t.TempDir()
@@ -51,13 +51,13 @@ func TestUpdateHookStatusAdoptsRotatedSession(t *testing.T) {
 	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
 
 	// Owner claims ownership.
-	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "owner-aaa", UpdatedAt: time.Now()})
+	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "owner-aaa", UpdatedAt: time.Now()}, true)
 	if got := s.GetHookStatus(); got != "waiting" {
 		t.Fatalf("owner hook not applied: hook=%q", got)
 	}
 
 	// Rotated session reports finished — must be adopted (continuation).
-	changed := s.UpdateHookStatus(&HookStatus{Status: "finished", SessionID: "rot-bbb", UpdatedAt: time.Now()})
+	changed := s.UpdateHookStatus(&HookStatus{Status: "finished", SessionID: "rot-bbb", UpdatedAt: time.Now()}, true)
 	if !changed {
 		t.Errorf("rotated hook should register as changed")
 	}
@@ -82,10 +82,10 @@ func TestUpdateHookStatusIgnoresNestedChild(t *testing.T) {
 	writeTranscript(t, proj, "child-bbb", base.Add(30*time.Minute), base.Add(31*time.Minute))
 
 	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
-	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-aaa", UpdatedAt: time.Now()})
+	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-aaa", UpdatedAt: time.Now()}, true)
 
 	// Child reports dead — must be ignored; owner state preserved.
-	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "child-bbb", UpdatedAt: time.Now()}); changed {
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "child-bbb", UpdatedAt: time.Now()}, true); changed {
 		t.Errorf("nested child hook should be ignored (changed=true)")
 	}
 	if got := s.GetHookStatus(); got != "running" {
@@ -93,5 +93,83 @@ func TestUpdateHookStatusIgnoresNestedChild(t *testing.T) {
 	}
 	if s.ClaudeSessionID != "owner-aaa" {
 		t.Errorf("resume id clobbered by nested child: %q, want owner-aaa", s.ClaudeSessionID)
+	}
+}
+
+// writeTranscriptRaw writes arbitrary JSONL lines for a session under the
+// HOME-rooted projects dir, for tests that need uuid / compact_boundary entries.
+func writeTranscriptRaw(t *testing.T, projectPath, sessionID string, lines ...string) {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".claude", "projects", ClaudeProjectDirName(projectPath))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, sessionID+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUpdateHookStatusAdoptsLinkedRotation covers continue/resume/fork: the new
+// transcript opens with a compact_boundary whose logicalParentUuid points at the
+// owner's tail uuid, and its first timestamp is OLD (preserved history) — so
+// proximity would miss it. The deterministic uuid link must adopt it anyway.
+func TestUpdateHookStatusAdoptsLinkedRotation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	proj := t.TempDir()
+
+	old := time.Now().Add(-4 * time.Hour).UTC().Format(time.RFC3339Nano)
+	// Owner transcript: its tail entry carries uuid "PARENT-TAIL".
+	writeTranscriptRaw(t, proj, "owner-link",
+		`{"type":"user","timestamp":"`+old+`","uuid":"u1"}`,
+		`{"type":"assistant","timestamp":"`+old+`","uuid":"PARENT-TAIL"}`,
+	)
+	// Rotated transcript: opens with a compact_boundary linking to PARENT-TAIL,
+	// first timestamp far in the past (proximity-defeating).
+	writeTranscriptRaw(t, proj, "child-link",
+		`{"type":"system","subtype":"compact_boundary","timestamp":"`+old+`","logicalParentUuid":"PARENT-TAIL","uuid":"cb1"}`,
+		`{"type":"user","timestamp":"`+time.Now().UTC().Format(time.RFC3339Nano)+`","uuid":"u2"}`,
+	)
+
+	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
+	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "owner-link", UpdatedAt: time.Now()}, true)
+
+	changed := s.UpdateHookStatus(&HookStatus{Status: "finished", SessionID: "child-link", UpdatedAt: time.Now()}, true)
+	if !changed || s.GetHookStatus() != "finished" || s.ClaudeSessionID != "child-link" {
+		t.Errorf("linked rotation not adopted: changed=%v hook=%q resumeID=%q (want true/finished/child-link)",
+			changed, s.GetHookStatus(), s.ClaudeSessionID)
+	}
+}
+
+// TestUpdateHookStatusIgnoresNestedChildWithCompaction guards the uuid signal's
+// precision: a nested child that compacted has a compact_boundary, but its
+// logicalParentUuid points at ITS OWN parent, not the owner — so it must NOT be
+// adopted.
+func TestUpdateHookStatusIgnoresNestedChildWithCompaction(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	proj := t.TempDir()
+
+	ownerTs := time.Now().Add(-4 * time.Hour).UTC().Format(time.RFC3339Nano)
+	childTs := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339Nano) // >10s from owner → proximity also rejects
+	writeTranscriptRaw(t, proj, "owner-x",
+		`{"type":"user","timestamp":"`+ownerTs+`","uuid":"owner-only-uuid"}`,
+	)
+	// Child links to a uuid that does NOT exist in the owner transcript, and its
+	// first entry is far from the owner's last (so neither signal adopts it).
+	writeTranscriptRaw(t, proj, "child-x",
+		`{"type":"system","subtype":"compact_boundary","timestamp":"`+childTs+`","logicalParentUuid":"some-other-parent","uuid":"cb1"}`,
+	)
+
+	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
+	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-x", UpdatedAt: time.Now()}, true)
+
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "child-x", UpdatedAt: time.Now()}, true); changed {
+		t.Errorf("nested child with foreign compaction link should be ignored")
+	}
+	if s.GetHookStatus() != "running" || s.ClaudeSessionID != "owner-x" {
+		t.Errorf("owner clobbered: hook=%q resumeID=%q", s.GetHookStatus(), s.ClaudeSessionID)
 	}
 }

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -456,6 +456,33 @@ func TestScenarioOwnerEndStillReported(t *testing.T) {
 	})
 }
 
+// TestScenarioStaleOverriddenWaitingSettlesFinished reproduces the stuck-running
+// bug a Claude session-id rotation triggers. The owner's last hook is a "waiting"
+// the pane overrides to finished (setting the override flag); the rotated
+// session's later Stop hook is dropped (see the ownership unit tests), so the
+// in-memory hook stays a stale overridden "waiting". When the agent then resumes
+// and finishes, the pane must drive the status BOTH ways — to running while it
+// works, and back to finished when the turn ends. Before the symmetric fast-path
+// it stuck on the last "running" it saw and never settled.
+func TestScenarioStaleOverriddenWaitingSettlesFinished(t *testing.T) {
+	runScenario(t, Scenario{
+		Name: "stale overridden-waiting hook settles to finished from the pane",
+		Events: []ScenarioEvent{
+			// Waiting hook; pane is the idle prompt → overridden to finished.
+			{At: 0, Hook: "waiting", SessionID: "owner-aaa", Pane: "@fixture:pane_finished_idle_prompt.txt"},
+			// Agent resumes — no hook fires (permission grant / dropped Stop).
+			{At: 2 * time.Second, Pane: "@fixture:pane_running_extended_thinking.txt"},
+			// Turn ends; pane returns to the idle prompt.
+			{At: 4 * time.Second, Pane: "@fixture:pane_finished_idle_prompt.txt"},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusFinished},               // override to finished
+			{At: 2 * time.Second, Expected: StatusRunning},  // pane-driven resume
+			{At: 4 * time.Second, Expected: StatusFinished}, // must settle back — was stuck running
+		},
+	})
+}
+
 func TestScenarioNoHooksFallback(t *testing.T) {
 	runScenario(t, Scenario{
 		Name: "no hooks, pane-only detection",

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -108,7 +108,7 @@ func runScenario(t *testing.T, sc Scenario) {
 					Status:    e.Hook,
 					SessionID: e.SessionID,
 					UpdatedAt: hookUpdatedAt,
-				})
+				}, true)
 			}
 
 			// Set pane content.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -63,6 +63,13 @@ type Session struct {
 	hookOverriddenAt time.Time // timestamp of hook that was overridden by pane; prevents re-evaluation of same stale hook
 	ownerSessionID   string    // Claude session_id that owns this fleet session; hooks from other (nested) Claudes are ignored
 
+	// Negative cache for the rotation check: the last (owner, foreign) pair that
+	// isSessionRotation rejected. A persistent foreign id (a nested-child eval
+	// harness) would otherwise rescan transcripts every worker cycle; once
+	// rejected we short-circuit until the owner or the foreign id changes.
+	rotRejectOwner   string
+	rotRejectForeign string
+
 	lastContentHash     string
 	lastContentChangeAt time.Time
 
@@ -233,7 +240,13 @@ type HookStatus struct {
 // UpdateHookStatus updates the session's hook-based status.
 // Returns true if the hook meaningfully changed (new status or new timestamp),
 // so callers can prioritize an immediate status recomputation.
-func (s *Session) UpdateHookStatus(hs *HookStatus) bool {
+//
+// resolveRotation gates the transcript I/O in isSessionRotation. The worker
+// passes true (it runs off the Bubble Tea Update() loop); the UI paths
+// (hookChangedMsg/statusUpdateMsg) pass false so a foreign id can't block the
+// render loop on disk reads — they simply defer it to the next worker cycle
+// (~500ms), which adopts it.
+func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 	if hs == nil {
 		return false
 	}
@@ -243,28 +256,43 @@ func (s *Session) UpdateHookStatus(hs *HookStatus) bool {
 	// Rare path: only fires when an id we don't already own reports.
 	//
 	// A different Claude session_id means one of two things:
-	//   - Claude rotated its session id mid-life (compaction, /clear, or a
-	//     resume/continue). A legitimate handoff: we MUST adopt the new id, or
-	//     the in-memory hook freezes at the old session's last event (e.g. a
-	//     stale "waiting") and the resume id / auto-name go stale.
+	//   - Claude rotated its session id (/clear, continue, resume, fork). A
+	//     legitimate handoff: we MUST adopt the new id, or the in-memory hook
+	//     freezes at the old session's last event (e.g. a stale "waiting") and
+	//     the resume id / auto-name go stale.
 	//   - A nested child `claude` (an eval harness spawning sub-Claudes)
 	//     inherited FLEET_INSTANCE_ID. Adopting it would clobber our status and
 	//     resume id, so it must be ignored.
-	// isSessionRotation distinguishes them via transcript continuity.
+	// isSessionRotation distinguishes them; a persistent rejection is cached so
+	// a nested child doesn't rescan transcripts every cycle.
 	var owner string
 	if hs.SessionID != "" {
 		s.mu.RLock()
 		owner = s.ownerSessionID
 		projectPath := s.ProjectPath
+		negCached := owner != "" && s.rotRejectOwner == owner && s.rotRejectForeign == hs.SessionID
 		s.mu.RUnlock()
 		if owner != "" && hs.SessionID != owner {
-			if isSessionRotation(projectPath, owner, hs.SessionID) {
+			switch {
+			case negCached:
+				return false // already rejected this (owner, foreign) pair
+			case resolveRotation && isSessionRotation(projectPath, owner, hs.SessionID):
 				debuglog.Logger.Info("adopting rotated claude session",
 					"id", s.ID, "old", owner, "new", hs.SessionID)
-			} else {
-				debuglog.Logger.Debug("ignoring foreign claude session",
-					"id", s.ID, "owner", owner, "foreign", hs.SessionID)
-				return false // foreign (nested) Claude — ignore entirely
+			default:
+				// Foreign (nested child), or deferred from the UI path. Cache the
+				// rejection only when we actually evaluated it (worker path), so a
+				// persistent foreign id doesn't rescan transcripts every cycle; the
+				// UI path leaves the verdict to the worker.
+				if resolveRotation {
+					s.mu.Lock()
+					s.rotRejectOwner = owner
+					s.rotRejectForeign = hs.SessionID
+					s.mu.Unlock()
+					debuglog.Logger.Debug("ignoring foreign claude session",
+						"id", s.ID, "owner", owner, "foreign", hs.SessionID)
+				}
+				return false
 			}
 		}
 	}
@@ -273,12 +301,11 @@ func (s *Session) UpdateHookStatus(hs *HookStatus) bool {
 	defer s.mu.Unlock()
 
 	// Claim ownership (first hook after launch), adopt a verified rotation, or
-	// no-op for the current owner. Re-validate under the write lock: if ownership
-	// changed to a different non-empty id since the snapshot above, drop rather
-	// than clobber it — the next worker cycle re-reads the hook file and
-	// re-evaluates. Unreachable while all UpdateHookStatus callers are serialized
-	// by workerMu (the only concurrent writer, clearHookState, just sets ""), but
-	// keeps this self-defending if a future caller isn't.
+	// no-op for the current owner. Re-validate under the write lock: the worker
+	// runs syncHookStatuses WITHOUT workerMu (app.go), so it races the UI path —
+	// ownership may have changed since the snapshot above. If it changed to a
+	// different non-empty id, drop rather than clobber it; the next cycle
+	// re-evaluates. (This re-check is load-bearing, not just defensive.)
 	if hs.SessionID != "" {
 		if cur := s.ownerSessionID; cur != "" && cur != owner && cur != hs.SessionID {
 			debuglog.Logger.Debug("owner changed under lock; dropping hook",
@@ -406,6 +433,8 @@ func (s *Session) clearHookState() {
 	s.hookUpdatedAt = time.Time{}
 	s.hookOverriddenAt = time.Time{}
 	s.ownerSessionID = ""
+	s.rotRejectOwner = ""
+	s.rotRejectForeign = ""
 	s.mu.Unlock()
 	hookFile := filepath.Join(hooks.GetHooksDir(), s.ID+".json")
 	if err := os.Remove(hookFile); err != nil && !os.IsNotExist(err) {
@@ -673,6 +702,10 @@ func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, log *s
 			} else {
 				s.Status = StatusFinished
 			}
+			// Match the non-overridden settle below: reset content tracking so a
+			// later waiting hook measures change from a clean baseline.
+			s.lastContentHash = ""
+			s.lastContentChangeAt = time.Time{}
 			log.Info("overridden waiting hook but pane shows idle prompt, settling to finished")
 		}
 		return

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -251,9 +251,10 @@ func (s *Session) UpdateHookStatus(hs *HookStatus) bool {
 	//     inherited FLEET_INSTANCE_ID. Adopting it would clobber our status and
 	//     resume id, so it must be ignored.
 	// isSessionRotation distinguishes them via transcript continuity.
+	var owner string
 	if hs.SessionID != "" {
 		s.mu.RLock()
-		owner := s.ownerSessionID
+		owner = s.ownerSessionID
 		projectPath := s.ProjectPath
 		s.mu.RUnlock()
 		if owner != "" && hs.SessionID != owner {
@@ -272,8 +273,18 @@ func (s *Session) UpdateHookStatus(hs *HookStatus) bool {
 	defer s.mu.Unlock()
 
 	// Claim ownership (first hook after launch), adopt a verified rotation, or
-	// no-op for the current owner.
+	// no-op for the current owner. Re-validate under the write lock: if ownership
+	// changed to a different non-empty id since the snapshot above, drop rather
+	// than clobber it — the next worker cycle re-reads the hook file and
+	// re-evaluates. Unreachable while all UpdateHookStatus callers are serialized
+	// by workerMu (the only concurrent writer, clearHookState, just sets ""), but
+	// keeps this self-defending if a future caller isn't.
 	if hs.SessionID != "" {
+		if cur := s.ownerSessionID; cur != "" && cur != owner && cur != hs.SessionID {
+			debuglog.Logger.Debug("owner changed under lock; dropping hook",
+				"id", s.ID, "snapshot", owner, "current", cur, "hook", hs.SessionID)
+			return false
+		}
 		s.ownerSessionID = hs.SessionID
 	}
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -237,20 +237,44 @@ func (s *Session) UpdateHookStatus(hs *HookStatus) bool {
 	if hs == nil {
 		return false
 	}
+
+	// Resolve ownership for a non-owner session_id BEFORE taking s.mu — the
+	// rotation check reads Claude transcripts and must not run under the lock.
+	// Rare path: only fires when an id we don't already own reports.
+	//
+	// A different Claude session_id means one of two things:
+	//   - Claude rotated its session id mid-life (compaction, /clear, or a
+	//     resume/continue). A legitimate handoff: we MUST adopt the new id, or
+	//     the in-memory hook freezes at the old session's last event (e.g. a
+	//     stale "waiting") and the resume id / auto-name go stale.
+	//   - A nested child `claude` (an eval harness spawning sub-Claudes)
+	//     inherited FLEET_INSTANCE_ID. Adopting it would clobber our status and
+	//     resume id, so it must be ignored.
+	// isSessionRotation distinguishes them via transcript continuity.
+	if hs.SessionID != "" {
+		s.mu.RLock()
+		owner := s.ownerSessionID
+		projectPath := s.ProjectPath
+		s.mu.RUnlock()
+		if owner != "" && hs.SessionID != owner {
+			if isSessionRotation(projectPath, owner, hs.SessionID) {
+				debuglog.Logger.Info("adopting rotated claude session",
+					"id", s.ID, "old", owner, "new", hs.SessionID)
+			} else {
+				debuglog.Logger.Debug("ignoring foreign claude session",
+					"id", s.ID, "owner", owner, "foreign", hs.SessionID)
+				return false // foreign (nested) Claude — ignore entirely
+			}
+		}
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Ignore events from a different Claude session than the one we own.
-	// Nested `claude` processes (eval harnesses that spawn child Claudes)
-	// inherit FLEET_INSTANCE_ID and would otherwise clobber our status, resume
-	// id, and auto-naming with their lifecycle events. The owner is the first
-	// Claude to report after launch/restart; foreign sessions are dropped.
+	// Claim ownership (first hook after launch), adopt a verified rotation, or
+	// no-op for the current owner.
 	if hs.SessionID != "" {
-		if s.ownerSessionID == "" {
-			s.ownerSessionID = hs.SessionID // claim ownership
-		} else if hs.SessionID != s.ownerSessionID {
-			return false // foreign (nested) Claude — ignore entirely
-		}
+		s.ownerSessionID = hs.SessionID
 	}
 
 	changed := s.hookStatus != hs.Status || s.hookUpdatedAt != hs.UpdatedAt
@@ -621,13 +645,24 @@ func (s *Session) applyHookRunning(oldStatus Status, paneContent string, paneSta
 func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, log *slog.Logger) {
 	// If this hook was already overridden by pane detection (stale hook),
 	// skip re-evaluation. A new hook (different timestamp) resets the flag.
-	// Exception: if pane shows running (active spinner), the user approved the
-	// permission and Claude started working — no hook fires for permission grants.
+	// The pane stays authoritative for this stale hook: a running spinner means
+	// the user approved and Claude resumed (no hook fires for a permission
+	// grant), and an idle prompt means the turn finished. Handling both keeps a
+	// stale overridden-waiting hook from staying pinned to the last "running" it
+	// saw — e.g. when the real Stop hook was dropped after a session-id rotation.
 	if !s.hookOverriddenAt.IsZero() && s.hookOverriddenAt.Equal(s.hookUpdatedAt) {
-		if paneStatus == StatusRunning {
+		switch paneStatus {
+		case StatusRunning:
 			s.Status = StatusRunning
 			s.Acknowledged = false
 			log.Info("overridden waiting hook but pane shows running, resuming")
+		case StatusFinished:
+			if s.Acknowledged {
+				s.Status = StatusIdle
+			} else {
+				s.Status = StatusFinished
+			}
+			log.Info("overridden waiting hook but pane shows idle prompt, settling to finished")
 		}
 		return
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -480,7 +480,7 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// then hand sessions whose hook changed to the worker via the priority queue
 		// so they get a full UpdateStatus() within ~100ms instead of waiting for round-robin.
 		h.workerMu.Lock()
-		changed := h.syncHookStatuses(h.sessions)
+		changed := h.syncHookStatuses(h.sessions, false) // UI loop: no rotation I/O
 		h.workerMu.Unlock()
 		h.rebuildFlatItems()
 		h.enqueuePriorityUpdates(changed)
@@ -491,7 +491,7 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.isAttaching.Store(false)
 		// Immediate hook sync (data already in HookWatcher from hooks that fired during attach).
 		h.workerMu.Lock()
-		changed := h.syncHookStatuses(h.sessions)
+		changed := h.syncHookStatuses(h.sessions, false) // UI loop: no rotation I/O
 		h.workerMu.Unlock()
 		h.rebuildFlatItems()
 		h.enqueuePriorityUpdates(changed)
@@ -3251,7 +3251,12 @@ func (h *Home) statusWorker() {
 // them to the given sessions. Caller must ensure thread-safe access to sessions.
 // Returns the IDs of sessions whose hook meaningfully changed (new status or timestamp);
 // callers can forward these to priorityStatusUpdates for immediate UpdateStatus().
-func (h *Home) syncHookStatuses(sessions []*session.Session) []string {
+//
+// resolveRotation must be true ONLY on the worker goroutine: a foreign/rotated
+// session id triggers blocking transcript I/O (rotation detection), which must
+// never run on the Bubble Tea Update() loop. UI-path callers pass false; the
+// worker adopts a rotation within one fast cycle (~500ms).
+func (h *Home) syncHookStatuses(sessions []*session.Session, resolveRotation bool) []string {
 	if h.hookWatcher == nil {
 		return nil
 	}
@@ -3268,7 +3273,7 @@ func (h *Home) syncHookStatuses(sessions []*session.Session) []string {
 				UpdatedAt:   hs.UpdatedAt,
 				UserPrompt:  hs.UserPrompt,
 				PromptCount: hs.PromptCount,
-			}) {
+			}, resolveRotation) {
 				changed = append(changed, s.ID)
 			}
 			// Persist new Claude session ID if it changed.
@@ -3448,8 +3453,9 @@ func (h *Home) statusWorkerCycle() {
 	// prematurely.
 	tmux.RefreshSessionCache()
 
-	// 3. Sync hook status (fast: in-memory map lookups).
-	h.syncHookStatuses(sessions)
+	// 3. Sync hook status (fast: in-memory map lookups; worker may resolve a
+	// session-id rotation here — off the UI loop, so its transcript I/O is safe).
+	h.syncHookStatuses(sessions, true)
 
 	// 3b. Auto-name: generate title for ONE session per cycle (heavy cadence).
 	// Priority: manual (R key) > custom-title > ai-title > last prompt heuristic.


### PR DESCRIPTION
## Problem

Two `/debug-status` snapshots (16:00 and 16:30, different repos) showed sessions stuck on **running** when the agent had clearly **finished**. Same root cause both times.

When Claude Code rotates its conversation `session_id` mid-life — compaction, `/clear`, or a continue/resume handoff — the new id (`1ba70e78`, `7fbd4947`) differs from the one fleet claimed at launch (`acff4e56`, `c12a0691`). The transcripts confirm a continuation: the new file's first entry lands **3–6 ms before** the old file's last entry.

`UpdateHookStatus`'s ownership guard treated the new id as a **nested/foreign Claude** and `return false`'d **every** hook from it — including the `Stop`/finished — **silently**. So:

1. The in-memory hook froze at the old session's last event (a stale `waiting`).
2. The pane fallback (`applyHookWaiting`) drove status from there. Its overridden fast-path only flipped to **running** on a spinner and did nothing on a finished pane, so once the agent finished it stayed pinned to the last `running` it saw.
3. Collateral: `ClaudeSessionID` stuck on the old id (restart/resume would resume the wrong conversation), and auto-naming froze.

The drop produced **no log line**, which is why this took a transcript dig to find.

## Fix

- **Adopt legitimate rotations.** When a non-owner `session_id` reports, distinguish a rotation from a concurrent nested child via **transcript continuity** (`isSessionRotation`): the rotated transcript's first entry lands within 10 s of the owner transcript's last entry. Rotations are adopted (ownership + resume id follow); concurrent children are still ignored. Transcript I/O runs on the rare non-owner path only, outside `s.mu`.
- **Symmetric fast-path** in `applyHookWaiting`: a stale overridden-waiting hook now settles to finished/idle when the pane shows the idle prompt, not just resumes on a spinner. Self-corrects the symptom even if a hook is dropped.
- **Visibility:** log ownership transfer (info) and foreign drops (debug).

## Tests

- `TestUpdateHookStatusAdoptsRotatedSession` / `TestUpdateHookStatusIgnoresNestedChild` — ownership handoff vs. nested-child rejection (hermetic, `HOME`-rooted transcript fixtures).
- `TestScenarioStaleOverriddenWaitingSettlesFinished` — the stuck-running transition.
- Verified each test **fails without its corresponding fix** and passes with it. Existing `TestScenarioNestedClaudeIgnored` / `TestScenarioOwnerEndStillReported` still pass. Full `go test -race ./...` green; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions no longer remain stuck in "running" after the assistant rotates its session ID mid-conversation (including during compaction, clearing, or continue), so session status updates now reflect actual conversation state.

* **Tests**
  * Added tests validating session rotation detection, transcript continuity handling, and correct ownership resolution between rotated and nested sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->