### PR TITLE
fix(status): detect ExitPlanMode plan-approval prompt as waiting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ chrome-extension/                # Chrome MV3 extension (service worker, manifes
 - `gh` CLI optional — PR info hidden if not installed
 - Preview strips OSC-8 hyperlink sequences to prevent dotted underline artifacts
 - Status detection: hook-based (primary, no time expiry) via Claude Code hooks + pane capture (fallback, ANSI-stripped)
-- Agent team status: sub-agents don't fire hooks, so pane detection handles team states via structural checks (numbered menu `❯ 1.`+`2.`+`Esc to cancel`, box-drawing `│`+`Waiting for team lead`); hook=running is never overridden to waiting by pane (avoids false-positives from code in scrollback)
+- Agent team status: sub-agents don't fire hooks, so pane detection handles team states via structural checks (numbered menu `❯ 1.`+`2.`+ a menu footer — `Esc to cancel`, or `approve with this feedback` for ExitPlanMode plan-approval prompts; box-drawing `│`+`Waiting for team lead`); hook=running is never overridden to waiting by pane (avoids false-positives from code in scrollback)
 - All blocking I/O (tmux, git, gh) runs in background worker goroutine, never in Bubble Tea Update()
 - Hook status files: `~/.config/fleet/hooks/{session_id}.json`
 - Hook handler: `fleet hook-handler` (invoked by Claude Code hooks, reads FLEET_INSTANCE_ID env)

--- a/changelog/unreleased/fix-plan-approval-waiting.md
+++ b/changelog/unreleased/fix-plan-approval-waiting.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Plan-approval prompts ("Claude has written up a plan… proceed?") now show **waiting** immediately instead of briefly flashing as running for ~15s.

--- a/internal/session/golden_test.go
+++ b/internal/session/golden_test.go
@@ -34,6 +34,7 @@ var goldenTests = []struct {
 	{"pane_running_plan_checklist_deep.txt", StatusRunning, "plan execution with whimsical activity line pushed deep by expanding checklist"},
 	{"pane_finished_quoted_crashdump_whimsical.txt", StatusFinished, "idle prompt with embedded crash-dump example containing a whimsical activity line in scrollback (~30 lines from bottom)"},
 	{"pane_waiting_askuserquestion_checkbox_focus.txt", StatusWaiting, "AskUserQuestion dialog with focus on checkbox question header (no `❯ N.` cursor in numbered options)"},
+	{"pane_waiting_exitplanmode_approve.txt", StatusWaiting, "ExitPlanMode plan-approval menu — numbered options with `shift+tab to approve with this feedback` footer (no `Esc to cancel`)"},
 	{"finished_idle_background_agent.txt", StatusFinished, "idle prompt while a background agent runs (`✻ Waiting for 1 background agent to finish` in scrollback + active sub-agent footer)"},
 }
 

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -954,6 +954,48 @@ func TestScenarioAskUserQuestionNavigationStaysWaiting(t *testing.T) {
 	})
 }
 
