### PR TITLE
fix(status): false-finish on stale waiting hook; fork-of-fork re-forking ancestor

### DIFF
--- a/changelog/unreleased/fork-of-fork.md
+++ b/changelog/unreleased/fork-of-fork.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Forking a session that was itself forked now correctly forks that session, not its original ancestor — a forked session reliably adopts its own conversation id once it diverges.

--- a/changelog/unreleased/status-waiting-active-transcript.md
+++ b/changelog/unreleased/status-waiting-active-transcript.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Sessions no longer briefly show "finished" while the agent is actively working after a granted permission prompt — fleet now checks the conversation transcript to confirm the turn really ended.

--- a/changelog/unreleased/status-waiting-active-transcript.md
+++ b/changelog/unreleased/status-waiting-active-transcript.md
@@ -1,4 +1,4 @@
 ---
 type: fixed
 ---
-Sessions no longer briefly show "finished" while the agent is actively working — whether after a granted permission prompt or during a long resumed turn — fleet now checks the conversation transcript to confirm the turn really ended.
+Sessions no longer show a stale "waiting" or "finished" state while the agent is actively working — after a granted permission prompt, an answered question, or during a long resumed turn. fleet now consults the conversation transcript to confirm whether the turn actually resumed or ended.

--- a/changelog/unreleased/status-waiting-active-transcript.md
+++ b/changelog/unreleased/status-waiting-active-transcript.md
@@ -1,4 +1,4 @@
 ---
 type: fixed
 ---
