### PR TITLE
fix(fork): log source/parent ids at fork-initiation (#142)

### DIFF
--- a/changelog/unreleased/fork-diagnostics.md
+++ b/changelog/unreleased/fork-diagnostics.md
@@ -1,0 +1,4 @@
+---
+type: improved
+---
+Forking a session now logs the source and parent conversation ids, making it easier to diagnose a fork that opens the wrong conversation.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -392,7 +392,7 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 						// SessionStart hook beat the first user turn to disk). Reject WITHOUT
 						// neg-caching so the next cycle re-evaluates once it flushes — neg-caching
 						// here would freeze the hook on the dead owner session forever (issue #23).
-						debuglog.Logger.Debug("deferring undecided claude session",
+						debuglog.Logger.Info("deferring undecided claude session",
 							"id", s.ID, "owner", owner, "foreign", hs.SessionID)
 						return false
 					}
@@ -401,7 +401,7 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 					// owner transcript). Neg-cache so a persistent foreign id doesn't rescan
 					// transcripts every cycle.
 					s.negCacheRotation(owner, hs.SessionID)
-					debuglog.Logger.Debug("ignoring foreign claude session",
+					debuglog.Logger.Info("ignoring foreign claude session",
 						"id", s.ID, "owner", owner, "foreign", hs.SessionID)
 					return false
 				}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -564,6 +564,18 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s.WorkspaceName = msg.workspaceName
 		s.ForkFromID = msg.parentClaudeSessionID
 		s.Agent = ag
+		// Record which conversation we're forking from. The fork resumes the
+		// source session's ClaudeSessionID; if that id is stale (a missed
+		// rotation), the fork opens the wrong conversation (issue #142). Logging
+		// the source id + parent claude id here lets a bug report pin whether the
+		// parent we forked was the source's current conversation.
+		debuglog.Logger.Info("forking session",
+			"newID", s.ID,
+			"newTitle", msg.title,
+			"sourceID", msg.sourceSessionID,
+			"sourceTitle", msg.sourceTitle,
+			"parentClaude", msg.parentClaudeSessionID,
+			"destPath", msg.path)
 		parentSessionID := msg.parentClaudeSessionID
 		sourcePath := msg.sourcePath
 		destPath := msg.path
@@ -2623,12 +2635,16 @@ func (h *Home) forkSelected() tea.Cmd {
 	}
 	title := s.Title + " (fork)"
 	claudeSessionID := s.ClaudeSessionID
+	sourceID := s.ID
+	sourceTitle := s.Title
 	path := s.ProjectPath
 	workspaceName := s.WorkspaceName
 	parentAgent := s.Agent
 	return func() tea.Msg {
 		return forkSessionMsg{
 			parentClaudeSessionID: claudeSessionID,
+			sourceSessionID:       sourceID,
+			sourceTitle:           sourceTitle,
 			sourcePath:            path,
 			path:                  path,
 			title:                 title,
@@ -2643,6 +2659,7 @@ func (h *Home) forkSelected() tea.Cmd {
 // targeting the chosen destination.
 type forkContext struct {
 	parentClaudeSessionID string
+	parentSessionID       string // fleet id of the session being forked (for diagnostics)
 	parentProjectPath     string
 	parentTitle           string
 }
@@ -2668,10 +2685,14 @@ func (h *Home) dispatchForkToWorktree(ctx *forkContext, destPath, destWorkspaceN
 		title = ctx.parentTitle + " (" + destWorkspaceName + ")"
 	}
 	parentClaudeSessionID := ctx.parentClaudeSessionID
+	sourceID := ctx.parentSessionID
+	sourceTitle := ctx.parentTitle
 	sourcePath := ctx.parentProjectPath
 	return func() tea.Msg {
 		return forkSessionMsg{
 			parentClaudeSessionID: parentClaudeSessionID,
+			sourceSessionID:       sourceID,
+			sourceTitle:           sourceTitle,
 			sourcePath:            sourcePath,
 			path:                  destPath,
 			title:                 title,
@@ -2708,6 +2729,7 @@ func (h *Home) forkToWorktreeSelected() tea.Cmd {
 	}
 	h.pendingForkCtx = &forkContext{
 		parentClaudeSessionID: s.ClaudeSessionID,
+		parentSessionID:       s.ID,
 		parentProjectPath:     s.ProjectPath,
 		parentTitle:           s.Title,
 	}

--- a/internal/ui/dialogs.go
+++ b/internal/ui/dialogs.go
@@ -32,6 +32,8 @@ type sessionCreateMsg struct {
 // destination's Claude project dir before the new session launches.
 type forkSessionMsg struct {
 	parentClaudeSessionID string
+	sourceSessionID       string // fleet id of the session being forked (for diagnostics)
+	sourceTitle           string // title of the session being forked (for diagnostics)
 	sourcePath            string
 	path                  string
 	title                 string


### PR DESCRIPTION
## Why

Issue #142: *"forked session is opened with the wrong session id."* The reporter forked `brizz-2` and the fork showed a different conversation. The attached debug log shows the fork **machinery** is healthy — the parent id was passed correctly and the fork-adoption fix (#133) fired as expected — but it can't confirm the **crux**: whether the parent id we resumed was the source session's *current* conversation.

That gap is structural, not bad luck:
- The forked source session had no hooks in the captured window (it was idle), so its `ClaudeSessionID` never appears.
- We never logged the source session's id at fork-initiation — the parent id only surfaced later via the fork's own SessionStart hook.
- The rotation rejections that would reveal a stale id (`ignoring foreign` / `deferring undecided`) were at `Debug` level, absent from an INFO dump.

Leading hypothesis: a **missed-rotation neg-cache** (issue #23 family) froze the source's `ClaudeSessionID` on a stale conversation, so forking resumed the old one. That root cause was fixed in **#144** (first in v2.11.1); the reporter is on **v2.9.0** (their auto-update is failing). This PR doesn't change that fix — it makes the *next* report conclusive either way.

## What

Diagnostics only, no behavior change:

- Add an INFO `forking session` log at fork-initiation recording the source fleet session (`sourceID` + `sourceTitle`) and the `parentClaude` id handed to `--fork-session`, threaded through both the in-place (`f`) and fork-to-worktree (`Shift+F`) paths.
- Bump the two rotation rejections (`ignoring foreign claude session` / `deferring undecided claude session`) from `Debug` → `Info`, so a missed rotation that freezes a session's `ClaudeSessionID` is visible in a normal bug report.

## Test

- `make build`, `go vet`, `go test ./internal/session/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced session forking diagnostics by logging source session ID and parent conversation context to help identify when a fork opens an incorrect conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->