### PR TITLE
fix(status): recover stuck-running status after a missed session rotation

### DIFF
--- a/changelog/unreleased/status-stuck-running-rotation.md
+++ b/changelog/unreleased/status-stuck-running-rotation.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Sessions no longer get stuck showing "running" while genuinely waiting for a permission prompt after a `/clear`-style session rotation.

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -214,7 +214,18 @@ func CopyClaudeForkTranscript(parentSessionID, parentProjectPath, destProjectPat
 // deterministic uuid signal below instead, which has no time dependence.)
 const rotationHandoffWindow = 10 * time.Second
 
-// isSessionRotation reports whether newSessionID is ownerSessionID's conversation
+// rotationVerdict is the result of sessionRotationVerdict: whether a foreign Claude
+// session_id continues the owner session (adopt), is a separate nested child (reject
+// and neg-cache), or can't be decided yet because the transcript hasn't flushed (retry).
+type rotationVerdict int
+
+const (
+	rotationNo      rotationVerdict = iota // a separate nested child — reject and neg-cache
+	rotationYes                            // a confirmed rotation — adopt the new id
+	rotationUnknown                        // undecidable this cycle (transcript not flushed) — retry
+)
+
+// sessionRotationVerdict reports whether newSessionID is ownerSessionID's conversation
 // continued under a fresh id (a Claude session-id rotation) rather than a separate
 // nested child claude that merely inherited the same FLEET_INSTANCE_ID.
 //
@@ -230,32 +241,39 @@ const rotationHandoffWindow = 10 * time.Second
 //     rotationHandoffWindow of the owner's last entry.
 //   - in-place compaction keeps the same session id, so it never reaches here.
 //
-// When transcripts can't be read we return false — the safe default, since
-// wrongly adopting a real nested child would clobber the owner's status and
-// resume id.
-func isSessionRotation(projectPath, ownerSessionID, newSessionID string) bool {
+// When the proximity fallback can't read a timestamp from either transcript it returns
+// rotationUnknown rather than rotationNo: a /clear rotation fires its SessionStart hook
+// before the new transcript flushes its first timestamped entry (the file opens with
+// timestamp-less mode/permission-mode/file-history-snapshot header entries), so a
+// premature rotationNo would get neg-cached and freeze the in-memory hook on the dead
+// owner session forever (issue #23). Unknown makes the caller retry next cycle.
+func sessionRotationVerdict(projectPath, ownerSessionID, newSessionID string) rotationVerdict {
 	if projectPath == "" || ownerSessionID == "" || newSessionID == "" {
-		return false
+		return rotationNo
 	}
 	newPath := ClaudeTranscriptPath(newSessionID, projectPath)
 	ownerPath := ClaudeTranscriptPath(ownerSessionID, projectPath)
 
 	// Primary: deterministic parent link (continue/resume/fork).
 	if link := transcriptParentLink(newPath); link != "" && transcriptContainsUUID(ownerPath, link) {
-		return true
+		return rotationYes
 	}
 
-	// Fallback: instant timestamp handoff (/clear).
+	// Fallback: instant timestamp handoff (/clear). Undecidable until both transcripts
+	// have a readable timestamp — see the note above on the SessionStart-vs-flush race.
 	newFirst := firstTranscriptTimestamp(newPath)
 	ownerLast := lastTranscriptTimestamp(ownerPath)
 	if newFirst.IsZero() || ownerLast.IsZero() {
-		return false
+		return rotationUnknown
 	}
 	delta := newFirst.Sub(ownerLast)
 	if delta < 0 {
 		delta = -delta
 	}
-	return delta <= rotationHandoffWindow
+	if delta <= rotationHandoffWindow {
+		return rotationYes
+	}
+	return rotationNo
 }
 
 // transcriptParentLink returns the logicalParentUuid of the first

--- a/internal/session/ownership_test.go
+++ b/internal/session/ownership_test.go
@@ -100,7 +100,7 @@ func TestUpdateHookStatusIgnoresNestedChild(t *testing.T) {
 // `claude --resume <parent> --fork-session` reports the PARENT's id at SessionStart
 // and only switches to its own id on the first prompt. The fork transcript copies
 // the parent's history verbatim (same OLD first timestamp) and carries no
-// logicalParentUuid, so BOTH isSessionRotation signals miss — leaving the fork
+// logicalParentUuid, so BOTH sessionRotationVerdict signals miss — leaving the fork
 // pinned to the parent id, so forking it re-forks the parent. With forkParentID
 // known, the fork's own id must be adopted deterministically.
 func TestUpdateHookStatusAdoptsForkDivergence(t *testing.T) {
@@ -182,6 +182,52 @@ func TestClearHookStateClearsForkParent(t *testing.T) {
 	}
 	if s.ClaudeSessionID != "parent-aaa" {
 		t.Errorf("nested child clobbered id after restart: %q, want parent-aaa", s.ClaudeSessionID)
+	}
+}
+
+// TestUpdateHookStatusDefersUndecidedRotation reproduces issue #23: a /clear-style
+// rotation fires its SessionStart hook before the new transcript flushes a timestamped
+// entry — the file opens with timestamp-less mode/permission-mode/file-history-snapshot
+// header entries — so the proximity check is undecidable on that first hook. It must be
+// DEFERRED (rejected without neg-caching), so once the transcript flushes its first real
+// entry a later hook still adopts it. Before the fix the first attempt neg-cached the
+// pair permanently, freezing the in-memory hook on the dead owner session.
+func TestUpdateHookStatusDefersUndecidedRotation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	proj := t.TempDir()
+
+	base := time.Now().Add(-time.Hour).UTC()
+	ownerEnd := base.Add(30 * time.Minute)
+	writeTranscript(t, proj, "owner-aaa", base, ownerEnd)
+	// Rotated transcript exists but is header-only — no timestamped entry yet.
+	writeTranscriptRaw(t, proj, "rot-bbb",
+		`{"type":"mode"}`,
+		`{"type":"permission-mode"}`,
+		`{"type":"file-history-snapshot"}`,
+	)
+
+	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
+	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "owner-aaa", UpdatedAt: time.Now()}, true)
+
+	// First rotated hook lands before the transcript flushes a timestamp → undecided.
+	// Must be deferred: not adopted, and crucially not neg-cached.
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "rot-bbb", UpdatedAt: time.Now()}, true); changed {
+		t.Errorf("undecided rotation should be deferred, not adopted yet")
+	}
+	if s.ClaudeSessionID != "owner-aaa" {
+		t.Errorf("undecided rotation prematurely adopted: %q, want owner-aaa", s.ClaudeSessionID)
+	}
+
+	// The transcript now flushes its first real (timestamped) entry, handing off within
+	// the proximity window. The deferred id must now be adopted — proving the first,
+	// undecidable attempt did NOT permanently neg-cache it.
+	writeTranscript(t, proj, "rot-bbb", ownerEnd.Add(-2*time.Millisecond), ownerEnd.Add(10*time.Minute))
+	changed := s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "rot-bbb", UpdatedAt: time.Now()}, true)
+	if !changed {
+		t.Errorf("rotation should be adopted once the transcript flushes a timestamp")
+	}
+	if s.ClaudeSessionID != "rot-bbb" {
+		t.Errorf("rotation not adopted after flush: %q, want rot-bbb", s.ClaudeSessionID)
 	}
 }
 