+func TestScenarioExitPlanModeApprovalStaysWaiting(t *testing.T) {
+	// Regression: Claude's ExitPlanMode plan-approval prompt ("Claude has written up
+	// a plan and is ready to execute. Would you like to proceed?") is a numbered menu,
+	// but its footer is "shift+tab to approve with this feedback" — it has NO "Esc to
+	// cancel". Before the fix, detectWaiting (which required "Esc to cancel") missed it,
+	// so paneStatus was "" while the menu painted in. applyHookWaiting's "content changed
+	// → assume running" override then fired on each repaint, flipping the genuine waiting
+	// state to running for ~15s until the cooldown expired.
+	//
+	// Fix: detectWaiting accepts "approve with this feedback" as a menu footer, so
+	// paneStatus=Waiting through the prompt; applyHookWaiting suppresses the running
+	// override when paneStatus=Waiting.
+	// Captured from snapshot 2026-06-18T14-27-14_change-quit-keybinding-from-q-.
+	fixture := "pane_waiting_exitplanmode_approve.txt"
+	if _, err := os.Stat(filepath.Join("testdata", fixture)); err != nil {
+		t.Skipf("fixture %s not available", fixture)
+	}
+
+	// Plain-text menu variants: the prompt stays on screen (still waiting) but the
+	// scrollback above it drifts, changing the content hash — simulates the menu
+	// painting in / output above it redrawing while the user hasn't answered yet.
+	menu := func(scrollback string) string {
+		return scrollback + "\n\nClaude has written up a plan and is ready to execute. Would you like to proceed?\n\n" +
+			"❯ 1. Yes, and use auto mode\n  2. Yes, manually approve edits\n  3. No, refine with Ultraplan\n  4. Tell Claude what to change\n     shift+tab to approve with this feedback\n\nctrl+g to edit in  VS Code\n"
+	}
+
+	runScenario(t, Scenario{
+		Name: "ExitPlanMode plan-approval: hook=waiting + drifting hash → stays waiting",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "waiting", Pane: "@fixture:" + fixture}, // real ANSI capture
+			{At: 3 * time.Second, Pane: menu("summary line one")},
+			{At: 6 * time.Second, Pane: menu("summary line one\nsummary line two appeared")}, // scrollback drifts, hash changes
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusWaiting},
+			{At: 3 * time.Second, Expected: StatusWaiting},  // before fix: flipped to running on hash drift
+			{At: 6 * time.Second, Expected: StatusWaiting},  // before fix: still running (15s cooldown)
+			{At: 20 * time.Second, Expected: StatusWaiting}, // long after any cooldown
+		},
+	})
+}
+
 func TestScenarioStaleWaitingWithActiveSpinner(t *testing.T) {
 	// Regression: user approves a PermissionRequest and Claude starts working.
 	// No UserPromptSubmit fires for permission grants, so the hook stays "waiting".

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1486,13 +1486,15 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 
 	// Structural check: numbered permission menu.
 	// Requires three cues: a cursor-on-numbered-option line ("❯ N."), at least
-	// one other numbered option line, AND "Esc to cancel" nearby. The cursor
+	// one other numbered option line, AND a menu footer nearby. The cursor
 	// may sit on any option (1, 2, 3…) depending on what the user has highlighted.
-	// Esc to cancel only appears in Claude's interactive prompts, preventing
-	// false-positives from user input numbered lists.
+	// The footer ("Esc to cancel" for a standard permission menu, or "approve
+	// with this feedback" for the ExitPlanMode plan-approval menu — which has no
+	// "Esc to cancel") only appears in Claude's interactive prompts, preventing
+	// false-positives from user-typed numbered lists.
 	hasCursorOnOption := false
 	hasOtherOption := false
-	hasEscCancel := false
+	hasMenuFooter := false
 	for i := 0; i < bottomN; i++ {
 		trimmed := strings.TrimSpace(recentLines[i])
 		if strings.HasPrefix(trimmed, "❯ ") && isNumberedMenuOption(strings.TrimPrefix(trimmed, "❯ ")) {
@@ -1500,11 +1502,12 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 		} else if isNumberedMenuOption(trimmed) {
 			hasOtherOption = true
 		}
-		if strings.Contains(strings.ToLower(trimmed), "esc to cancel") {
-			hasEscCancel = true
+		lower := strings.ToLower(trimmed)
+		if strings.Contains(lower, "esc to cancel") || strings.Contains(lower, "approve with this feedback") {
+			hasMenuFooter = true
 		}
 	}
-	if hasCursorOnOption && hasOtherOption && hasEscCancel {
+	if hasCursorOnOption && hasOtherOption && hasMenuFooter {
 		log.Debug("detectStatus: matched permission menu structure")
 		return StatusWaiting
 	}

--- a/internal/session/testdata/pane_waiting_exitplanmode_approve.txt
+++ b/internal/session/testdata/pane_waiting_exitplanmode_approve.txt
@@ -1,0 +1,37 @@
+ ---
+ type: changed
+ ---
+ Quit is now Ctrl+C instead of q.
+
+ [1mOut[0m [1mof[0m [1mscope[0m [1m(left[0m [1munchanged)[0m
+
+ - The settings dialog ([38;5;153minternal/ui/settings.go:132[39m) and new-session dialog
+ ([38;5;153minternal/ui/session_create.go:50[39m) close on [38;5;153mcase[39m [38;5;153m"esc",[39m [38;5;153m"q":[39m. These are dialog-local
+ "close this dialog" handlers, not the global quit — unrelated to this change, so left as-is.
+ (Result: [38;5;153mq[39m no longer quits the app but still closes those two dialogs, same as [38;5;153mesc[39m.)
+
+ [1mVerification[0m
+
+ - [38;5;153mmake[39m [38;5;153mbuild[39m — confirms it compiles.
+ - [38;5;153mmake[39m [38;5;153mtest[39m — keybinding/help rendering tests, if any, still pass.
+ - Manual ([38;5;153mmake[39m [38;5;153mrun[39m):
+   - In the sidebar, press [38;5;153mq[39m → app stays open (no longer quits).
+   - Press [38;5;153mCtrl+C[39m → app quits cleanly.
+   - Press [38;5;153m?[39m → help overlay shows [38;5;153mCtrl+C[39m  [38;5;153mQuit[39m in the Global section.
+   - Footer bottom-right shows [38;5;153m⌃C[39m [38;5;153mQuit[39m.
+   - [38;5;153mCtrl+K[39m command palette → "Quit" entry shows the [38;5;153m⌃C[39m shortcut and quits when chosen.
+   - Attach to a session, press [38;5;153mCtrl+C[39m → interrupts the agent (does not quit fleet);
+ [38;5;153mCtrl+Q[39m detaches.
+[38;5;239m╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+
+[38;5;73m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m [38;5;246mClaude[39m [38;5;246mhas[39m [38;5;246mwritten[39m [38;5;246mup[39m [38;5;246ma[39m [38;5;246mplan[39m [38;5;246mand[39m [38;5;246mis[39m [38;5;246mready[39m [38;5;246mto[39m [38;5;246mexecute.[39m [38;5;246mWould[39m [38;5;246myou[39m [38;5;246mlike[39m [38;5;246mto[39m [38;5;246mproceed?[39m
+
+ [38;5;153m❯[39m [38;5;246m1.[39m [38;5;153mYes,[39m [38;5;153mand[39m [38;5;153muse[39m [38;5;153mauto[39m [38;5;153mmode[39m
+   [38;5;246m2.[39m Yes, manually approve edits
+   [38;5;246m3.[39m No, refine with Ultraplan on Claude Code on the web
+   [38;5;246m4.[39m [38;5;246mTell[39m [38;5;246mClaude[39m [38;5;246mwhat[39m [38;5;246mto[39m [38;5;246mchange[39m
+      [38;5;246mshift+tab[39m [38;5;246mto[39m [38;5;246mapprove[39m [38;5;246mwith[39m [38;5;246mthis[39m [38;5;246mfeedback[39m
+
+ [38;5;246mctrl+g[39m [38;5;246mto[39m [38;5;246medit[39m [38;5;246min[39m  [1m[38;5;246mVS[0m [1m[38;5;246mCode[0m [38;5;246m ·[39m [38;5;246m~/.claude/plans/change-the-quit-from-reactive-hamster.md[39m
+


### PR DESCRIPTION
## Problem

A plan-approval prompt — *"Claude has written up a plan and is ready to execute. Would you like to proceed?"* — showed **running** in the sidebar for ~15s before correcting to **waiting**. Diagnosed via the `D`-key snapshot (`2026-06-18T14-27-14_change-quit-keybinding-from-q-`).

## Root cause

The plan-approval prompt (ExitPlanMode) is a numbered menu, but its footer is `shift+tab to approve with this feedback` — it has **no** `Esc to cancel`. `detectWaiting`'s numbered-menu structural check *required* `Esc to cancel`, so it missed this variant and `detectStatus` returned `""` (pane detection blind to the prompt).

The hook correctly fired `waiting`. But with the pane unrecognized, `applyHookWaiting`'s "content changed → user must have approved → assume running" tiebreaker had no `paneStatus == StatusWaiting` guard to hold it — so each repaint of the menu (as it painted in) flipped the genuine waiting state to `running`. It self-corrected only after the pane stopped changing and the 15s running-cooldown expired.

Debug-log smoking gun:
```
14:27:07.153  status changed (hook) old=running new=waiting   ✓ correct
14:27:07.781  content changed while waiting, assuming running  ✗ flipped back
```

## Fix

Accept `approve with this feedback` as a valid menu footer alongside `Esc to cancel` in `detectWaiting`. Once the prompt is recognized as `Waiting`, the existing `paneStatus == StatusWaiting` guard in `applyHookWaiting` holds the state — no change needed there.

## Tests

- **Golden** (`pane_waiting_exitplanmode_approve.txt`): frozen ANSI capture from the snapshot → expects `StatusWaiting`.
- **Scenario** (`TestScenarioExitPlanModeApprovalStaysWaiting`): hook=waiting + drifting pane hash → must stay `waiting` across the cooldown window.

Both **fail before** the fix (golden returns `""`; scenario flips to `running` at t=3s/6s — the exact bug) and pass after. Full `go test -race ./internal/session/` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TtBCb6Vtq6U8DaYouWkEZ