### PR TITLE
fix(ui): neutralize emoji width in preview to keep the navbar on-screen

### DIFF
--- a/changelog/unreleased/preview-emoji-wrapping.md
+++ b/changelog/unreleased/preview-emoji-wrapping.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Emoji and other font-dependent glyphs in a session's preview no longer push the top navbar off-screen or scramble the layout.

--- a/internal/ui/preview.go
+++ b/internal/ui/preview.go
@@ -32,7 +32,7 @@ func RenderPreview(s *session.Session, content string, repoInfo *git.RepoInfo, w
 		if idx := strings.IndexByte(prompt, '\n'); idx != -1 {
 			prompt = prompt[:idx] + "…"
 		}
-		full := "  > " + prompt
+		full := "  > " + neutralizeUnsafeWidth(prompt)
 		if lipgloss.Width(full) > width {
 			full = ansi.Truncate(full, width, "…")
 		}
@@ -300,11 +300,23 @@ func clusterHasUnsafeWidthRune(cluster string) bool {
 	return strings.ContainsFunc(cluster, isUnsafeWidthRune)
 }
 
-// isUnsafeWidthRune flags codepoints that drive emoji presentation and so have
-// font-dependent display widths the wcwidth tables can't be trusted on: the
-// emoji planes (incl. regional-indicator flags), variation selectors, and ZWJ.
-// Deliberately narrow — BMP symbols/dingbats default to text presentation and
-// measure correctly, so they stay out to avoid mangling glyphs like ✓ or →.
+// isUnsafeWidthRune flags codepoints whose terminal display width can disagree
+// with the wcwidth tables fleet measures with: the emoji planes (incl.
+// regional-indicator flags), variation selectors, and ZWJ — multi-codepoint
+// and font-ligated sequences the tables are most likely to undercount.
+//
+// Deliberately narrow. BMP default-emoji points (⌚U+231A, ⏰U+23F0, ✅U+2705,
+// ❌U+274C, ✨U+2728, …) are intentionally left OUT not because they render as
+// text — they don't, they're Emoji_Presentation=Yes — but because the width
+// table already reports them width-2, matching how the terminal draws them, so
+// there's no disagreement to close. Listing them would only turn correctly
+// rendered emoji into dots. Text-default dingbats (✓, ✗) and arrows (→) measure
+// width-1 and render width-1, so they also stay out.
+//
+// Residual gap: a cluster the table undercounts that contains none of the
+// flagged runes — e.g. a codepoint newer than the bundled Unicode tables that
+// the table calls width-1 while the font draws width-2 — still slips through.
+// Extend the ranges below if such a case is reported.
 func isUnsafeWidthRune(r rune) bool {
 	switch {
 	case r == 0x200D: // ZERO WIDTH JOINER (emoji sequences)

--- a/internal/ui/preview.go
+++ b/internal/ui/preview.go
@@ -59,6 +59,7 @@ func RenderPreview(s *session.Session, content string, repoInfo *git.RepoInfo, w
 	}
 
 	content = stripOSC8(content)
+	content = neutralizeUnsafeWidth(content)
 	lines := strings.Split(strings.TrimRight(content, "\n"), "\n")
 	start := len(lines) - contentHeight
 	if start < 0 {
@@ -250,6 +251,70 @@ func relativeTime(t time.Time) string {
 			return "1d ago"
 		}
 		return fmt.Sprintf("%dd ago", days)
+	}
+}
+
+// neutralizeUnsafeWidth replaces emoji / ZWJ / variation-selector grapheme
+// clusters in captured pane output with width-matched ASCII dots so fleet's
+// measured width can never undercount what the terminal actually draws.
+//
+// Why this exists: the preview pane is a live mirror of an external agent pane
+// (codex/claude/opencode) — the only place fleet renders untrusted content.
+// Every width decision downstream (RenderPreview truncation, ensureExactWidth
+// padding, the bordered-panel content rows) trusts ansi/lipgloss wcwidth
+// tables. When iTerm2 + a font render a cluster WIDER than those tables claim
+// (newer-than-the-table emoji, ZWJ family sequences, flags, VS16 emoji), the
+// row overflows the panel, the terminal wraps it onto an extra physical line,
+// the fixed-height frame grows by a row, and the whole UI scrolls up — taking
+// the top navbar off-screen (issue #143). Replacing each such cluster with N
+// dots, where N is the SAME width the tables measured, forces measured==actual
+// for those cells, so no row can overflow regardless of how the font draws it.
+// Box-drawing, arrows, dingbat checkmarks (✓/✗), CJK, Hebrew and ordinary text
+// all measure reliably and are passed through untouched.
+func neutralizeUnsafeWidth(content string) string {
+	if !strings.ContainsFunc(content, isUnsafeWidthRune) {
+		return content // fast path: pure text / box-drawing / arrows — no risk
+	}
+
+	var b strings.Builder
+	b.Grow(len(content))
+
+	var state byte
+	data := content
+	for len(data) > 0 {
+		seq, width, n, newState := ansi.GraphemeWidth.DecodeSequenceInString(data, state, nil)
+		if width > 0 && clusterHasUnsafeWidthRune(seq) {
+			b.WriteString(strings.Repeat(".", width))
+		} else {
+			b.WriteString(seq)
+		}
+		data = data[n:]
+		state = newState
+	}
+	return b.String()
+}
+
+// clusterHasUnsafeWidthRune reports whether a grapheme cluster contains a rune
+// whose terminal display width can disagree with the wcwidth tables.
+func clusterHasUnsafeWidthRune(cluster string) bool {
+	return strings.ContainsFunc(cluster, isUnsafeWidthRune)
+}
+
+// isUnsafeWidthRune flags codepoints that drive emoji presentation and so have
+// font-dependent display widths the wcwidth tables can't be trusted on: the
+// emoji planes (incl. regional-indicator flags), variation selectors, and ZWJ.
+// Deliberately narrow — BMP symbols/dingbats default to text presentation and
+// measure correctly, so they stay out to avoid mangling glyphs like ✓ or →.
+func isUnsafeWidthRune(r rune) bool {
+	switch {
+	case r == 0x200D: // ZERO WIDTH JOINER (emoji sequences)
+		return true
+	case r >= 0xFE00 && r <= 0xFE0F: // variation selectors (VS1–VS16)
+		return true
+	case r >= 0x1F000 && r <= 0x1FAFF: // emoji, pictographs, flags, supplemental
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/ui/preview_test.go
+++ b/internal/ui/preview_test.go
@@ -21,7 +21,7 @@ func TestNeutralizeUnsafeWidth(t *testing.T) {
 		{"hebrew untouched", "שלום עולם", "שלום עולם"},
 		{"simple emoji to dots", "ship it 🚀 now", "ship it .. now"},
 		{"heart with VS16 to dots", "love ❤️ this", "love .. this"},
-		{"zwj family emoji to dots", "team \U0001F468‍\U0001F469‍\U0001F467 here", "team .. here"},
+		{"zwj family emoji to dots", "team \U0001F468\u200d\U0001F469\u200d\U0001F467 here", "team .. here"},
 		{"flag to dots", "lang \U0001F1EE\U0001F1F1 set", "lang .. set"},
 	}
 
@@ -42,7 +42,7 @@ func TestNeutralizeUnsafeWidthPreservesMeasuredWidth(t *testing.T) {
 	for _, in := range []string{
 		"ship it 🚀 now",
 		"love ❤️ this",
-		"team \U0001F468‍\U0001F469‍\U0001F467 here",
+		"team \U0001F468\u200d\U0001F469\u200d\U0001F467 here",
 		"\U0001F1EE\U0001F1F1 multi 🎉🎉 emoji",
 	} {
 		out := neutralizeUnsafeWidth(in)

--- a/internal/ui/preview_test.go
+++ b/internal/ui/preview_test.go
@@ -1,0 +1,67 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestNeutralizeUnsafeWidth(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain ascii untouched", "if err := workflow.Run()", "if err := workflow.Run()"},
+		{"box drawing untouched", "├─ │ └─ ╭──╮", "├─ │ └─ ╭──╮"},
+		{"arrows untouched", "foo → bar ← baz", "foo → bar ← baz"},
+		{"dingbat checkmarks untouched", "✓ done ✗ failed", "✓ done ✗ failed"},
+		{"em dash untouched", "pair — only once", "pair — only once"},
+		{"hebrew untouched", "שלום עולם", "שלום עולם"},
+		{"simple emoji to dots", "ship it 🚀 now", "ship it .. now"},
+		{"heart with VS16 to dots", "love ❤️ this", "love .. this"},
+		{"zwj family emoji to dots", "team \U0001F468‍\U0001F469‍\U0001F467 here", "team .. here"},
+		{"flag to dots", "lang \U0001F1EE\U0001F1F1 set", "lang .. set"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := neutralizeUnsafeWidth(tt.in)
+			if got != tt.want {
+				t.Errorf("neutralizeUnsafeWidth(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// The core invariant: after neutralization, fleet's measured width equals the
+// width of the (all-ASCII) result — so no downstream padding/truncation that
+// trusts ansi.StringWidth can produce a row that overflows in the terminal.
+func TestNeutralizeUnsafeWidthPreservesMeasuredWidth(t *testing.T) {
+	for _, in := range []string{
+		"ship it 🚀 now",
+		"love ❤️ this",
+		"team \U0001F468‍\U0001F469‍\U0001F467 here",
+		"\U0001F1EE\U0001F1F1 multi 🎉🎉 emoji",
+	} {
+		out := neutralizeUnsafeWidth(in)
+		if ansi.StringWidth(out) != ansi.StringWidth(in) {
+			t.Errorf("width drift for %q: in=%d out=%d", in, ansi.StringWidth(in), ansi.StringWidth(out))
+		}
+		// Result must be free of the codepoints that caused the disagreement.
+		if strings.ContainsFunc(out, isUnsafeWidthRune) {
+			t.Errorf("neutralizeUnsafeWidth(%q) left unsafe runes: %q", in, out)
+		}
+	}
+}
+
+// SGR color sequences must survive untouched while an embedded emoji is still
+// neutralized — the capture path uses `capture-pane -e`, so content is colored.
+func TestNeutralizeUnsafeWidthKeepsAnsiSequences(t *testing.T) {
+	in := "\x1b[32m+ added 🚀\x1b[0m"
+	want := "\x1b[32m+ added ..\x1b[0m"
+	if got := neutralizeUnsafeWidth(in); got != want {
+		t.Errorf("neutralizeUnsafeWidth(%q) = %q, want %q", in, got, want)
+	}
+}


### PR DESCRIPTION
## Problem

Selecting a specific codex session made **the top navbar disappear** and scrambled the preview into overlapping garbled text (issue #143). It reproduced only on that session, never on a freshly created one.

### Root cause

The preview pane is a live mirror of an external agent pane, and every width decision downstream — `RenderPreview` truncation, `ensureExactWidth` padding, and the bordered-panel content rows — trusts the `ansi`/`lipgloss` wcwidth tables.

The frame is composed to be *exactly* the terminal height (header + panels + footer = `h.height`). When iTerm2 + the font render a grapheme **wider** than those tables measure (newer-than-the-table emoji, ZWJ family sequences, regional-indicator flags, VS16 emoji — the kind of glyph that happened to be in that session's rendered diff), the line overflows the panel, the terminal **wraps it onto an extra physical row**, the frame grows past `h.height`, the terminal scrolls up by a line, and row 0 (the navbar) scrolls off the top. The same overflow overprints the rows below it → the garbled diff in the screenshot. A fresh session shows the clean home screen with no such glyph, so it never reproduces there.

## Fix

A single guard in the preview render path: after `stripOSC8`, captured content runs through `neutralizeUnsafeWidth`, which replaces emoji / ZWJ / variation-selector grapheme clusters with **ASCII dots of the same measured width**. That forces `measured == actual` for those cells, so no preview line can overflow and wrap — regardless of how the font draws the glyph.

- **Scoped to the preview** — the only place fleet renders untrusted external content.
- **Deliberately narrow target set** (emoji planes `U+1F000–1FAFF`, variation selectors `U+FE00–FE0F`, ZWJ). Box-drawing, arrows, dingbat `✓`/`✗`, em-dash, CJK and Hebrew measure reliably and pass through untouched, so codex diffs aren't mangled.
- Rejected alternatives: disabling terminal autowrap (would corrupt the agent's own rendering during PTY attach) and a conservative full-frame truncation (would clip legitimate wide content).

Cosmetic trade-off: an exotic emoji renders as `.`/`..` in the preview instead of breaking the layout.

## Testing

- New `internal/ui/preview_test.go`: pass-through (ascii, box-drawing, arrows, `✓`/`✗`, Hebrew, em-dash), emoji→dots, the width-preservation invariant, and SGR-sequence survival.
- `make build` ✅ · `make test` (race) ✅ · `gofmt` clean.

Fixes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where emoji and font-dependent glyphs in session previews caused the navbar to be pushed off-screen or scrambled the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->