--- a/internal/session/ownership_test.go
+++ b/internal/session/ownership_test.go
@@ -242,7 +242,7 @@ func TestUpdateHookStatusCapsUndecidedRotation(t *testing.T) {
 
 	// Owner claims ownership, but its transcript is never written — so the proximity
 	// check can't read ownerLast and the (owner, foreign) pair stays undecidable.
-	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
+	s := &Session{ID: "abcd1234-1700000000", ProjectPath: proj, Status: StatusRunning}
 	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "owner-aaa", UpdatedAt: time.Now()}, true)
 
 	// Foreign session has a real transcript, but with no readable owner transcript the

--- a/internal/session/ownership_test.go
+++ b/internal/session/ownership_test.go
@@ -231,6 +231,43 @@ func TestUpdateHookStatusDefersUndecidedRotation(t *testing.T) {
 	}
 }
 
+// TestUpdateHookStatusCapsUndecidedRotation guards the retry cap on rotationUnknown: a
+// pair that can never decide (here a permanently missing owner transcript, so
+// sessionRotationVerdict's ownerLast is always zero) must not defer forever and rescan
+// transcripts on every worker pass. After rotationUndecidedRetryCap consecutive
+// undecided cycles it falls back to the neg-cache.
+func TestUpdateHookStatusCapsUndecidedRotation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	proj := t.TempDir()
+
+	// Owner claims ownership, but its transcript is never written — so the proximity
+	// check can't read ownerLast and the (owner, foreign) pair stays undecidable.
+	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
+	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "owner-aaa", UpdatedAt: time.Now()}, true)
+
+	// Foreign session has a real transcript, but with no readable owner transcript the
+	// verdict is rotationUnknown every cycle.
+	base := time.Now().Add(-time.Hour).UTC()
+	writeTranscript(t, proj, "foreign-bbb", base, base.Add(time.Minute))
+
+	// The first rotationUndecidedRetryCap cycles defer without neg-caching.
+	for i := 0; i < rotationUndecidedRetryCap; i++ {
+		s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "foreign-bbb", UpdatedAt: time.Now()}, true)
+		if s.rotRejectForeign == "foreign-bbb" {
+			t.Fatalf("neg-cached too early at cycle %d (cap=%d)", i+1, rotationUndecidedRetryCap)
+		}
+	}
+	// One more undecided cycle exceeds the cap → neg-cache.
+	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "foreign-bbb", UpdatedAt: time.Now()}, true)
+	if s.rotRejectForeign != "foreign-bbb" {
+		t.Errorf("undecided pair past the retry cap should be neg-cached, got rotRejectForeign=%q", s.rotRejectForeign)
+	}
+	// The owner id is never clobbered by the undecidable foreign session.
+	if s.ClaudeSessionID != "owner-aaa" {
+		t.Errorf("owner clobbered by undecided foreign: %q, want owner-aaa", s.ClaudeSessionID)
+	}
+}
+
 // writeTranscriptRaw writes arbitrary JSONL lines for a session under the
 // HOME-rooted projects dir, for tests that need uuid / compact_boundary entries.
 func writeTranscriptRaw(t *testing.T, projectPath, sessionID string, lines ...string) {

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -1050,3 +1050,31 @@ func TestScenarioFreshWaitingHookRenderSpinnerStaysWaiting(t *testing.T) {
 		},
 	})
 }