-Sessions no longer briefly show "finished" while the agent is actively working after a granted permission prompt — fleet now checks the conversation transcript to confirm the turn really ended.
+Sessions no longer briefly show "finished" while the agent is actively working — whether after a granted permission prompt or during a long resumed turn — fleet now checks the conversation transcript to confirm the turn really ended.

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -329,52 +329,15 @@ func transcriptContainsUUID(path, uuid string) bool {
 // firstTranscriptTimestamp returns the timestamp of the earliest timestamped JSONL
 // entry in the transcript at path, or the zero time if it's missing/unreadable or
 // has no timestamped entries.
-func firstTranscriptTimestamp(path string) time.Time { return scanTranscriptTimestamp(path, false) }
+func firstTranscriptTimestamp(path string) time.Time {
+	return scanTranscriptTimestamp(path, false, false)
+}
 
 // lastTranscriptTimestamp returns the timestamp of the latest timestamped JSONL
 // entry in the transcript at path, or the zero time. It scans the whole file;
 // transcripts are small and this runs only on the rare session-id-change path.
-func lastTranscriptTimestamp(path string) time.Time { return scanTranscriptTimestamp(path, true) }
-
-// scanTranscriptTimestamp walks the JSONL transcript at path and returns the
-// first (last=false) or last (last=true) entry timestamp it can parse.
-func scanTranscriptTimestamp(path string, last bool) time.Time {
-	if path == "" {
-		return time.Time{}
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return time.Time{}
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max line
-
-	var result time.Time
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.Contains(line, `"timestamp"`) {
-			continue
-		}
-		var entry struct {
-			Timestamp string `json:"timestamp"`
-		}
-		if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Timestamp == "" {
-			continue
-		}
-		// RFC3339Nano: Claude transcripts stamp millisecond precision (e.g.
-		// "...:04.226Z"). The layout also parses entries with no fractional part.
-		ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp)
-		if err != nil {
-			continue
-		}
-		if !last {
-			return ts
-		}
-		result = ts
-	}
-	return result
+func lastTranscriptTimestamp(path string) time.Time {
+	return scanTranscriptTimestamp(path, true, false)
 }
 
 // lastLeadTranscriptTimestamp returns the timestamp of the last lead-conversation
@@ -384,6 +347,13 @@ func scanTranscriptTimestamp(path string, last bool) time.Time {
 // out-of-pane tiebreaker for the between-bursts frame where the pane is
 // indistinguishable from finished (see conversationActivePastHook).
 func lastLeadTranscriptTimestamp(path string) time.Time {
+	return scanTranscriptTimestamp(path, true, true)
+}
+
+// scanTranscriptTimestamp walks the JSONL transcript at path and returns the first
+// (last=false) or last (last=true) entry timestamp it can parse. When excludeSidechain
+// is set, sub-agent (isSidechain:true) entries are skipped.
+func scanTranscriptTimestamp(path string, last bool, excludeSidechain bool) time.Time {
 	if path == "" {
 		return time.Time{}
 	}
@@ -409,12 +379,17 @@ func lastLeadTranscriptTimestamp(path string) time.Time {
 		if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Timestamp == "" {
 			continue
 		}
-		if entry.IsSidechain {
+		if excludeSidechain && entry.IsSidechain {
 			continue
 		}
+		// RFC3339Nano: Claude transcripts stamp millisecond precision (e.g.
+		// "...:04.226Z"). The layout also parses entries with no fractional part.
 		ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp)
 		if err != nil {
 			continue
+		}
+		if !last {
+			return ts
 		}
 		result = ts
 	}

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -376,3 +376,47 @@ func scanTranscriptTimestamp(path string, last bool) time.Time {
 	}
 	return result
 }
+
+// lastLeadTranscriptTimestamp returns the timestamp of the last lead-conversation
+// (non-sidechain) entry in the transcript at path, or the zero time if it's
+// missing/unreadable or has no such entries. Sub-agent (sidechain) entries are
+// skipped so a still-running sub-agent can't mask a finished lead turn. Used as the
+// out-of-pane tiebreaker for the between-bursts frame where the pane is
+// indistinguishable from finished (see conversationActivePastHook).
+func lastLeadTranscriptTimestamp(path string) time.Time {
+	if path == "" {
+		return time.Time{}
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return time.Time{}
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max line
+
+	var result time.Time
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, `"timestamp"`) {
+			continue
+		}
+		var entry struct {
+			Timestamp   string `json:"timestamp"`
+			IsSidechain bool   `json:"isSidechain"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Timestamp == "" {
+			continue
+		}
+		if entry.IsSidechain {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp)
+		if err != nil {
+			continue
+		}
+		result = ts
+	}
+	return result
+}

--- a/internal/session/claude_name_test.go
+++ b/internal/session/claude_name_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestClaudeProjectDirName(t *testing.T) {
@@ -395,4 +396,49 @@ func TestDeslugify(t *testing.T) {
 			t.Errorf("deslugify(%q) = %q, want %q", in, got, want)
 		}
 	}
+}
+
+func TestLastLeadTranscriptTimestamp(t *testing.T) {
+	t.Run("returns last lead entry, skipping sidechain", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "t.jsonl")
+		content := strings.Join([]string{
+			`{"type":"user","timestamp":"2026-06-16T11:25:00.000Z"}`,
+			`{"type":"assistant","timestamp":"2026-06-16T11:26:00.000Z"}`,
+			// A sub-agent (sidechain) entry AFTER the last lead entry must be ignored.
+			`{"type":"assistant","isSidechain":true,"timestamp":"2026-06-16T11:30:00.000Z"}`,
+		}, "\n") + "\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got := lastLeadTranscriptTimestamp(path)
+		want, _ := time.Parse(time.RFC3339Nano, "2026-06-16T11:26:00.000Z")
+		if !got.Equal(want) {
+			t.Errorf("lastLeadTranscriptTimestamp = %v, want %v (sidechain entry should be skipped)", got, want)
+		}
+	})
+
+	t.Run("missing file returns zero", func(t *testing.T) {
+		if got := lastLeadTranscriptTimestamp(filepath.Join(t.TempDir(), "nope.jsonl")); !got.IsZero() {
+			t.Errorf("expected zero time for missing file, got %v", got)
+		}
+	})
+
+	t.Run("empty path returns zero", func(t *testing.T) {
+		if got := lastLeadTranscriptTimestamp(""); !got.IsZero() {
+			t.Errorf("expected zero time for empty path, got %v", got)
+		}
+	})
+
+	t.Run("only sidechain entries returns zero", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "t.jsonl")
+		content := `{"type":"assistant","isSidechain":true,"timestamp":"2026-06-16T11:30:00.000Z"}` + "\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := lastLeadTranscriptTimestamp(path); !got.IsZero() {
+			t.Errorf("expected zero time when all entries are sidechain, got %v", got)
+		}
+	})
 }

--- a/internal/session/ownership_test.go
+++ b/internal/session/ownership_test.go
@@ -146,6 +146,45 @@ func TestUpdateHookStatusAdoptsForkDivergence(t *testing.T) {
 	}
 }
 
+// Review issue #2a: clearHookState() must clear forkParentID. Restart()/RespawnClaude()
+// call clearHookState() without going through Start() (the only place forkParentID is
+// set), so an un-diverged fork that survives a restart and resumes the parent id would
+// otherwise re-claim owner==forkParent and re-arm the unconditional fork-adoption branch —
+// the next foreign hook (incl. a nested child) would then be force-adopted.
+func TestClearHookStateClearsForkParent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	proj := t.TempDir()
+
+	// Un-diverged fork: launched as a fork of parent-aaa, claimed the parent's id at
+	// SessionStart, never diverged (no first prompt yet).
+	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning, forkParentID: "parent-aaa", ownerSessionID: "parent-aaa"}
+
+	s.clearHookState()
+	if s.forkParentID != "" {
+		t.Fatalf("clearHookState should clear forkParentID, got %q", s.forkParentID)
+	}
+
+	// After a restart the session re-claims the parent id on its next SessionStart
+	// (owner was cleared). A nested child firing inside the old pre-divergence window
+	// must NOT be force-adopted now that the fork link is gone.
+	base := time.Now().Add(-time.Hour).UTC()
+	writeTranscript(t, proj, "parent-aaa", base, base.Add(30*time.Minute))
+	s.UpdateHookStatus(&HookStatus{Status: "finished", SessionID: "parent-aaa", UpdatedAt: time.Now()}, true)
+	if s.ClaudeSessionID != "parent-aaa" {
+		t.Fatalf("re-claim parent: ClaudeSessionID=%q, want parent-aaa", s.ClaudeSessionID)
+	}
+
+	// Nested child: fresh transcript, no descent from the parent (10min gap, no parent
+	// link) → both rotation signals miss → must be rejected, not adopted.
+	writeTranscript(t, proj, "nested-ccc", base.Add(40*time.Minute), base.Add(41*time.Minute))
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "nested-ccc", UpdatedAt: time.Now()}, true); changed {
+		t.Errorf("nested child after restart should be ignored, not adopted")
+	}
+	if s.ClaudeSessionID != "parent-aaa" {
+		t.Errorf("nested child clobbered id after restart: %q, want parent-aaa", s.ClaudeSessionID)
+	}
+}
+
 // writeTranscriptRaw writes arbitrary JSONL lines for a session under the
 // HOME-rooted projects dir, for tests that need uuid / compact_boundary entries.
 func writeTranscriptRaw(t *testing.T, projectPath, sessionID string, lines ...string) {

--- a/internal/session/ownership_test.go
+++ b/internal/session/ownership_test.go
@@ -96,6 +96,56 @@ func TestUpdateHookStatusIgnoresNestedChild(t *testing.T) {
 	}
 }
 
+// TestUpdateHookStatusAdoptsForkDivergence reproduces the fork-of-a-fork bug: a
+// `claude --resume <parent> --fork-session` reports the PARENT's id at SessionStart
+// and only switches to its own id on the first prompt. The fork transcript copies
+// the parent's history verbatim (same OLD first timestamp) and carries no
+// logicalParentUuid, so BOTH isSessionRotation signals miss — leaving the fork
+// pinned to the parent id, so forking it re-forks the parent. With forkParentID
+// known, the fork's own id must be adopted deterministically.
+func TestUpdateHookStatusAdoptsForkDivergence(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	proj := t.TempDir()
+
+	// Parent A: a >10s conversation (so the proximity fallback can't bridge it).
+	base := time.Now().Add(-time.Hour).UTC()
+	writeTranscript(t, proj, "parent-aaa", base, base.Add(30*time.Minute))
+	// Fork B: copies the parent's history verbatim — same OLD first timestamp, no
+	// logicalParentUuid — exactly what --fork-session writes. Both rotation signals miss.
+	writeTranscript(t, proj, "fork-bbb", base, base.Add(31*time.Minute))
+
+	// Session launched as a fork of parent-aaa (forkParentID is set by Start()).
+	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning, forkParentID: "parent-aaa"}
+
+	// SessionStart reports the PARENT's id (the fork hasn't diverged yet).
+	s.UpdateHookStatus(&HookStatus{Status: "finished", SessionID: "parent-aaa", UpdatedAt: time.Now()}, true)
+	if s.ClaudeSessionID != "parent-aaa" {
+		t.Fatalf("pre-divergence: ClaudeSessionID=%q, want parent-aaa", s.ClaudeSessionID)
+	}
+
+	// First prompt: the fork diverges to its OWN id. Must be adopted (forking this
+	// session should now use fork-bbb, not re-fork parent-aaa).
+	changed := s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "fork-bbb", UpdatedAt: time.Now()}, true)
+	if !changed {
+		t.Errorf("fork divergence hook should register as changed")
+	}
+	if s.ClaudeSessionID != "fork-bbb" {
+		t.Errorf("fork id not adopted: ClaudeSessionID=%q, want fork-bbb (forking it would re-fork the parent)", s.ClaudeSessionID)
+	}
+	if s.forkParentID != "" {
+		t.Errorf("forkParentID should be cleared after divergence, got %q", s.forkParentID)
+	}
+
+	// After divergence the fork link is gone, so a genuine nested child is ignored again.
+	writeTranscript(t, proj, "nested-ccc", base.Add(40*time.Minute), base.Add(41*time.Minute))
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "nested-ccc", UpdatedAt: time.Now()}, true); changed {
+		t.Errorf("post-divergence nested child should be ignored")
+	}
+	if s.ClaudeSessionID != "fork-bbb" {
+		t.Errorf("nested child clobbered fork id: %q, want fork-bbb", s.ClaudeSessionID)
+	}
+}
+
 // writeTranscriptRaw writes arbitrary JSONL lines for a session under the
 // HOME-rooted projects dir, for tests that need uuid / compact_boundary entries.
 func writeTranscriptRaw(t *testing.T, projectPath, sessionID string, lines ...string) {

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -37,6 +37,7 @@ type ScenarioEvent struct {
 	Acknowledge bool          // simulate user acknowledging the session
 	ActivityAge time.Duration // simulate tmux window_activity this long ago (0 = no activity data)
 	HookAge     time.Duration // backdate the hook's UpdatedAt by this much (0 = now); simulates a stale hook
+	ConvActive  *bool         // inject conversationActivePastHook result; nil = leave unchanged
 }
 
 // ScenarioCheck asserts the session status at a point in time.
@@ -67,12 +68,16 @@ func runScenario(t *testing.T, sc Scenario) {
 	debuglog.Init()
 
 	mock := &mockPane{alive: true}
+	// Transcript tiebreaker stub: events flip this via ConvActive; the closure is
+	// read on the single test goroutine, so no synchronization is needed.
+	convActive := false
 	s := &Session{
 		ID:           "test-scenario",
 		Title:        sc.Name,
 		Status:       StatusStarting,
 		Agent:        sc.Agent,
 		paneCapturer: mock,
+		convActiveFn: func() bool { return convActive },
 	}
 
 	// Build sorted timeline.
@@ -130,6 +135,11 @@ func runScenario(t *testing.T, sc Scenario) {
 				s.mu.Lock()
 				s.Acknowledged = true
 				s.mu.Unlock()
+			}
+
+			// Inject the transcript tiebreaker result.
+			if e.ConvActive != nil {
+				convActive = *e.ConvActive
 			}
 
 			// Adjust content timing for stability checks.
@@ -479,6 +489,49 @@ func TestScenarioStaleOverriddenWaitingSettlesFinished(t *testing.T) {
 			{At: 0, Expected: StatusFinished},               // override to finished
 			{At: 2 * time.Second, Expected: StatusRunning},  // pane-driven resume
 			{At: 4 * time.Second, Expected: StatusFinished}, // must settle back — was stuck running
+		},
+	})
+}
+
+func TestScenarioStaleWaitingConversationActiveStaysRunning(t *testing.T) {
+	// The reported bug: a permission prompt was granted (no hook fires), the agent
+	// resumed, but the hook is still "waiting". Modern Claude keeps the ❯ box on
+	// screen while working, so a between-bursts frame (activity line momentarily gone)
+	// reads as a finished idle prompt and used to flip the session to finished. The
+	// transcript tiebreaker (ConvActive) proves the lead turn is still appending past
+	// the hook → stay running. HookAge backdates the hook so trustPane engages (the
+	// real bug had a >1m stale hook).
+	runScenario(t, Scenario{
+		Name: "stale waiting hook + active transcript: between-bursts idle frames stay running",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "waiting", SessionID: "owner-aaa", HookAge: 90 * time.Second, Pane: "@fixture:pane_finished_idle_prompt.txt", ConvActive: new(true)},
+			// Another between-bursts idle frame — transcript still active.
+			{At: 2 * time.Second, Pane: "@fixture:pane_finished_idle_prompt.txt"},
+			// Activity line back on screen; pane reads running.
+			{At: 4 * time.Second, Pane: "@fixture:pane_running_extended_thinking.txt"},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusRunning},               // override suppressed by tiebreaker
+			{At: 2 * time.Second, Expected: StatusRunning}, // stays running; hookOverriddenAt never set
+			{At: 4 * time.Second, Expected: StatusRunning}, // running frame still reports running
+		},
+	})
+}
+
+func TestScenarioStaleWaitingConversationIdleSettlesFinished(t *testing.T) {
+	// Guard for the fix above: when the transcript is NOT active past the hook (the
+	// turn genuinely ended, e.g. a dropped Stop hook), the idle-prompt pane must still
+	// override the stale waiting hook to finished — no regression to
+	// TestScenarioStaleOverriddenWaitingSettlesFinished.
+	runScenario(t, Scenario{
+		Name: "stale waiting hook + idle transcript: still settles to finished",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "waiting", SessionID: "owner-aaa", Pane: "@fixture:pane_finished_idle_prompt.txt", ConvActive: new(false)},
+			{At: 2 * time.Second, Pane: "@fixture:pane_finished_idle_prompt.txt"},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusFinished},
+			{At: 2 * time.Second, Expected: StatusFinished},
 		},
 	})
 }

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -574,6 +574,28 @@ func TestScenarioStaleFinishedConversationIdleSettlesFinished(t *testing.T) {
 	})
 }
 
+func TestScenarioOverriddenWaitingTranscriptUnlatchesRunning(t *testing.T) {
+	// Review issue #3: the override latches. On the first finished frame the transcript
+	// tiebreaker was momentarily false (resumed lead entry not yet flushed, or within the
+	// skew), so applyHookWaiting settled finished and set hookOverriddenAt. A granted
+	// permission fires no new hook, so every later tick then took the overridden branch —
+	// which didn't consult convActive — and kept settling finished for the rest of the
+	// turn. The fix re-checks the tiebreaker at the top of the overridden branch: once the
+	// lead entry flushes past the hook, the session recovers to running.
+	runScenario(t, Scenario{
+		Name: "overridden waiting hook recovers to running when the transcript goes active",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "waiting", SessionID: "owner-aaa", Pane: "@fixture:pane_finished_idle_prompt.txt", ConvActive: new(false)},
+			// Same hook (a grant fires no new event); transcript now shows the lead resumed.
+			{At: 2 * time.Second, Pane: "@fixture:pane_finished_idle_prompt.txt", ConvActive: new(true)},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusFinished},              // latched finished on the momentarily-false frame
+			{At: 2 * time.Second, Expected: StatusRunning}, // overridden branch re-checks tiebreaker → recovers
+		},
+	})
+}
+
 func TestScenarioStaleWaitingTranscriptResumesRunning(t *testing.T) {
 	// The original stuck-on-waiting bug: an auto-approved permission fires no resume
 	// hook, the agent resumes a long turn, but the pane never reads running (the
@@ -592,8 +614,8 @@ func TestScenarioStaleWaitingTranscriptResumesRunning(t *testing.T) {
 			{At: 20 * time.Second, Pane: ambiguous, ConvActive: new(true)},
 		},
 		Checks: []ScenarioCheck{
-			{At: 0, Expected: StatusWaiting},                 // trust the hook; pane gives no signal
-			{At: 20 * time.Second, Expected: StatusRunning},  // was stuck at waiting; transcript flips it
+			{At: 0, Expected: StatusWaiting},                // trust the hook; pane gives no signal
+			{At: 20 * time.Second, Expected: StatusRunning}, // was stuck at waiting; transcript flips it
 		},
 	})
 }

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -574,6 +574,30 @@ func TestScenarioStaleFinishedConversationIdleSettlesFinished(t *testing.T) {
 	})
 }
 
+func TestScenarioStaleWaitingTranscriptResumesRunning(t *testing.T) {
+	// The original stuck-on-waiting bug: an auto-approved permission fires no resume
+	// hook, the agent resumes a long turn, but the pane never reads running (the
+	// activity line is pushed out of the detection window by queued messages / long
+	// output) AND the normalized content hash is stable (spinner stripped) — so neither
+	// the content-drift nor the pane-running flip fires and the session is pinned at
+	// waiting. The same ambiguous pane is used at both ticks (identical hash → no
+	// drift) and the cooldown has expired, so only the transcript tiebreaker can flip
+	// it. detectStatus returns "" for this content (no spinner/menu/❯).
+	ambiguous := "running the build...\ncompiling module foo\ncompiling module bar\n"
+	runScenario(t, Scenario{
+		Name: "stale waiting hook, ambiguous stable pane, transcript resumed → running",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "waiting", SessionID: "owner-aaa", Pane: ambiguous},
+			// 20s later (past the 15s cooldown): same content, transcript now active.
+			{At: 20 * time.Second, Pane: ambiguous, ConvActive: new(true)},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusWaiting},                 // trust the hook; pane gives no signal
+			{At: 20 * time.Second, Expected: StatusRunning},  // was stuck at waiting; transcript flips it
+		},
+	})
+}
+
 func TestScenarioNoHooksFallback(t *testing.T) {
 	runScenario(t, Scenario{
 		Name: "no hooks, pane-only detection",

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -536,6 +536,44 @@ func TestScenarioStaleWaitingConversationIdleSettlesFinished(t *testing.T) {
 	})
 }
 
+func TestScenarioStaleFinishedConversationActiveStaysRunning(t *testing.T) {
+	// Sibling of the waiting-path bug on the finished path: a stale SessionStart/
+	// finished hook (a resume that kicked off one long turn, no Stop since). The pane
+	// usually shows the working spinner (overrides finished→running), but a single
+	// between-bursts frame (spinner gone, only the persistent ❯ box) reads as finished
+	// and used to demote the live turn. The transcript tiebreaker (ConvActive) keeps
+	// it running. HookAge backdates the hook so it's clearly stale.
+	runScenario(t, Scenario{
+		Name: "stale finished hook + active transcript: between-bursts idle frame stays running",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "finished", SessionID: "owner-aaa", HookAge: 11 * time.Minute, Pane: "@fixture:pane_running_extended_thinking.txt"},
+			{At: 2 * time.Second, Pane: "@fixture:pane_finished_idle_prompt.txt", ConvActive: new(true)},
+			{At: 4 * time.Second, Pane: "@fixture:pane_running_extended_thinking.txt"},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusRunning},               // pane spinner overrides finished hook
+			{At: 2 * time.Second, Expected: StatusRunning}, // between-bursts idle frame must NOT demote to finished
+			{At: 4 * time.Second, Expected: StatusRunning},
+		},
+	})
+}
+
+func TestScenarioStaleFinishedConversationIdleSettlesFinished(t *testing.T) {
+	// Guard: when the transcript is NOT active past the finished hook (the turn really
+	// ended), an idle pane must still settle to finished — no regression.
+	runScenario(t, Scenario{
+		Name: "stale finished hook + idle transcript: settles to finished",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "finished", SessionID: "owner-aaa", HookAge: 11 * time.Minute, Pane: "@fixture:pane_running_extended_thinking.txt"},
+			{At: 2 * time.Second, Pane: "@fixture:pane_finished_idle_prompt.txt", ConvActive: new(false)},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusRunning},
+			{At: 2 * time.Second, Expected: StatusFinished},
+		},
+	})
+}
+
 func TestScenarioNoHooksFallback(t *testing.T) {
 	runScenario(t, Scenario{
 		Name: "no hooks, pane-only detection",

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -84,6 +84,15 @@ type Session struct {
 
 	deathRecorded bool // crash dump already written for the current life of this session; reset by Restart
 
+	// Transcript tiebreaker cache. conversationActivePastHook runs on the ~500ms fast
+	// pass for a session held running through a long turn, and lastLeadTranscriptTimestamp
+	// is a full JSONL scan of a growing file. Skip the scan when the transcript is
+	// unchanged since the last read (path+size+mtime match). Guarded by s.mu.
+	convTranscriptPath  string
+	convTranscriptSize  int64
+	convTranscriptMtime time.Time
+	convLeadTimestamp   time.Time
+
 	tmuxSession  *tmux.Session
 	paneCapturer PaneCapturer // optional override for testing; if nil, uses tmuxSession
 	convActiveFn func() bool  // optional override for testing; if nil, reads the real transcript
@@ -220,12 +229,36 @@ func (s *Session) conversationActivePastHook() bool {
 	claudeID := s.ClaudeSessionID
 	projectPath := s.ProjectPath
 	hookUpdatedAt := s.hookUpdatedAt
+	cachePath := s.convTranscriptPath
+	cacheSize := s.convTranscriptSize
+	cacheMtime := s.convTranscriptMtime
+	cacheTS := s.convLeadTimestamp
 	s.mu.RUnlock()
 
 	if agentType == agent.Codex || claudeID == "" {
 		return false
 	}
-	last := lastLeadTranscriptTimestamp(ClaudeTranscriptPath(claudeID, projectPath))
+
+	path := ClaudeTranscriptPath(claudeID, projectPath)
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	// Skip the full JSONL scan when the transcript is unchanged since the last read.
+	// os.Stat is a cheap syscall; the scan only runs when the file actually grew.
+	var last time.Time
+	if path == cachePath && fi.Size() == cacheSize && fi.ModTime().Equal(cacheMtime) {
+		last = cacheTS
+	} else {
+		last = lastLeadTranscriptTimestamp(path)
+		s.mu.Lock()
+		s.convTranscriptPath = path
+		s.convTranscriptSize = fi.Size()
+		s.convTranscriptMtime = fi.ModTime()
+		s.convLeadTimestamp = last
+		s.mu.Unlock()
+	}
 	if last.IsZero() {
 		return false
 	}
@@ -324,7 +357,10 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 				// conversation length, not a handoff gap, and misses for any parent older
 				// than ~10s — leaving the fork pinned to the parent id (so forking it
 				// re-forks the parent). The window where we own the parent id is before
-				// the fork's first turn, so no nested child can race this.
+				// the fork's first turn; clearHookState() clears forkParentID so a restart
+				// can't re-open it. The residual gap — a nested child `claude` that fires a
+				// hook inside that sub-second pre-divergence window — is narrow enough that
+				// we don't pay transcript I/O here to verify descent.
 				debuglog.Logger.Info("adopting forked claude session",
 					"id", s.ID, "parent", owner, "new", hs.SessionID)
 			case negCached:
@@ -493,6 +529,12 @@ func (s *Session) clearHookState() {
 	s.ownerSessionID = ""
 	s.rotRejectOwner = ""
 	s.rotRejectForeign = ""
+	// Clear the fork parent link too. Restart()/RespawnClaude() call this without
+	// going through Start() (the only place forkParentID is set), so without this an
+	// un-diverged fork that resumes the parent id would re-claim owner==forkParent on
+	// its next SessionStart and re-arm the unconditional fork-adoption branch — the
+	// next foreign hook (incl. a nested child) would then be force-adopted.
+	s.forkParentID = ""
 	s.mu.Unlock()
 	hookFile := filepath.Join(hooks.GetHooksDir(), s.ID+".json")
 	if err := os.Remove(hookFile); err != nil && !os.IsNotExist(err) {
@@ -784,6 +826,19 @@ func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, convAc
 	// stale overridden-waiting hook from staying pinned to the last "running" it
 	// saw — e.g. when the real Stop hook was dropped after a session-id rotation.
 	if !s.hookOverriddenAt.IsZero() && s.hookOverriddenAt.Equal(s.hookUpdatedAt) {
+		// The override latches: once hookOverriddenAt is set on a finished frame, no new
+		// hook fires on a permission grant, so without this we'd keep settling finished
+		// for the rest of the turn — even if convActive was only momentarily false on the
+		// frame that latched it (resumed lead entry not yet flushed, or within the skew).
+		// Re-check the transcript tiebreaker first: if the lead turn has since advanced
+		// past the hook, the turn resumed and we recover to running (convActive is
+		// recomputed every tick).
+		if convActive {
+			s.Status = StatusRunning
+			s.Acknowledged = false
+			log.Info("overridden waiting hook but transcript active past hook — resuming")
+			return
+		}
 		switch paneStatus {
 		case StatusRunning:
 			s.Status = StatusRunning

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -636,8 +636,13 @@ func (s *Session) updateStatusFromHook(oldStatus Status, hookStatus string, hook
 	convActive := false
 	switch hookStatus {
 	case "waiting":
-		// Stale waiting hook (granted permission fires no resume hook) + idle pane.
-		if paneStatus == StatusFinished {
+		// Stale waiting hook (a granted permission / answered question fires no resume
+		// hook) where the pane doesn't structurally confirm a prompt — either an idle ❯
+		// box (StatusFinished) or nothing matched ("") because the activity line was
+		// pushed out of the detection window. The transcript decides whether the turn
+		// resumed. Exclude paneStatus==waiting (a real prompt on screen) and ==running
+		// (the pane already flips it) so genuine prompts never read the transcript.
+		if paneStatus != StatusRunning && paneStatus != StatusWaiting {
 			convActive = s.conversationActivePastHook()
 		}
 	case "finished":
@@ -842,6 +847,21 @@ func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, convAc
 
 	s.Status = StatusWaiting
 	s.Acknowledged = false
+
+	// Out-of-pane resume signal. The pane shows no running spinner (the activity line
+	// was pushed out of the detection window by queued messages / long output) AND the
+	// normalized content hash is stable (the spinner is stripped), so neither flip
+	// below can fire — yet the transcript's LEAD turn has advanced past this waiting
+	// hook and is still fresh. The user approved/answered and the lead resumed (no
+	// resume hook fires on a permission grant). Flip to running. Unlike window_activity
+	// (deliberately unused here — a sub-agent keeps it fresh during a genuine prompt),
+	// the LEAD-only transcript stays static while the lead is truly blocked. Don't set
+	// hookOverriddenAt: re-evaluate each tick until a real hook lands or it goes stale.
+	if convActive {
+		s.Status = StatusRunning
+		log.Info("hook=waiting but transcript advanced past hook — assuming running")
+		return
+	}
 
 	if paneContent == "" {
 		return

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -63,6 +63,7 @@ type Session struct {
 	hookUpdatedAt    time.Time
 	hookOverriddenAt time.Time // timestamp of hook that was overridden by pane; prevents re-evaluation of same stale hook
 	ownerSessionID   string    // Claude session_id that owns this fleet session; hooks from other (nested) Claudes are ignored
+	forkParentID     string    // parent's claude session id while this fork hasn't diverged yet; lets us adopt the fork's own id deterministically (cleared on divergence)
 
 	// Negative cache for the rotation check: the last (owner, foreign) pair that
 	// isSessionRotation rejected. A persistent foreign id (a nested-child eval
@@ -151,6 +152,12 @@ func (s *Session) Start() error {
 
 	s.mu.Lock()
 	s.Status = s.initialRunStatus()
+	// Remember the fork parent: a `claude --resume <parent> --fork-session` reports
+	// the PARENT's id at SessionStart and only switches to its own id once it
+	// diverges (first prompt). Keeping the parent id lets UpdateHookStatus adopt the
+	// fork's own id deterministically when it appears, instead of relying on the
+	// transcript heuristic (which can't see a fork). Cleared on divergence.
+	s.forkParentID = s.ForkFromID
 	s.ForkFromID = "" // Clear after first start so restarts use session's own ClaudeSessionID.
 	s.mu.Unlock()
 	debuglog.Logger.Info("session started", "id", s.ID, "title", s.Title)
@@ -300,11 +307,26 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 	if hs.SessionID != "" {
 		s.mu.RLock()
 		owner = s.ownerSessionID
+		forkParent := s.forkParentID
 		projectPath := s.ProjectPath
 		negCached := owner != "" && s.rotRejectOwner == owner && s.rotRejectForeign == hs.SessionID
 		s.mu.RUnlock()
 		if owner != "" && hs.SessionID != owner {
 			switch {
+			case forkParent != "" && owner == forkParent:
+				// This session was forked (`claude --resume <parent> --fork-session`).
+				// Its SessionStart hook reports the PARENT's id; the fork's own id only
+				// appears once it diverges (first prompt). That first id different from
+				// the parent IS this fork's own session, so adopt it directly. We can't
+				// use isSessionRotation here: fork transcripts carry no logicalParentUuid,
+				// and they copy the parent's history verbatim (with the parent's original
+				// timestamps), so the timestamp-handoff check measures the parent's whole
+				// conversation length, not a handoff gap, and misses for any parent older
+				// than ~10s — leaving the fork pinned to the parent id (so forking it
+				// re-forks the parent). The window where we own the parent id is before
+				// the fork's first turn, so no nested child can race this.
+				debuglog.Logger.Info("adopting forked claude session",
+					"id", s.ID, "parent", owner, "new", hs.SessionID)
 			case negCached:
 				return false // already rejected this (owner, foreign) pair
 			case resolveRotation && isSessionRotation(projectPath, owner, hs.SessionID):
@@ -344,6 +366,11 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 			return false
 		}
 		s.ownerSessionID = hs.SessionID
+		// Once we own an id other than the fork parent, the fork has diverged to its
+		// own session — drop the parent link so it can't influence later hooks.
+		if s.forkParentID != "" && hs.SessionID != s.forkParentID {
+			s.forkParentID = ""
+		}
 	}
 
 	changed := s.hookStatus != hs.Status || s.hookUpdatedAt != hs.UpdatedAt

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -85,6 +85,7 @@ type Session struct {
 
 	tmuxSession  *tmux.Session
 	paneCapturer PaneCapturer // optional override for testing; if nil, uses tmuxSession
+	convActiveFn func() bool  // optional override for testing; if nil, reads the real transcript
 	mu           sync.RWMutex
 }
 
@@ -196,6 +197,35 @@ func (s *Session) getCapturer() PaneCapturer {
 		return s.paneCapturer
 	}
 	return s.tmuxSession
+}
+
+// conversationActivePastHook reports whether the Claude conversation transcript
+// shows lead-turn activity that resumed after the current waiting hook — the
+// out-of-pane tiebreaker for the between-bursts frame where the pane is
+// indistinguishable from a finished idle prompt. Claude only; Codex has no Claude
+// transcript. MUST NOT be called while holding s.mu — it does disk I/O.
+func (s *Session) conversationActivePastHook() bool {
+	if s.convActiveFn != nil {
+		return s.convActiveFn()
+	}
+	s.mu.RLock()
+	agentType := s.Agent
+	claudeID := s.ClaudeSessionID
+	projectPath := s.ProjectPath
+	hookUpdatedAt := s.hookUpdatedAt
+	s.mu.RUnlock()
+
+	if agentType == agent.Codex || claudeID == "" {
+		return false
+	}
+	last := lastLeadTranscriptTimestamp(ClaudeTranscriptPath(claudeID, projectPath))
+	if last.IsZero() {
+		return false
+	}
+	// Advanced past the hook (the agent did something after the prompt fired) AND
+	// still fresh (recently appending → mid-turn, not a finished-with-dropped-Stop).
+	return last.After(hookUpdatedAt.Add(conversationActiveSkew)) &&
+		time.Since(last) < conversationActiveWindow
 }
 
 // IsAlive checks if the tmux session exists.
@@ -571,6 +601,16 @@ func (s *Session) updateStatusFromHook(oldStatus Status, hookStatus string, hook
 		paneStatus = detectStatus(paneContent, log)
 	}
 
+	// Out-of-pane tiebreaker for the waiting path: a between-bursts frame (the agent
+	// resumed after a granted permission prompt, but the activity line is momentarily
+	// gone) is indistinguishable from a finished idle prompt, so consult the
+	// transcript. Read here, before the lock — conversationActivePastHook does disk
+	// I/O and must not run under s.mu. Gated to the only frame it matters on.
+	convActive := false
+	if hookStatus == "waiting" && paneStatus == StatusFinished {
+		convActive = s.conversationActivePastHook()
+	}
+
 	hookSaysDead := false
 	func() {
 		s.mu.Lock()
@@ -580,7 +620,7 @@ func (s *Session) updateStatusFromHook(oldStatus Status, hookStatus string, hook
 		case "running":
 			s.applyHookRunning(oldStatus, paneContent, paneStatus, log)
 		case "waiting":
-			s.applyHookWaiting(paneContent, paneStatus, log)
+			s.applyHookWaiting(paneContent, paneStatus, convActive, log)
 		case "finished":
 			s.applyHookFinished(paneStatus, log)
 		case "dead":
@@ -644,6 +684,10 @@ func (s *Session) applyHookRunning(oldStatus Status, paneContent string, paneSta
 	}
 
 	// Content change detection: if content is stable >10s, Claude likely stopped.
+	// Unlike the waiting path, this override is NOT given the transcript tiebreaker
+	// (conversationActivePastHook): it already requires 10s of hash-stable content
+	// AND defers to a fresh tmux window_activity below, so a single between-bursts
+	// frame with the activity line missing can't trip a false finished here.
 	hash := hashContent(normalizeForHash(paneContent))
 	if hash != s.lastContentHash {
 		s.lastContentHash = hash
@@ -682,8 +726,10 @@ func (s *Session) applyHookRunning(oldStatus Status, paneContent string, paneSta
 }
 
 // applyHookWaiting handles hook status "waiting" with content change detection.
+// convActive is the pre-computed transcript tiebreaker (see conversationActivePastHook);
+// it is only meaningful when paneStatus == StatusFinished.
 // Must be called with s.mu held.
-func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, log *slog.Logger) {
+func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, convActive bool, log *slog.Logger) {
 	// If this hook was already overridden by pane detection (stale hook),
 	// skip re-evaluation. A new hook (different timestamp) resets the flag.
 	// The pane stays authoritative for this stale hook: a running spinner means
@@ -723,6 +769,17 @@ func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, log *s
 	// - If user interrupts/escapes, no hook fires — pane override catches this
 	// - Content change detection below handles the gap if hooks are delayed
 	if paneStatus == StatusFinished {
+		if convActive {
+			// Pane reads as a finished idle prompt, but the transcript shows the lead
+			// turn still appending past this waiting hook — modern Claude keeps the ❯
+			// input box on screen while working, and this is a between-bursts frame
+			// where the activity line is momentarily gone. Stay running; do NOT set
+			// hookOverriddenAt so each tick re-evaluates until the turn truly ends.
+			s.Status = StatusRunning
+			s.Acknowledged = false
+			log.Info("hook=waiting, pane idle, but transcript active past hook — staying running")
+			return
+		}
 		// Pane shows idle prompt — user is no longer being prompted.
 		// Preserve idle if already acknowledged to prevent finished↔idle oscillation.
 		if s.Acknowledged {
@@ -834,6 +891,18 @@ const finishedHoldMaxAge = 5 * time.Second
 // leaving render speed and the hook ts's whole-second granularity unable to flip the
 // status prematurely.
 const waitingHookRenderBackstop = 5 * time.Second
+
+// conversationActiveWindow bounds how recent the last lead-conversation transcript
+// entry must be for conversationActivePastHook to count the agent as actively
+// working. Sized above the longest observed gap between lead entries during silent
+// thinking/tool stretches (~80s) so a live agent is never read as finished, while a
+// genuinely dropped Stop hook settles to finished once the transcript ages past it.
+const conversationActiveWindow = 120 * time.Second
+
+// conversationActiveSkew is how far past the waiting hook's timestamp the last lead
+// entry must advance to prove the agent resumed after the hook (not the entry that
+// triggered the hook itself). Matches the snapshot's advanced_past_hook >2s rule.
+const conversationActiveSkew = 2 * time.Second
 
 // applyHookFinished handles hook status "finished" with pane override for active spinners.
 // Must be called with s.mu held.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -628,14 +628,28 @@ func (s *Session) updateStatusFromHook(oldStatus Status, hookStatus string, hook
 		paneStatus = detectStatus(paneContent, log)
 	}
 
-	// Out-of-pane tiebreaker for the waiting path: a between-bursts frame (the agent
-	// resumed after a granted permission prompt, but the activity line is momentarily
-	// gone) is indistinguishable from a finished idle prompt, so consult the
-	// transcript. Read here, before the lock — conversationActivePastHook does disk
-	// I/O and must not run under s.mu. Gated to the only frame it matters on.
+	// Out-of-pane tiebreaker: a between-bursts frame (the agent is working but its
+	// activity line is momentarily gone, so the persistent ❯ box reads as a finished
+	// idle prompt) can't be told from a real finish by pane content alone. Consult
+	// the transcript. Read here, before the lock — conversationActivePastHook does
+	// disk I/O and must not run under s.mu. Gated tightly so it's a rare read.
 	convActive := false
-	if hookStatus == "waiting" && paneStatus == StatusFinished {
-		convActive = s.conversationActivePastHook()
+	switch hookStatus {
+	case "waiting":
+		// Stale waiting hook (granted permission fires no resume hook) + idle pane.
+		if paneStatus == StatusFinished {
+			convActive = s.conversationActivePastHook()
+		}
+	case "finished":
+		// Stale finished hook (e.g. a SessionStart/resume that kicked off one long
+		// turn, no Stop since) about to demote a still-running session on an idle/
+		// ambiguous frame. Gate on oldStatus==running so a genuinely-finished session
+		// (already settled) never reads the transcript every round-robin cycle; the
+		// gate is self-sustaining — keeping it running across between-bursts frames
+		// keeps oldStatus running, so a live turn can't be demoted by one bad frame.
+		if oldStatus == StatusRunning && paneStatus != StatusRunning && paneStatus != StatusWaiting {
+			convActive = s.conversationActivePastHook()
+		}
 	}
 
 	hookSaysDead := false
@@ -649,7 +663,7 @@ func (s *Session) updateStatusFromHook(oldStatus Status, hookStatus string, hook
 		case "waiting":
 			s.applyHookWaiting(paneContent, paneStatus, convActive, log)
 		case "finished":
-			s.applyHookFinished(paneStatus, log)
+			s.applyHookFinished(paneStatus, convActive, log)
 		case "dead":
 			s.lastContentHash = ""
 			s.lastContentChangeAt = time.Time{}
@@ -932,8 +946,10 @@ const conversationActiveWindow = 120 * time.Second
 const conversationActiveSkew = 2 * time.Second
 
 // applyHookFinished handles hook status "finished" with pane override for active spinners.
+// convActive is the pre-computed transcript tiebreaker (see conversationActivePastHook);
+// it is only meaningful when paneStatus is not running/waiting.
 // Must be called with s.mu held.
-func (s *Session) applyHookFinished(paneStatus Status, log *slog.Logger) {
+func (s *Session) applyHookFinished(paneStatus Status, convActive bool, log *slog.Logger) {
 	s.lastContentHash = ""
 	s.lastContentChangeAt = time.Time{}
 	if paneStatus == StatusRunning {
@@ -977,6 +993,16 @@ func (s *Session) applyHookFinished(paneStatus Status, log *slog.Logger) {
 				"hookAge", time.Since(s.hookUpdatedAt).Round(time.Millisecond))
 			return
 		}
+	}
+	// Stale finished hook, idle-looking pane — but the transcript shows the lead turn
+	// still appending past the hook (a SessionStart/resume that began one long turn,
+	// caught on a between-bursts frame where the activity line wasn't rendered). The
+	// agent is working; don't demote it to finished.
+	if convActive {
+		s.Status = StatusRunning
+		s.Acknowledged = false
+		log.Info("hook=finished, pane idle, but transcript active past hook — staying running")
+		return
 	}
 	if s.Acknowledged {
 		s.Status = StatusIdle


### PR DESCRIPTION
Two independent session-tracking fixes, both rooted in how fleet reconciles Claude hooks against the conversation transcript.

## 1. Session shows "finished" while the agent is actively running

`fix(status): keep session running when transcript advances past a stale waiting hook` (57437f0)

A granted permission prompt fires no resume hook, so the hook lingers at `waiting`. Modern Claude keeps the `❯` input box on screen while working, so a between-bursts frame (activity line momentarily gone) reads as a finished idle prompt — and `applyHookWaiting` overrode `waiting → finished` while the agent was actively running. Verified from a snapshot: at both false-finished moments the transcript's last lead entry was ~0.5s/3s old and ~90s past the hook.

**Fix:** when the hook is `waiting` and the pane reads finished, consult the transcript (`conversationActivePastHook`) — if the last lead (non-sidechain) entry advanced >2s past the hook and is <120s old, the agent resumed, so stay running. The read happens **before `s.mu`** (disk I/O) and is gated to that one frame. The running-hook path is intentionally left to its existing 10s-stable + tmux-activity guards.

## 2. Forking a forked session re-forked its ancestor

`fix(fork): forking a forked session re-forked its ancestor, not itself` (c7c1742)

Fork A → B, work on B, fork B → C was a fork of **A**, not B.

`claude --resume <parent> --fork-session` reports the **parent's** id at `SessionStart` and only switches to the fork's own id on the first prompt. `isSessionRotation` can't adopt that new id for a fork: fork transcripts carry no `logicalParentUuid`, and they copy the parent's history verbatim **with the parent's original timestamps** — so the 10s timestamp-handoff check measures the parent's whole conversation length, not a handoff gap, and misses for any parent older than ~10s. The miss is then permanently negative-cached, pinning the fork to the parent id; `forkSelected` reads `ClaudeSessionID` → re-forks the parent. (A trivial <10s parent squeaks under the window — why it looked intermittent.)

**Fix:** remember the fork parent id (`Session.forkParentID`, captured in `Start`). When a hook reports an id different from the parent while the session still owns the parent's id, adopt it **deterministically** — it can only be the fork diverging. No transcript heuristic, no 10s window, no negative cache; cleared on divergence; self-heals across restart.

## Tests
- `TestScenarioStaleWaitingConversationActiveStaysRunning` + `…IdleSettlesFinished`, `TestLastLeadTranscriptTimestamp` (status fix)
- `TestUpdateHookStatusAdoptsForkDivergence` (fork fix) — reproduces the exact failure (>10s parent, copied timestamps, no parent link)
- Each new test verified to fail with its fix disabled and pass with it; full suite green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forked-from-fork sessions now correctly switch to the fork’s own conversation ID once the fork diverges.
  * Sessions no longer show stale “waiting” or “finished” UI states while the agent is actively working, including after permission prompts, answered questions, and during long resumed turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->