### PR TITLE
fix(config): preserve unknown keys on save; log config writes

### DIFF
--- a/changelog/unreleased/config-preserve-unknown-keys.md
+++ b/changelog/unreleased/config-preserve-unknown-keys.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Your settings (theme, telemetry consent, onboarding state) no longer reset when an older fleet build saves the config — config now preserves fields it doesn't recognize instead of dropping them. Every config write is also logged with the build that made it, for easier diagnosis.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"runtime/debug"
+	"sort"
 	"strings"
 
 	"github.com/brizzai/fleet/internal/debuglog"
@@ -51,6 +54,13 @@ type Config struct {
 	// has no config.json, so this is the one signal that doesn't depend on the
 	// telemetry/consent path.
 	loadedFromDisk bool
+
+	// unknownKeys preserves any top-level JSON keys present on disk that this
+	// binary's struct doesn't recognize — e.g. a field a newer fleet wrote that
+	// an older binary would otherwise silently drop on the next Save. Captured
+	// in Load, re-merged in Save. Unexported, so the struct path never
+	// serializes it; it is re-injected manually by marshal.
+	unknownKeys map[string]json.RawMessage
 }
 
 // IsFirstRun reports whether this is a genuinely fresh install — no config file
@@ -125,6 +135,7 @@ func Load() *Config {
 	if err := json.Unmarshal(data, cfg); err != nil {
 		debuglog.Logger.Error("failed to parse config file", "path", path, "error", err)
 	} else {
+		cfg.unknownKeys = extractUnknownKeys(data)
 		debuglog.Logger.Info("config loaded", "path", path)
 	}
 
@@ -143,7 +154,7 @@ func (c *Config) Save() error {
 		debuglog.Logger.Error("failed to create config directory", "path", path, "error", err)
 		return err
 	}
-	data, err := json.MarshalIndent(c, "", "  ")
+	data, err := c.marshal()
 	if err != nil {
 		debuglog.Logger.Error("failed to marshal config", "error", err)
 		return err
@@ -152,7 +163,117 @@ func (c *Config) Save() error {
 		debuglog.Logger.Error("failed to write config file", "path", path, "error", err)
 		return err
 	}
+	// Stamp every save with the build that wrote it (VCS revision, present even
+	// for `go run`/`make run`) and the exact keys persisted. If a stale binary
+	// ever drops a newer field, this line pins which build did it and when.
+	debuglog.Logger.Info("config saved", "path", path, "build", buildID(), "keys", topLevelKeys(data))
 	return nil
+}
+
+// marshal renders the config to indented JSON, re-merging any unknown keys
+// captured at load time so fields written by a newer fleet survive a save by
+// this binary. With no unknown keys (the common case) the output is byte-for-
+// byte the struct's own ordered marshal; the merge path alphabetizes keys.
+func (c *Config) marshal() ([]byte, error) {
+	if len(c.unknownKeys) == 0 {
+		return json.MarshalIndent(c, "", "  ")
+	}
+	base, err := json.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+	merged := map[string]json.RawMessage{}
+	if err := json.Unmarshal(base, &merged); err != nil {
+		return nil, err
+	}
+	for k, v := range c.unknownKeys {
+		if _, known := merged[k]; !known {
+			merged[k] = v
+		}
+	}
+	return json.MarshalIndent(merged, "", "  ")
+}
+
+// extractUnknownKeys returns the top-level keys in on-disk config JSON that this
+// binary's Config struct doesn't define. Preserving them across a Save round-
+// trip stops an older binary from silently dropping fields a newer one wrote.
+func extractUnknownKeys(data []byte) map[string]json.RawMessage {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	known := knownConfigKeys()
+	for k := range raw {
+		if known[k] {
+			delete(raw, k)
+		}
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
+}
+
+// knownConfigKeys is the set of JSON field names the Config struct defines,
+// derived from its json tags so it never drifts as fields are added/removed.
+func knownConfigKeys() map[string]bool {
+	t := reflect.TypeFor[Config]()
+	keys := make(map[string]bool, t.NumField())
+	for f := range t.Fields() {
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		if name, _, _ := strings.Cut(tag, ","); name != "" {
+			keys[name] = true
+		}
+	}
+	return keys
+}
+
+// topLevelKeys returns the JSON object's top-level keys, sorted and comma-joined,
+// for the save-log. Empty string if data isn't a JSON object.
+func topLevelKeys(data []byte) string {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return ""
+	}
+	keys := make([]string, 0, len(raw))
+	for k := range raw {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ",")
+}
+
+// buildID returns a short identifier for the running binary: the embedded VCS
+// revision (Go embeds it for `go build`/`go run`, so it works under `make run`),
+// suffixed "-dirty" when the working tree had uncommitted changes at build time.
+// Falls back to "unknown" when no VCS info is embedded.
+func buildID() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	var rev, mod string
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			rev = s.Value
+		case "vcs.modified":
+			mod = s.Value
+		}
+	}
+	if rev == "" {
+		return "unknown"
+	}
+	if len(rev) > 12 {
+		rev = rev[:12]
+	}
+	if mod == "true" {
+		rev += "-dirty"
+	}
+	return rev
 }
 
 // IsCopyClaudeSettingsEnabled returns whether to copy .claude/settings.local.json to new worktrees (default: true).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -316,5 +317,76 @@ func TestIsFirstRun(t *testing.T) {
 	// tests) is treated as a first run — the safe default.
 	if !(&Config{}).IsFirstRun() {
 		t.Error("zero-value Config should report IsFirstRun() == true")
+	}
+}
+
+func TestSavePreservesUnknownKeys(t *testing.T) {
+	// Regression: an older binary whose struct lacks a field a newer fleet wrote
+	// must not silently drop it on save (the theme-reset / consent-prompt-
+	// reappears bug). Load captures unknown keys; Save re-merges them.
+	t.Setenv("HOME", t.TempDir())
+
+	// Simulate a config written by a newer fleet: a key this struct knows
+	// (theme) plus one it doesn't (future_feature).
+	onDisk := `{"theme":"nord","future_feature":{"nested":true},"future_flag":42}`
+	if err := os.MkdirAll(filepath.Dir(DefaultConfigPath()), 0700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(DefaultConfigPath(), []byte(onDisk), 0600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cfg := Load()
+	if cfg.Theme != "nord" {
+		t.Errorf("Theme: got %q, want %q", cfg.Theme, "nord")
+	}
+
+	// A normal mutation + save (as the settings dialog would do).
+	cfg.Editor = "vim"
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(DefaultConfigPath())
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal saved: %v", err)
+	}
+	for _, k := range []string{"future_feature", "future_flag"} {
+		if _, ok := raw[k]; !ok {
+			t.Errorf("unknown key %q was dropped on save; got %s", k, data)
+		}
+	}
+	if string(raw["theme"]) != `"nord"` {
+		t.Errorf("theme not preserved: got %s", raw["theme"])
+	}
+	if string(raw["editor"]) != `"vim"` {
+		t.Errorf("mutation not persisted: got %s", raw["editor"])
+	}
+}
+
+func TestSaveNoUnknownKeysIsByteIdenticalToStructMarshal(t *testing.T) {
+	// The common case (no unknown keys on disk) must stay exactly the struct's
+	// own ordered marshal — the merge path only engages when there's something
+	// to preserve.
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := &Config{Theme: "nord", Editor: "vim"}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := os.ReadFile(DefaultConfigPath())
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	want, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("output diverged from struct marshal:\n got: %s\nwant: %s", got, want)
 	}
 }