+
+// TestScenarioStaleWaitingLatchRecoversToWaiting reproduces issue #23's stuck-running
+// symptom in isolation. A stale waiting hook gets latched (overridden to finished on an
+// idle frame, then to running on a working frame, all without a new hook timestamp), and
+// then a REAL permission prompt appears on the pane. Before the fix, the latched-override
+// switch in applyHookWaiting had no StatusWaiting case, so the genuine prompt was ignored
+// and the session stayed pinned to running. In the field this latch never resets because
+// a missed session-id rotation froze the hook (no fresh hook ever lands), so recovery has
+// to come from the pane.
+func TestScenarioStaleWaitingLatchRecoversToWaiting(t *testing.T) {
+	const waitingPrompt = "Would you like to proceed?\n❯ 1. Yes\n  2. No\nEsc to cancel\n"
+	runScenario(t, Scenario{
+		Name: "stale waiting latch recovers to waiting on real prompt",
+		Events: []ScenarioEvent{
+			// Stale waiting hook + idle prompt → override to finished and latch.
+			{At: 0, Hook: "waiting", HookAge: 11 * time.Minute, Pane: "@fixture:pane_finished_idle_prompt.txt"},
+			// Same (stale) hook, pane now shows work → latched branch flips to running.
+			{At: 2 * time.Second, Pane: "@fixture:pane_running_extended_thinking.txt"},
+			// Same hook, a genuine permission prompt is now structurally on screen.
+			{At: 4 * time.Second, Pane: waitingPrompt},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusFinished},
+			{At: 2 * time.Second, Expected: StatusRunning},
+			{At: 4 * time.Second, Expected: StatusWaiting}, // was stuck at StatusRunning before the fix
+		},
+	})
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -66,7 +66,7 @@ type Session struct {
 	forkParentID     string    // parent's claude session id while this fork hasn't diverged yet; lets us adopt the fork's own id deterministically (cleared on divergence)
 
 	// Negative cache for the rotation check: the last (owner, foreign) pair that
-	// isSessionRotation rejected. A persistent foreign id (a nested-child eval
+	// sessionRotationVerdict rejected. A persistent foreign id (a nested-child eval
 	// harness) would otherwise rescan transcripts every worker cycle; once
 	// rejected we short-circuit until the owner or the foreign id changes.
 	rotRejectOwner   string
@@ -312,7 +312,7 @@ type HookStatus struct {
 // Returns true if the hook meaningfully changed (new status or new timestamp),
 // so callers can prioritize an immediate status recomputation.
 //
-// resolveRotation gates the transcript I/O in isSessionRotation. The worker
+// resolveRotation gates the transcript I/O in sessionRotationVerdict. The worker
 // passes true (it runs off the Bubble Tea Update() loop); the UI paths
 // (hookChangedMsg/statusUpdateMsg) pass false so a foreign id can't block the
 // render loop on disk reads — they simply defer it to the next worker cycle
@@ -334,7 +334,7 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 	//   - A nested child `claude` (an eval harness spawning sub-Claudes)
 	//     inherited FLEET_INSTANCE_ID. Adopting it would clobber our status and
 	//     resume id, so it must be ignored.
-	// isSessionRotation distinguishes them; a persistent rejection is cached so
+	// sessionRotationVerdict distinguishes them; a persistent rejection is cached so
 	// a nested child doesn't rescan transcripts every cycle.
 	var owner string
 	if hs.SessionID != "" {
@@ -351,7 +351,7 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 				// Its SessionStart hook reports the PARENT's id; the fork's own id only
 				// appears once it diverges (first prompt). That first id different from
 				// the parent IS this fork's own session, so adopt it directly. We can't
-				// use isSessionRotation here: fork transcripts carry no logicalParentUuid,
+				// use sessionRotationVerdict here: fork transcripts carry no logicalParentUuid,
 				// and they copy the parent's history verbatim (with the parent's original
 				// timestamps), so the timestamp-handoff check measures the parent's whole
 				// conversation length, not a handoff gap, and misses for any parent older
@@ -365,23 +365,35 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 					"id", s.ID, "parent", owner, "new", hs.SessionID)
 			case negCached:
 				return false // already rejected this (owner, foreign) pair
-			case resolveRotation && isSessionRotation(projectPath, owner, hs.SessionID):
-				debuglog.Logger.Info("adopting rotated claude session",
-					"id", s.ID, "old", owner, "new", hs.SessionID)
+			case !resolveRotation:
+				// UI path: the rotation check reads transcripts off disk, which must not
+				// block the render loop. Defer to the next worker cycle (~500ms), which
+				// re-evaluates with resolveRotation=true.
+				return false
 			default:
-				// Foreign (nested child), or deferred from the UI path. Cache the
-				// rejection only when we actually evaluated it (worker path), so a
-				// persistent foreign id doesn't rescan transcripts every cycle; the
-				// UI path leaves the verdict to the worker.
-				if resolveRotation {
+				switch sessionRotationVerdict(projectPath, owner, hs.SessionID) {
+				case rotationYes:
+					debuglog.Logger.Info("adopting rotated claude session",
+						"id", s.ID, "old", owner, "new", hs.SessionID)
+					// fall through to the adoption block below
+				case rotationUnknown:
+					// The rotated transcript hasn't flushed a timestamped entry yet (its
+					// SessionStart hook beat the first user turn to disk). Reject WITHOUT
+					// neg-caching so the next cycle re-evaluates once it flushes — neg-caching
+					// here would freeze the hook on the dead owner session forever (issue #23).
+					debuglog.Logger.Debug("deferring undecided claude session",
+						"id", s.ID, "owner", owner, "foreign", hs.SessionID)
+					return false
+				default: // rotationNo — a genuine nested child (eval harness). Neg-cache so a
+					// persistent foreign id doesn't rescan transcripts every cycle.
 					s.mu.Lock()
 					s.rotRejectOwner = owner
 					s.rotRejectForeign = hs.SessionID
 					s.mu.Unlock()
 					debuglog.Logger.Debug("ignoring foreign claude session",
 						"id", s.ID, "owner", owner, "foreign", hs.SessionID)
+					return false
 				}
-				return false
 			}
 		}
 	}
