### PR TITLE
fix(ui): keep help overlay (?) reachable on short terminals

### DIFF
--- a/changelog/unreleased/fix-help-overflow.md
+++ b/changelog/unreleased/fix-help-overflow.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+The `?` help overlay no longer gets cut off on short terminals — it lays bindings out in columns sized to the window and scrolls (↑↓) when there's still more than fits.

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -21,10 +21,16 @@ func NewHelpOverlay() *HelpOverlay {
 	return &HelpOverlay{}
 }
 
-func (h *HelpOverlay) Show()             { h.visible = true; h.scroll = 0 }
-func (h *HelpOverlay) Hide()             { h.visible = false }
-func (h *HelpOverlay) IsVisible() bool   { return h.visible }
-func (h *HelpOverlay) SetSize(w, ht int) { h.width = w; h.height = ht }
+func (h *HelpOverlay) Show()           { h.visible = true; h.scroll = 0 }
+func (h *HelpOverlay) Hide()           { h.visible = false }
+func (h *HelpOverlay) IsVisible() bool { return h.visible }
+
+// SetSize records the terminal size and re-clamps the scroll offset, so it
+// owns the scroll invariant on resize and View() can stay read-only.
+func (h *HelpOverlay) SetSize(w, ht int) {
+	h.width, h.height = w, ht
+	h.scroll = clampInt(h.scroll, 0, h.layout().maxScroll)
+}
 
 // Update scrolls when the sheet overflows; any non-scroll key closes it.
 func (h *HelpOverlay) Update(msg tea.Msg) (*HelpOverlay, tea.Cmd) {
@@ -88,24 +94,29 @@ func (h *HelpOverlay) layout() helpLayout {
 	n := len(entries)
 
 	const (
-		keyCap  = 14 // widest key label is "= = then digit"
-		gutter  = 2  // space between columns
-		chromeV = 8  // border(2) + padding(2) + title+blank(2) + blank+hint(2)
-		chromeH = 6  // border(2) + padding(4)
-		marginH = 2  // breathing room from the screen edges
-		indRows = 2  // ⋮ above / ⋮ below lines reserved when scrolling
+		gutter  = 2 // space between columns
+		marginH = 2 // breathing room from the screen edges
+		indRows = 2 // ⋮ above / ⋮ below lines reserved when scrolling
+		// Non-grid lines View() always emits: title+blank and blank+hint.
+		titleLines = 2
+		hintLines  = 2
 	)
+	// Frame overhead (border + padding) is read from DialogStyle, so the scroll
+	// math follows automatically if the dialog is ever restyled.
+	frameV := DialogStyle.GetVerticalFrameSize()
+	frameH := DialogStyle.GetHorizontalFrameSize()
 
+	// keyW is the true widest key (not capped), so colW always accounts for it —
+	// lipgloss .Width is a minimum, so a capped value could be overflowed.
 	keyW, descW := 0, 0
 	for _, e := range entries {
 		keyW = max(keyW, lipgloss.Width(e.Key))
 		descW = max(descW, lipgloss.Width(e.Desc))
 	}
-	keyW = min(keyW, keyCap)
 	colW := keyW + 2 + descW
 
-	availH := max(1, h.height-chromeV)
-	availW := max(colW, h.width-chromeH-marginH)
+	availH := max(1, h.height-frameV-titleLines-hintLines)
+	availW := max(colW, h.width-frameH-marginH)
 
 	colsByWidth := max(1, (availW+gutter)/(colW+gutter))
 	colsByHeight := ceilDiv(n, availH)
@@ -155,7 +166,6 @@ func (lay helpLayout) row(r int) string {
 // View renders the keybinding cheat sheet.
 func (h *HelpOverlay) View() string {
 	lay := h.layout()
-	h.scroll = clampInt(h.scroll, 0, lay.maxScroll)
 
 	var lines []string
 	lines = append(lines, TitleStyle.Render("Keybindings"), "")
@@ -191,6 +201,10 @@ func (h *HelpOverlay) View() string {
 	// an explicit Width would make lipgloss count the horizontal padding against
 	// the content area and wrap the longest binding.
 	box := DialogStyle.Render(strings.Join(lines, "\n"))
+	// Safety net so the box never bleeds past the screen. Below ~9 rows the
+	// frame + title + one binding + hint can't all fit and MaxHeight drops the
+	// hint — but that's sub-usable territory (the main sidebar/preview UI can't
+	// render at that height either).
 	box = lipgloss.NewStyle().MaxWidth(h.width).MaxHeight(h.height).Render(box)
 	return lipgloss.Place(h.width, h.height, lipgloss.Center, lipgloss.Center, box)
 }

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -12,6 +13,7 @@ type HelpOverlay struct {
 	visible bool
 	width   int
 	height  int
+	scroll  int // top grid row when the sheet is taller than the screen
 }
 
 // NewHelpOverlay creates a new help overlay.
@@ -19,44 +21,208 @@ func NewHelpOverlay() *HelpOverlay {
 	return &HelpOverlay{}
 }
 
-func (h *HelpOverlay) Show()             { h.visible = true }
+func (h *HelpOverlay) Show()             { h.visible = true; h.scroll = 0 }
 func (h *HelpOverlay) Hide()             { h.visible = false }
 func (h *HelpOverlay) IsVisible() bool   { return h.visible }
 func (h *HelpOverlay) SetSize(w, ht int) { h.width = w; h.height = ht }
 
-// Update dismisses on any key press.
+// Update scrolls when the sheet overflows; any non-scroll key closes it.
 func (h *HelpOverlay) Update(msg tea.Msg) (*HelpOverlay, tea.Cmd) {
-	if _, ok := msg.(tea.KeyMsg); ok {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return h, nil
+	}
+	lay := h.layout()
+	if lay.maxScroll == 0 {
+		// Whole sheet is visible — preserve the "any key closes" behaviour.
 		h.Hide()
 		return h, nil
 	}
+	switch key.String() {
+	case "up", "k":
+		h.scroll--
+	case "down", "j":
+		h.scroll++
+	case "pgup":
+		h.scroll -= lay.pageStep
+	case "pgdown":
+		h.scroll += lay.pageStep
+	case "home", "g":
+		h.scroll = 0
+	case "end", "G":
+		h.scroll = lay.maxScroll
+	default:
+		h.Hide()
+		return h, nil
+	}
+	h.scroll = clampInt(h.scroll, 0, lay.maxScroll)
 	return h, nil
+}
+
+// helpLayout holds the geometry computed from the terminal size, shared by
+// Update (clamping/paging) and View (rendering) so they can't disagree.
+type helpLayout struct {
+	entries     []struct{ Key, Desc string }
+	keyW        int
+	colW        int
+	gutter      int
+	cols        int
+	rowsPerCol  int
+	visibleRows int // grid rows shown at once
+	pageStep    int
+	maxScroll   int
+}
+
+// layout lays the bindings out as newspaper-style columns sized to the
+// terminal: a short/wide pane gets more columns so it fits without scrolling.
+// When even the widest-possible column count is still too tall, the remaining
+// rows scroll.
+func (h *HelpOverlay) layout() helpLayout {
+	var entries []struct{ Key, Desc string }
+	for _, b := range HelpOverlayBindings() {
+		if b.Key == "" { // drop section separators; columns provide the gaps
+			continue
+		}
+		entries = append(entries, b)
+	}
+	n := len(entries)
+
+	const (
+		keyCap  = 14 // widest key label is "= = then digit"
+		gutter  = 2  // space between columns
+		chromeV = 8  // border(2) + padding(2) + title+blank(2) + blank+hint(2)
+		chromeH = 6  // border(2) + padding(4)
+		marginH = 2  // breathing room from the screen edges
+		indRows = 2  // ⋮ above / ⋮ below lines reserved when scrolling
+	)
+
+	keyW, descW := 0, 0
+	for _, e := range entries {
+		keyW = max(keyW, lipgloss.Width(e.Key))
+		descW = max(descW, lipgloss.Width(e.Desc))
+	}
+	keyW = min(keyW, keyCap)
+	colW := keyW + 2 + descW
+
+	availH := max(1, h.height-chromeV)
+	availW := max(colW, h.width-chromeH-marginH)
+
+	colsByWidth := max(1, (availW+gutter)/(colW+gutter))
+	colsByHeight := ceilDiv(n, availH)
+	cols := clampInt(colsByHeight, 1, colsByWidth)
+	rowsPerCol := ceilDiv(n, cols)
+
+	visibleRows, maxScroll := rowsPerCol, 0
+	if rowsPerCol > availH { // can't fit even at max columns → scroll
+		visibleRows = max(1, availH-indRows)
+		maxScroll = rowsPerCol - visibleRows
+	}
+
+	return helpLayout{
+		entries:     entries,
+		keyW:        keyW,
+		colW:        colW,
+		gutter:      gutter,
+		cols:        cols,
+		rowsPerCol:  rowsPerCol,
+		visibleRows: visibleRows,
+		pageStep:    max(1, visibleRows-1),
+		maxScroll:   maxScroll,
+	}
+}
+
+// row renders one grid line: each column's cell joined by the gutter.
+func (lay helpLayout) row(r int) string {
+	keyStyle := lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Width(lay.keyW)
+	var b strings.Builder
+	for c := 0; c < lay.cols; c++ {
+		if c > 0 {
+			b.WriteString(strings.Repeat(" ", lay.gutter))
+		}
+		cell := ""
+		if idx := c*lay.rowsPerCol + r; idx < len(lay.entries) {
+			e := lay.entries[idx]
+			cell = keyStyle.Render(e.Key) + "  " + e.Desc
+		}
+		if w := lipgloss.Width(cell); w < lay.colW {
+			cell += strings.Repeat(" ", lay.colW-w)
+		}
+		b.WriteString(cell)
+	}
+	return b.String()
 }
 
 // View renders the keybinding cheat sheet.
 func (h *HelpOverlay) View() string {
-	bindings := HelpOverlayBindings()
+	lay := h.layout()
+	h.scroll = clampInt(h.scroll, 0, lay.maxScroll)
 
-	var b strings.Builder
-	b.WriteString(TitleStyle.Render("Keybindings"))
-	b.WriteString("\n\n")
+	var lines []string
+	lines = append(lines, TitleStyle.Render("Keybindings"), "")
 
-	for _, bind := range bindings {
-		if bind.Key == "" {
-			b.WriteString("\n")
-			continue
+	if lay.maxScroll == 0 {
+		for r := 0; r < lay.rowsPerCol; r++ {
+			lines = append(lines, lay.row(r))
 		}
-		key := lipgloss.NewStyle().
-			Foreground(ColorAccent).
-			Bold(true).
-			Width(12).
-			Render(bind.Key)
-		b.WriteString("  " + key + "  " + bind.Desc + "\n")
+	} else {
+		above, below := lay.hiddenCounts(h.scroll)
+		if above > 0 {
+			lines = append(lines, DimStyle.Render(fmt.Sprintf("⋮ +%d above", above)))
+		} else {
+			lines = append(lines, "")
+		}
+		for r := h.scroll; r < h.scroll+lay.visibleRows; r++ {
+			lines = append(lines, lay.row(r))
+		}
+		if below > 0 {
+			lines = append(lines, DimStyle.Render(fmt.Sprintf("⋮ +%d below", below)))
+		} else {
+			lines = append(lines, "")
+		}
 	}
 
-	b.WriteString("\n")
-	b.WriteString(DimStyle.Render("Press any key to close"))
+	hint := "Press any key to close"
+	if lay.maxScroll > 0 {
+		hint = "↑↓ scroll · any other key to close"
+	}
+	lines = append(lines, "", DimStyle.Render(hint))
 
-	box := DialogStyle.Width(40).Render(b.String())
+	// Let the box auto-size to its widest line (the padded grid rows). Forcing
+	// an explicit Width would make lipgloss count the horizontal padding against
+	// the content area and wrap the longest binding.
+	box := DialogStyle.Render(strings.Join(lines, "\n"))
+	box = lipgloss.NewStyle().MaxWidth(h.width).MaxHeight(h.height).Render(box)
 	return lipgloss.Place(h.width, h.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+// hiddenCounts returns how many bindings sit above and below the visible
+// window, counting actual entries (the last column may be short).
+func (lay helpLayout) hiddenCounts(scroll int) (above, below int) {
+	end := scroll + lay.visibleRows
+	for i := range lay.entries {
+		row := i % lay.rowsPerCol
+		if row < scroll {
+			above++
+		} else if row >= end {
+			below++
+		}
+	}
+	return
+}
+
+func ceilDiv(a, b int) int {
+	if b <= 0 {
+		return a
+	}
+	return (a + b - 1) / b
+}
+
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
 }

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -1,0 +1,77 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderedBoxHeight measures the height of the dialog box inside the centering
+// padding produced by lipgloss.Place.
+func renderedBoxHeight(view string) int {
+	lines := strings.Split(view, "\n")
+	first, last := -1, -1
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) != "" {
+			if first == -1 {
+				first = i
+			}
+			last = i
+		}
+	}
+	if first == -1 {
+		return 0
+	}
+	return last - first + 1
+}
+
+// The help sheet must never exceed the terminal: short panes used to clip the
+// top and bottom rows (issue #141).
+func TestHelpOverlayNeverOverflows(t *testing.T) {
+	sizes := []struct{ w, h int }{
+		{120, 45}, {120, 30}, {100, 20}, {80, 24}, {200, 20}, {60, 15},
+	}
+	for _, s := range sizes {
+		ho := NewHelpOverlay()
+		ho.SetSize(s.w, s.h)
+		ho.Show()
+		view := ho.View()
+		if bh := renderedBoxHeight(view); bh > s.h {
+			t.Errorf("%dx%d: box height %d exceeds terminal height %d", s.w, s.h, bh, s.h)
+		}
+		for _, ln := range strings.Split(view, "\n") {
+			if w := lipgloss.Width(ln); w > s.w {
+				t.Errorf("%dx%d: line width %d exceeds terminal width %d", s.w, s.h, w, s.w)
+				break
+			}
+		}
+	}
+}
+
+// On a short terminal where the sheet must scroll, every binding has to be
+// reachable across the scroll range.
+func TestHelpOverlayAllBindingsReachable(t *testing.T) {
+	ho := NewHelpOverlay()
+	ho.SetSize(100, 20)
+	ho.Show()
+	lay := ho.layout()
+	if lay.maxScroll == 0 {
+		t.Fatalf("expected the sheet to scroll at 100x20, got maxScroll=0")
+	}
+	seen := map[string]bool{}
+	for s := 0; s <= lay.maxScroll; s++ {
+		ho.scroll = s
+		v := ho.View()
+		for _, e := range lay.entries {
+			if strings.Contains(v, e.Desc) {
+				seen[e.Desc] = true
+			}
+		}
+	}
+	for _, e := range lay.entries {
+		if !seen[e.Desc] {
+			t.Errorf("binding %q (%s) is never visible while scrolling", e.Desc, e.Key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #141 — the `?` keybindings help overlay rendered all ~37 bindings as one tall single column and centered it with `lipgloss.Place`, which clips the top and bottom rows (including the title) whenever the box is taller than the terminal. On a short pane the clipped bindings were unreachable.

## What changed (`internal/ui/help.go`)

- **Responsive columns** — bindings now flow into newspaper-style columns sized to the window, so a wide-enough terminal fits everything without scrolling. A shared `layout()` method computes column count from both available width and height (used by `View` and `Update` so they can't disagree).
- **Scroll fallback** — when even the widest-possible column count is still too tall (e.g. a ~20-row pane), the sheet scrolls (`↑/↓`, `PgUp/PgDn`, `g/G`) with `⋮ +N above/below` cues. Any non-scroll key still closes it; when the sheet already fits, *any* key closes (unchanged behavior).
- **Never exceeds the screen** — a `MaxWidth/MaxHeight` clamp guarantees the box fits, so the title is always visible.
- **Fixed a wrapping bug** — `DialogStyle.Width(...)` made lipgloss count horizontal padding against the content area, wrapping the longest binding (`Bind/unbind slot …`) and making it unreachable. The box now auto-sizes to its content.

## Tradeoff

Because a few descriptions are long (~47 chars), two columns only engage around ~130+ cols wide; at typical laptop widths it stays single-column and relies on scroll. Both correct and reachable at any size.

## Testing

- `make build`, `go test -race ./internal/ui/`, and `go test ./...` all pass.
- New `internal/ui/help_test.go`: asserts the box never overflows the terminal across 6 sizes (incl. the 100×20 repro), and that every binding is reachable across the scroll range.
- Rendered at 100×20 and 160×22 to confirm visually — fits, title visible, long binding intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)