### PR DESCRIPTION
## What & why

Launching a fleet build that **predates a config field** was silently resetting newer settings — the symptom that kicked this off: relaunching and finding the **theme changed** and the **telemetry/onboarding prompts reappeared**.

Root cause: Go's `json.Unmarshal` ignores keys the struct doesn't define, so an older binary loads the config without them, and the next `Save()` round-trips them out of existence. With `omitempty`, fields like `theme`, `analytics_consent_seen`, and `display_onboarding_seen` vanish.

## Changes (`internal/config/config.go`)

**Preserve unknown keys (kills the bug class)**
- `Load()` captures any top-level JSON keys the struct doesn't define. The known-key set is derived via reflection over the struct's `json` tags, so it never drifts as fields are added.
- `Save()` re-merges them. **No unknown keys (the common case) → output is byte-identical to the struct's own marshal**; the merge path only engages when there's something to preserve (guarded by a test).

**Log config writes (catch-it-next-time)**
- `Save()` logs each write with the embedded VCS revision (`runtime/debug.ReadBuildInfo` — present even under `go run`/`make run`, where the ldflags version is always `dev`) and the exact keys persisted. Any future drop is now traceable to the precise build that made it.

## Tests (`config_test.go`)
- `TestSavePreservesUnknownKeys` — load a config with future fields, mutate, save, assert they survive.
- `TestSaveNoUnknownKeysIsByteIdenticalToStructMarshal` — common case output unchanged.

## Caveat
This protects configs written by binaries that **have** this code. A pre-fix build can still strip fields — but the new save-log will now name exactly which commit did it.

## Verification
- `make build` ✅
- `go test -race ./...` ✅ (all packages)
- Confirmed the real binary embeds `vcs.revision` (`go version -m build/fleet`), so the save-log is meaningful under `make run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration now preserves unknown keys, preventing user settings (theme, telemetry consent, onboarding state) from resetting when older builds save configuration.
  * Config writes are now logged with build information to assist with diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->