@@ -868,6 +880,17 @@ func (s *Session) applyHookWaiting(paneContent string, paneStatus Status, convAc
 			s.Status = StatusRunning
 			s.Acknowledged = false
 			log.Info("overridden waiting hook but pane shows running, resuming")
+		case StatusWaiting:
+			// A real permission prompt is structurally on screen now. The latch was set
+			// on an earlier finished/running frame of this same stale hook, but the agent
+			// is genuinely blocked — the pane stays authoritative for a stale waiting hook
+			// (see above), so recover to waiting instead of staying pinned to the last
+			// running we saw. Without this case the switch matched nothing and returned,
+			// leaving a genuine prompt stuck showing running when a missed session-id
+			// rotation froze the hook so no fresh hook ever reset the latch (issue #23).
+			s.Status = StatusWaiting
+			s.Acknowledged = false
+			log.Info("overridden waiting hook but pane shows waiting prompt, recovering to waiting")
 		case StatusFinished:
 			if s.Acknowledged {
 				s.Status = StatusIdle

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -72,6 +72,16 @@ type Session struct {
 	rotRejectOwner   string
 	rotRejectForeign string
 
+	// Bounded retry tracking for an undecidable (owner, foreign) pair — one
+	// sessionRotationVerdict can't yet classify because a transcript hasn't flushed a
+	// timestamp. The transient /clear-flush race clears in a cycle or two, but a
+	// permanently unreadable/missing owner transcript would stay undecidable forever
+	// and rescan transcripts every worker pass. After rotationUndecidedRetryCap
+	// consecutive undecided cycles we fall back to the neg-cache.
+	rotUndecidedOwner   string
+	rotUndecidedForeign string
+	rotUndecidedCount   int
+
 	lastContentHash     string
 	lastContentChangeAt time.Time
 
@@ -371,29 +381,33 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 				// re-evaluates with resolveRotation=true.
 				return false
 			default:
-				switch sessionRotationVerdict(projectPath, owner, hs.SessionID) {
-				case rotationYes:
-					debuglog.Logger.Info("adopting rotated claude session",
-						"id", s.ID, "old", owner, "new", hs.SessionID)
-					// fall through to the adoption block below
-				case rotationUnknown:
-					// The rotated transcript hasn't flushed a timestamped entry yet (its
-					// SessionStart hook beat the first user turn to disk). Reject WITHOUT
-					// neg-caching so the next cycle re-evaluates once it flushes — neg-caching
-					// here would freeze the hook on the dead owner session forever (issue #23).
-					debuglog.Logger.Debug("deferring undecided claude session",
-						"id", s.ID, "owner", owner, "foreign", hs.SessionID)
-					return false
-				default: // rotationNo — a genuine nested child (eval harness). Neg-cache so a
-					// persistent foreign id doesn't rescan transcripts every cycle.
-					s.mu.Lock()
-					s.rotRejectOwner = owner
-					s.rotRejectForeign = hs.SessionID
-					s.mu.Unlock()
+				// Only a confirmed rotation (rotationYes) may proceed to the adoption
+				// block below — every other verdict returns here. Keep this an explicit
+				// guard, not a fall-through-by-not-returning: a stray statement after this
+				// block or a reordered case must not be able to silently route an adopted
+				// rotation to a no-op (the hook would stay frozen on the dead owner id).
+				if v := sessionRotationVerdict(projectPath, owner, hs.SessionID); v != rotationYes {
+					if v == rotationUnknown && s.bumpUndecidedRotation(owner, hs.SessionID) {
+						// The rotated transcript hasn't flushed a timestamped entry yet (its
+						// SessionStart hook beat the first user turn to disk). Reject WITHOUT
+						// neg-caching so the next cycle re-evaluates once it flushes — neg-caching
+						// here would freeze the hook on the dead owner session forever (issue #23).
+						debuglog.Logger.Debug("deferring undecided claude session",
+							"id", s.ID, "owner", owner, "foreign", hs.SessionID)
+						return false
+					}
+					// rotationNo (a genuine nested-child eval harness), or a pair that has
+					// stayed undecidable past the retry cap (e.g. a permanently unreadable
+					// owner transcript). Neg-cache so a persistent foreign id doesn't rescan
+					// transcripts every cycle.
+					s.negCacheRotation(owner, hs.SessionID)
 					debuglog.Logger.Debug("ignoring foreign claude session",
 						"id", s.ID, "owner", owner, "foreign", hs.SessionID)
 					return false
 				}
+				debuglog.Logger.Info("adopting rotated claude session",
+					"id", s.ID, "old", owner, "new", hs.SessionID)
+				// proceed to the adoption block below
 			}
 		}
 	}
@@ -456,6 +470,43 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 		s.FirstPrompt = hs.UserPrompt
 	}
 	return changed
