### PR TITLE
fix(status): time out git/gh calls so a hang can't freeze every session's status

### DIFF
--- a/changelog/unreleased/status-worker-timeouts.md
+++ b/changelog/unreleased/status-worker-timeouts.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Session statuses no longer freeze across the whole app when a `git` or `gh` call hangs — those calls now time out (8s/15s) instead of wedging the background status worker indefinitely.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -11,11 +12,31 @@ import (
 	"github.com/brizzai/fleet/internal/debuglog"
 )
 
+// gitTimeout bounds every git subprocess. git is normally local and fast, but a
+// hung call (a held .git/index.lock, a dead NFS mount, a wedged filesystem)
+// must not freeze the caller. The status worker waits synchronously on these
+// during its per-cycle git+PR fan-out, so a single indefinite git call would
+// stall every session's status update.
+const gitTimeout = 8 * time.Second
+
+// gitOutput runs `git <args>` under gitTimeout and returns its stdout.
+func gitOutput(args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "git", args...).Output()
+}
+
+// gitRun runs `git <args>` under gitTimeout, discarding output.
+func gitRun(args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "git", args...).Run()
+}
+
 // GetBranchName returns the current branch name for the given repo path.
 // Returns empty string if not a git repo or on error.
 func GetBranchName(repoPath string) string {
-	cmd := exec.Command("git", "-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD")
-	output, err := cmd.Output()
+	output, err := gitOutput("-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return ""
 	}
@@ -24,8 +45,7 @@ func GetBranchName(repoPath string) string {
 
 // HasUncommittedChanges returns true if the working tree has uncommitted changes.
 func HasUncommittedChanges(repoPath string) bool {
-	cmd := exec.Command("git", "-C", repoPath, "status", "--porcelain")
-	output, err := cmd.Output()
+	output, err := gitOutput("-C", repoPath, "status", "--porcelain")
 	if err != nil {
 		return false
 	}
@@ -44,11 +64,10 @@ type BranchInfo struct {
 // ListBranches returns all branches sorted by most recently committed first.
 // Includes both local and remote branches, with deduplication.
 func ListBranches(repoPath string) ([]BranchInfo, error) {
-	cmd := exec.Command("git", "-C", repoPath, "for-each-ref",
+	output, err := gitOutput("-C", repoPath, "for-each-ref",
 		"--sort=-committerdate",
 		"--format=%(refname:short)\t%(committerdate:unix)\t%(authoremail)",
 		"refs/heads/", "refs/remotes/origin/")
-	output, err := cmd.Output()
 	if err != nil {
 		debuglog.Logger.Debug("ListBranches failed", "path", repoPath, "error", err)
 		return nil, fmt.Errorf("git for-each-ref: %w", err)
@@ -117,8 +136,7 @@ func ListBranches(repoPath string) ([]BranchInfo, error) {
 
 // GetUserEmail returns the git user.email for the given repo.
 func GetUserEmail(repoPath string) string {
-	cmd := exec.Command("git", "-C", repoPath, "config", "user.email")
-	output, err := cmd.Output()
+	output, err := gitOutput("-C", repoPath, "config", "user.email")
 	if err != nil {
 		return ""
 	}
@@ -128,7 +146,9 @@ func GetUserEmail(repoPath string) string {
 // CheckoutBranch checks out the given branch in the repo.
 // For remote-only branches, git auto-creates a local tracking branch.
 func CheckoutBranch(repoPath, branch string) error {
-	cmd := exec.Command("git", "-C", repoPath, "checkout", branch)
+	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "checkout", branch)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		debuglog.Logger.Debug("CheckoutBranch failed", "path", repoPath, "branch", branch, "error", strings.TrimSpace(string(output)))
@@ -143,8 +163,7 @@ func CheckoutBranch(repoPath, branch string) error {
 // remote tip rather than the local branch. Falls back to local "main"/"master".
 func GetDefaultBranch(repoPath string) string {
 	// Try origin HEAD reference first.
-	cmd := exec.Command("git", "-C", repoPath, "symbolic-ref", "refs/remotes/origin/HEAD")
-	if output, err := cmd.Output(); err == nil {
+	if output, err := gitOutput("-C", repoPath, "symbolic-ref", "refs/remotes/origin/HEAD"); err == nil {
 		ref := strings.TrimSpace(string(output))
 		return "origin/" + strings.TrimPrefix(ref, "refs/remotes/origin/")
 	} else {
@@ -152,8 +171,7 @@ func GetDefaultBranch(repoPath string) string {
 	}
 	// Fallback: check if "main" or "master" exists.
 	for _, name := range []string{"main", "master"} {
-		cmd := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "refs/heads/"+name)
-		if cmd.Run() == nil {
+		if gitRun("-C", repoPath, "rev-parse", "--verify", "refs/heads/"+name) == nil {
 			return name
 		}
 	}
@@ -163,14 +181,12 @@ func GetDefaultBranch(repoPath string) string {
 
 // IsWorktree returns true if the given path is a git worktree (not the main repo).
 func IsWorktree(repoPath string) bool {
-	gitDir := exec.Command("git", "-C", repoPath, "rev-parse", "--git-dir")
-	gitDirOut, err := gitDir.Output()
+	gitDirOut, err := gitOutput("-C", repoPath, "rev-parse", "--git-dir")
 	if err != nil {
 		return false
 	}
 
-	commonDir := exec.Command("git", "-C", repoPath, "rev-parse", "--git-common-dir")
-	commonDirOut, err := commonDir.Output()
+	commonDirOut, err := gitOutput("-C", repoPath, "rev-parse", "--git-common-dir")
 	if err != nil {
 		return false
 	}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -12,8 +11,7 @@ import (
 // "<host>/<path>". Repos with no remote — or any parse failure — fall back to
 // "local:<basename>" so they remain distinct groups keyed off the folder name.
 func GetOriginKey(repoPath string) string {
-	cmd := exec.Command("git", "-C", repoPath, "config", "--get", "remote.origin.url")
-	out, err := cmd.Output()
+	out, err := gitOutput("-C", repoPath, "config", "--get", "remote.origin.url")
 	if err != nil {
 		return "local:" + filepath.Base(repoPath)
 	}

--- a/internal/git/repo_info.go
+++ b/internal/git/repo_info.go
@@ -49,7 +49,13 @@ func RefreshPRInfo(info *RepoInfo, repoPath string, ignorePatterns []string) {
 		return
 	}
 	if err != nil {
-		debuglog.Logger.Debug("RefreshPRInfo failed", "path", repoPath, "branch", info.Branch, "error", err)
+		// Transient failure (e.g. gh timed out). Keep the cached PR badge —
+		// info.PR was carried forward by the caller — instead of overwriting it
+		// with nil. Still stamp LastPRRefresh so the TTL gate applies and we
+		// don't re-fire gh every cycle while it's slow.
+		debuglog.Logger.Debug("RefreshPRInfo failed; keeping cached PR", "path", repoPath, "branch", info.Branch, "error", err)
+		info.LastPRRefresh = time.Now()
+		return
 	}
 	info.PR = pr
 	info.LastPRRefresh = time.Now()

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -104,6 +104,15 @@ func GetPRForBranch(repoPath, branch string, ignorePatterns []string) (*PR, erro
 	cmd.Stderr = &stderr
 	output, err := cmd.Output()
 	if err != nil {
+		// A deadline-exceeded error means gh hung and we killed it — a transient
+		// failure, NOT "no PR for this branch". gh also leaves stderr empty on the
+		// kill, so without this it would fall through to (nil, nil) below and let
+		// RefreshPRInfo clear a real PR's badge. Return an error so the caller
+		// keeps the cached badge.
+		if ctx.Err() == context.DeadlineExceeded {
+			debuglog.Logger.Debug("PR fetch: timed out", "path", repoPath, "branch", branch)
+			return nil, fmt.Errorf("gh pr view timed out: %w", ctx.Err())
+		}
 		stderrStr := strings.TrimSpace(stderr.String())
 		if rlErr := classifyGHError(stderrStr); rlErr != nil {
 			debuglog.Logger.Debug("PR fetch: rate-limited", "path", repoPath, "branch", branch, "stderr", stderrStr)

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -2,15 +2,24 @@ package github
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os/exec"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/brizzai/fleet/internal/debuglog"
 )
+
+// ghTimeout bounds every gh subprocess. gh makes network calls to GitHub, so a
+// hung request (network stall, API hang, blocked auth refresh) must not freeze
+// the caller. The status worker waits synchronously on these during its
+// per-cycle PR fan-out, so one indefinite gh call would stall every session's
+// status update until the OS finally tore the connection down.
+const ghTimeout = 15 * time.Second
 
 // ErrRateLimited is returned when gh reports a GitHub API rate-limit error.
 // Callers use this to back off subsequent PR refreshes instead of hammering
@@ -45,8 +54,9 @@ type PR struct {
 
 // IsGHAvailable checks if the gh CLI is installed and accessible.
 func IsGHAvailable() bool {
-	cmd := exec.Command("gh", "--version")
-	return cmd.Run() == nil
+	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "gh", "--version").Run() == nil
 }
 
 // ghPRResponse matches the JSON output of gh pr view.
@@ -84,7 +94,9 @@ func GetPRForBranch(repoPath, branch string, ignorePatterns []string) (*PR, erro
 
 	debuglog.Logger.Debug("PR fetch: start", "path", repoPath, "branch", branch)
 
-	cmd := exec.Command("gh", "pr", "view", branch,
+	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", branch,
 		"--json", "number,title,url,state,reviewDecision,statusCheckRollup,mergeable,isDraft",
 	)
 	cmd.Dir = repoPath
@@ -147,7 +159,9 @@ func getUnresolvedThreadCount(repoPath string, prNumber int, prURL string) int {
 		}
 	}`, owner, repo, prNumber)
 
-	cmd := exec.Command("gh", "api", "graphql", "-f", "query="+query)
+	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query)
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
@@ -1581,7 +1582,9 @@ func GetRepoRoot(projectPath string) string {
 	}
 	repoRootCacheMu.RUnlock()
 
-	cmd := exec.Command("git", "-C", projectPath, "rev-parse", "--show-toplevel")
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", projectPath, "rev-parse", "--show-toplevel")
 	output, err := cmd.Output()
 	root := projectPath
 	if err == nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -216,6 +216,15 @@ type Home struct {
 	statusRRIndex    int       // round-robin index for status updates
 	lastHeavyCycleAt time.Time // wall-clock gate: heavy worker work runs at most every tickInterval
 
+	// Status-worker liveness stamps (unix-nano), written by statusWorkerCycle and
+	// read lock-free by the snapshot + the dev-only watchdog. lastWorkerCycleNano
+	// is the last COMPLETED cycle; workerCycleStartNano is the in-flight cycle's
+	// start (0 when idle). A stale lastWorkerCycleNano means the worker wedged —
+	// the failure mode where every session's status freezes while the UI stays
+	// responsive (it waits synchronously on the per-cycle git+PR fan-out).
+	lastWorkerCycleNano  atomic.Int64
+	workerCycleStartNano atomic.Int64
+
 	// lastTmuxStatusBar tracks the most recent (status, theme) tuple applied
 	// to each session's tmux status bar so the worker can skip no-op
 	// re-applies. Map is only read/written from the worker goroutine — no
@@ -1802,8 +1811,9 @@ func (h *Home) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return h, nil
 		}
 		h.actionLog.Add("status snapshot", s.Title, true)
+		hb := h.workerHeartbeat()
 		return h, func() tea.Msg {
-			return captureStatusSnapshot(s, s.ID)
+			return captureStatusSnapshot(s, s.ID, hb)
 		}
 	case "?":
 		h.helpOverlay.Show()
@@ -3420,6 +3430,13 @@ func (h *Home) splashTick() tea.Cmd {
 // statusWorker runs in its own goroutine, performing all blocking I/O
 // (tmux, git, gh) outside the Bubble Tea Update() loop.
 func (h *Home) statusWorker() {
+	// Dev-only watchdog: auto-dumps goroutine stacks if this worker ever stops
+	// completing cycles. Gated to `make run` (version=="dev") builds — it's a
+	// debugging aid, not something to run on user machines.
+	if h.version == "dev" {
+		go h.workerWatchdog()
+	}
+
 	ticker := time.NewTicker(activeStatusInterval)
 	defer ticker.Stop()
 
@@ -3603,6 +3620,16 @@ func (h *Home) seedActiveCaptures(active []*session.Session) {
 }
 
 func (h *Home) statusWorkerCycle() {
+	// Liveness stamps for the snapshot + watchdog. Registered first so it runs
+	// LAST (after the recover below), recording completion even if the body
+	// panics. A healthy worker refreshes lastWorkerCycleNano every ~500ms; a
+	// stale value is the wedge signal.
+	h.workerCycleStartNano.Store(time.Now().UnixNano())
+	defer func() {
+		h.lastWorkerCycleNano.Store(time.Now().UnixNano())
+		h.workerCycleStartNano.Store(0)
+	}()
+
 	// Recover from panics to keep the worker alive.
 	defer func() {
 		if r := recover(); r != nil {
@@ -3792,6 +3819,68 @@ drainPriority:
 	// value are skipped — a single tmux set-option round-trip is fast but
 	// running it for 100 idle sessions every 2s is wasteful.
 	h.refreshTmuxStatusBars(sessions)
+}
+
+// workerStallThreshold is how long the status worker may go without completing a
+// cycle before the dev-only watchdog treats it as wedged and dumps goroutine
+// stacks. Set well above the worst-case bounded cycle (git/gh now time out at
+// 8s/15s, fanned out 4-wide), so it fires only when a call ignores its deadline
+// or a real deadlock occurs — not on a merely slow cycle.
+const workerStallThreshold = 30 * time.Second
+
+// workerWatchdog auto-captures a goroutine dump when the status worker stops
+// completing cycles — the failure mode where every session's status freezes
+// while the UI stays responsive (the worker waits synchronously on its
+// per-cycle git+PR fan-out). Launched only on dev (`make run`) builds.
+func (h *Home) workerWatchdog() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	var dumpedForCycle int64 // lastWorkerCycleNano value we already dumped for
+	for {
+		select {
+		case <-h.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		last := h.lastWorkerCycleNano.Load()
+		if last == 0 {
+			continue // worker hasn't completed its first cycle yet
+		}
+		stalledFor := time.Since(time.Unix(0, last))
+		if stalledFor < workerStallThreshold {
+			continue
+		}
+		// One dump per stall episode: lastWorkerCycleNano is frozen while wedged,
+		// so dump once and wait for it to advance (worker recovered) before arming
+		// again.
+		if last == dumpedForCycle {
+			continue
+		}
+		dumpedForCycle = last
+
+		var cycleStart time.Time
+		if s := h.workerCycleStartNano.Load(); s != 0 {
+			cycleStart = time.Unix(0, s)
+		}
+		dir := writeWorkerStallDump(stalledFor, cycleStart)
+		debuglog.Logger.Warn("status worker stalled — goroutine dump written",
+			"stalled_for", stalledFor.Round(time.Millisecond), "dir", dir)
+	}
+}
+
+// workerHeartbeat snapshots the status worker's liveness stamps for a status
+// snapshot. Reads lock-free atomics, safe from any goroutine.
+func (h *Home) workerHeartbeat() workerHeartbeat {
+	var hb workerHeartbeat
+	if n := h.lastWorkerCycleNano.Load(); n != 0 {
+		hb.LastCycleAt = time.Unix(0, n)
+	}
+	if n := h.workerCycleStartNano.Load(); n != 0 {
+		hb.CycleStartAt = time.Unix(0, n)
+	}
+	return hb
 }
 
 // refreshTmuxStatusBars re-applies the theme + state pill on every session's

--- a/internal/ui/snapshot.go
+++ b/internal/ui/snapshot.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -22,7 +23,14 @@ type statusSnapshotMsg struct {
 	err  error
 }
 
-func captureStatusSnapshot(s *session.Session, sessionID string) statusSnapshotMsg {
+// workerHeartbeat carries the status worker's liveness stamps into a snapshot so
+// "is the worker wedged?" is answerable at a glance, without log archaeology.
+type workerHeartbeat struct {
+	LastCycleAt  time.Time // last completed statusWorkerCycle (zero if none yet)
+	CycleStartAt time.Time // in-flight cycle start (zero when idle)
+}
+
+func captureStatusSnapshot(s *session.Session, sessionID string, hb workerHeartbeat) statusSnapshotMsg {
 	ts := s.GetTmuxSession()
 	if ts == nil {
 		return statusSnapshotMsg{err: fmt.Errorf("no tmux session")}
@@ -71,8 +79,11 @@ func captureStatusSnapshot(s *session.Session, sessionID string) statusSnapshotM
 	_ = os.WriteFile(filepath.Join(snapshotDir, "pane_raw.txt"), []byte(rawPane), 0644)
 	_ = os.WriteFile(filepath.Join(snapshotDir, "pane_clean.txt"), []byte(session.StripANSI(rawPane)), 0644)
 	_ = os.WriteFile(filepath.Join(snapshotDir, "debug_tail.txt"), []byte(debugTail), 0644)
+	// All goroutine stacks — pins exactly what the status worker is blocked on
+	// when its heartbeat (worker block in snapshot.json) shows it stalled.
+	writeGoroutineDump(filepath.Join(snapshotDir, "goroutines.txt"))
 
-	meta := buildSnapshotJSON(snap, hookFileContent, hookFileInfo, now, claudeLog)
+	meta := buildSnapshotJSON(snap, hookFileContent, hookFileInfo, now, claudeLog, hb)
 	jsonData, _ := json.MarshalIndent(meta, "", "  ")
 	_ = os.WriteFile(filepath.Join(snapshotDir, "snapshot.json"), jsonData, 0644)
 
@@ -81,7 +92,7 @@ func captureStatusSnapshot(s *session.Session, sessionID string) statusSnapshotM
 	return statusSnapshotMsg{path: snapshotDir}
 }
 
-func buildSnapshotJSON(snap session.StatusSnapshot, hookFileRaw []byte, hookFileInfo os.FileInfo, now time.Time, claudeLog map[string]any) map[string]any {
+func buildSnapshotJSON(snap session.StatusSnapshot, hookFileRaw []byte, hookFileInfo os.FileInfo, now time.Time, claudeLog map[string]any, hb workerHeartbeat) map[string]any {
 	m := map[string]any{
 		"captured_at": now.Format(time.RFC3339Nano),
 		"session": map[string]any{
@@ -97,6 +108,22 @@ func buildSnapshotJSON(snap session.StatusSnapshot, hookFileRaw []byte, hookFile
 	if claudeLog != nil {
 		m["claude_log"] = claudeLog
 	}
+
+	// Worker liveness. `stalled: true` (or a large last_cycle_ago) means the
+	// status worker wedged — the on-screen status is frozen, not mis-detected.
+	// goroutines.txt then shows exactly where it's blocked.
+	worker := map[string]any{}
+	if hb.LastCycleAt.IsZero() {
+		worker["last_cycle_at"] = nil
+	} else {
+		worker["last_cycle_at"] = hb.LastCycleAt.Format(time.RFC3339Nano)
+		worker["last_cycle_ago"] = fmtSnapshotAge(hb.LastCycleAt, now)
+		worker["stalled"] = now.Sub(hb.LastCycleAt) > workerStallThreshold
+	}
+	if !hb.CycleStartAt.IsZero() {
+		worker["cycle_in_flight_for"] = fmtSnapshotAge(hb.CycleStartAt, now)
+	}
+	m["worker"] = worker
 
 	hookMap := map[string]any{
 		"status":        snap.HookStatus,
@@ -130,6 +157,53 @@ func buildSnapshotJSON(snap session.StatusSnapshot, hookFileRaw []byte, hookFile
 	}
 
 	return m
+}
+
+// writeGoroutineDump writes every goroutine's stack to path. Used by the D-key
+// snapshot and the worker-stall watchdog to pin a wedged status worker.
+func writeGoroutineDump(path string) {
+	buf := make([]byte, 1<<20) // 1 MiB; grow until the full dump fits
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			buf = buf[:n]
+			break
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+	// 0600: goroutine stacks are user-private (may embed paths/args).
+	_ = os.WriteFile(path, buf, 0600)
+}
+
+// writeWorkerStallDump is the dev-only watchdog's output: a goroutine dump plus
+// a small stall.json, written under the snapshots dir so the debug-status /
+// debug-perf skills discover it alongside manual snapshots. Returns the dir, or
+// "" on failure.
+func writeWorkerStallDump(stalledFor time.Duration, cycleStart time.Time) string {
+	now := time.Now()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(home, ".config", "fleet", "snapshots",
+		now.Format("2006-01-02T15-04-05")+"_worker-stall")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return ""
+	}
+
+	writeGoroutineDump(filepath.Join(dir, "goroutines.txt"))
+
+	meta := map[string]any{
+		"captured_at": now.Format(time.RFC3339Nano),
+		"reason":      "status worker stall",
+		"stalled_for": stalledFor.Round(time.Millisecond).String(),
+	}
+	if !cycleStart.IsZero() {
+		meta["cycle_in_flight_for"] = now.Sub(cycleStart).Round(time.Millisecond).String()
+	}
+	data, _ := json.MarshalIndent(meta, "", "  ")
+	_ = os.WriteFile(filepath.Join(dir, "stall.json"), data, 0644)
+	return dir
 }
 
 func fmtSnapshotAge(t time.Time, now time.Time) string {


### PR DESCRIPTION
## Problem

A session showed `running` for ~12 minutes when it was genuinely `waiting`. Tracing it revealed this is **not a status-detection bug** — the detection was correct, it just wasn't being called.

The decisive evidence: three unrelated sessions all flushed their pending status within **11ms** of each other, with hook ages of **1m45s, 17m23s, and 12m16s**. A single burst draining a multi-minute backlog across sessions = the background status worker goroutine **stalled, then resumed**. The UI stayed responsive the whole time (the `D`-key snapshot worked).

## Root cause

`UpdateStatus()` runs only on the `statusWorker` goroutine. Its heavy cycle calls `refreshAllGitAndPR(repos, 4, 0, nil)` with `deadline=0`, which runs `dispatchAndWait()` **synchronously**, ending in `wg.Wait()`. The per-repo goroutines run `git`/`gh` execs that had **no timeouts** — so one hung `gh` call (network stall, blocked auth) meant `wg.Done()` never fired, `wg.Wait()` blocked forever, and the entire worker (every session's status) froze until the OS finally tore the connection down (~18 min).

## Fix

- **git/gh timeouts (the actual fix):** wrap all git execs at 8s (`git.go` `gitOutput`/`gitRun`, `remote.go`, `session.go` `GetRepoRoot`) and gh execs at 15s (`pr.go` `ghTimeout`). A hung call now errors in bounded time, so the cycle always completes. `tmux` calls already had timeouts; git/gh were the gap.
- **Worker heartbeat in snapshots:** `lastWorkerCycleNano`/`workerCycleStartNano` atomics stamped in `statusWorkerCycle`. The `D`-key snapshot now emits a `worker` block in `snapshot.json` (`last_cycle_ago`, `stalled`) + a `goroutines.txt` dump — so a worker stall is a one-glance diagnosis next time.
- **Dev-only watchdog:** `workerWatchdog` launches **only when `version=="dev"`** (i.e. `make run`; released builds get a real semver and never run it). If a cycle doesn't complete for 30s it auto-writes a `<ts>_worker-stall/` snapshot dir with a goroutine dump — no need to be quick on the `D` key.

## Testing

- `make build` clean, `go vet` clean
- `go test -race ./internal/session/...` (status detection suite) + `github`/`ui` tests pass

## Not changed (flagged)

The worker still does its git/PR fan-out with `deadline=0` (synchronous `wg.Wait()`). The per-call timeouts now bound it; a whole-fan-out deadline would be belt-and-suspenders but wasn't needed to fix the stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session statuses no longer freeze when `git` or `gh` hang; subprocess calls now time out (8s for git, 15s for gh) to keep the background worker responsive.
  * PR info refresh now preserves cached PR data on transient GitHub errors instead of clearing it.

* **New Features**
  * Status snapshots now include worker liveness and produce goroutine dump files for improved diagnostics; a dev-only watchdog captures stall information.

* **Chores**
  * Updated changelog for unreleased changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->