+}
+
+// rotationUndecidedRetryCap bounds how many consecutive worker cycles a single
+// (owner, foreign) pair may stay undecidable in sessionRotationVerdict before we give
+// up and neg-cache it. The transient /clear-flush race clears in a cycle or two, so the
+// happy path never approaches the cap; it only catches a pair that can never decide
+// (e.g. a permanently unreadable owner transcript) and would otherwise rescan
+// transcripts on every pass forever.
+const rotationUndecidedRetryCap = 10
+
+// bumpUndecidedRotation records that the (owner, foreign) pair was undecidable this
+// cycle and reports whether to keep deferring. It returns false once the pair has been
+// undecidable for rotationUndecidedRetryCap consecutive cycles, signalling the caller to
+// neg-cache instead. A change of pair resets the counter.
+func (s *Session) bumpUndecidedRotation(owner, foreign string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.rotUndecidedOwner != owner || s.rotUndecidedForeign != foreign {
+		s.rotUndecidedOwner = owner
+		s.rotUndecidedForeign = foreign
+		s.rotUndecidedCount = 0
+	}
+	s.rotUndecidedCount++
+	return s.rotUndecidedCount <= rotationUndecidedRetryCap
+}
+
+// negCacheRotation records the (owner, foreign) pair as a confirmed non-rotation so
+// future hooks for it short-circuit without rescanning transcripts, and clears any
+// undecided-retry tracking for it.
+func (s *Session) negCacheRotation(owner, foreign string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rotRejectOwner = owner
+	s.rotRejectForeign = foreign
+	s.rotUndecidedOwner = ""
+	s.rotUndecidedForeign = ""
+	s.rotUndecidedCount = 0
 }
 
 // Restart kills and recreates the tmux session with the same config.


### PR DESCRIPTION
## Problem

Diagnosed from a `D`-hotkey snapshot (`/debug-status`): a session was genuinely **waiting** on a permission prompt but the TUI was stuck showing **running**.

A `/clear`-style session rotation (`24e30322` → `a3f8eaa5`, triggered by interrupting a tool call) fires its `SessionStart` hook before the new transcript flushes its first *timestamped* entry — the file opens with timestamp-less `mode`/`permission-mode`/`file-history-snapshot` header entries. The proximity-based rotation check read zero timestamps, concluded "not a rotation", and **permanently neg-cached** the `(owner, foreign)` pair. From then on:

- fleet stayed pinned to the dead owner transcript, with its in-memory hook frozen ~55 min in the past (proven by `hookAge=55m7s` in the logs).
- Every hook from the new session — including the real `PermissionRequest` (waiting) — was dropped as "foreign".
- A latched stale-waiting hook + `applyHookWaiting`'s switch having no `StatusWaiting` case left the status pinned to `running` even with the prompt structurally on screen.

## Fix

Two compounding fixes (either resolves the case; together they're defense-in-depth):

1. **`sessionRotationVerdict` (was `isSessionRotation`) is now tri-state.** When a transcript timestamp can't be read yet it returns `rotationUnknown`, and the caller **defers** (rejects without neg-caching) so the next worker cycle re-adopts once the transcript flushes — instead of pinning the session to the dead owner id forever.

2. **`applyHookWaiting`'s latched-override switch gains a `StatusWaiting` case** so a real permission prompt on the pane recovers the status to `waiting`, rather than staying pinned to the last `running` it saw when a frozen hook never resets the latch.

## Tests

- `TestUpdateHookStatusDefersUndecidedRotation` — header-only transcript on first hook → deferred (not adopted, not neg-cached); after the timestamp flushes, a later hook adopts it.
- `TestScenarioStaleWaitingLatchRecoversToWaiting` — stale waiting hook latches finished→running, then a real prompt appears → must show `waiting`.

Both verified to fail without their fix and pass with it. Full `internal/session` suite green with `-race`; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sessions sometimes getting stuck showing a `"running"` status after rotation when they’re actually waiting for a permission prompt.
  * Improved recovery from stale “waiting” signals so the session transitions back to waiting when the prompt reappears.
  * Added safer rotation decision handling so undecided cases are deferred and retried rather than permanently rejected.
* **Tests**
  * Added coverage for deferred/undecided rotation behavior, including retry and negative-caching limits.
  * Added scenario coverage for recovering from a stale waiting latch to the correct waiting state.
* **Chores**
  * Added an unreleased changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->