### PR TITLE
fix: show sessions as running during /compact

### DIFF
--- a/.claude/skills/debug-status/SKILL.md
+++ b/.claude/skills/debug-status/SKILL.md
@@ -21,12 +21,14 @@ Status flows through a pipeline. Your job is to trace the pipeline and find wher
 ```text
 Claude Code → hook event → hook-handler binary → status file → fsnotify → UpdateStatus() → TUI
                                                                               ↓
-                                                  pane capture + conversation-log (JSONL) — fallback/supplement
+                             pane capture + conversation-log (JSONL) + Claude session status file — fallback/supplement
 ```
 
 At each stage, ask: **what does this stage think the status is, and is it correct?**
 
 The **conversation log** (`~/.claude/projects/*/<claude_session_id>.jsonl`) is a fourth, often-decisive signal: it is appended on real conversation events (tool calls, results, thinking), so unlike the pane it is immune to repaint/spinner/queued-message quirks. Its key use: **if the log's last entry is newer than a `waiting` hook's timestamp, the user already acted and the agent resumed** — the session is running even though the hook still says waiting. (It can only *confirm running*, not waiting: a genuine unanswered prompt and a long-running tool both leave the log static — see Step 2.)
+
+The **Claude session status file** (`~/.claude/sessions/<pid>.json`, one per live `claude` process) is a fifth signal — the only one carrying Claude Code's *own* `status` flag (`busy` / `idle` / `shell`) rather than something fleet infers. It's keyed by pid but records `sessionId`, so you match it to a fleet session by the hook's `session_id`. Best use: a clean **Running-vs-Idle corroborator** when the pane is ambiguous. Three sharp limits: (1) **trust the value, not `statusUpdatedAt`** — it's event-driven, not a heartbeat, so a busy turn can carry a minutes-old timestamp; gate on whether the pid is alive instead. (2) **No `waiting` value** — a permission prompt reads `idle`/`busy` here, so it can't source Waiting. (3) **Blind to `/compact`** — compaction isn't counted as `busy`, so it stays `idle` right through a multi-minute compaction (see Step 2's compaction note). fleet does not consult this file for status detection yet, but the `D` snapshot **does** freeze it (`claude_session_status.json` + a `claude_status` block in `snapshot.json`).
 
 ## Step 0: Check for snapshots (only if user mentions they took one)
 
@@ -44,6 +46,7 @@ cat ~/.config/fleet/snapshots/<dir>/pane_clean.txt   # Human-readable pane conte
 cat ~/.config/fleet/snapshots/<dir>/debug_tail.txt   # Last 100 debug log lines for this session
 # pane_raw.txt          = ANSI-preserved capture, ready to copy to testdata/ for golden tests
 # claude_session.jsonl  = frozen copy of the Claude conversation transcript at capture time
+# claude_session_status.json = frozen copy of Claude Code's own status file (busy/idle/shell flag)
 ```
 
 Two fields in `snapshot.json` resolve most cases immediately:
@@ -51,6 +54,8 @@ Two fields in `snapshot.json` resolve most cases immediately:
 - `claude_log.advanced_past_hook` — **`true` means the conversation advanced >2s past the `waiting` hook, so the agent already resumed and a lingering `waiting` is stale** (the classic stuck-at-waiting bug). Also surfaces `last_entry_age`, `seconds_past_hook`, and `recent_gaps_s` (append cadence). `claude_log` is absent for Codex sessions (no Claude transcript).
 
 If a snapshot is available, you can often skip directly to Step 3 (Find the divergence). The frozen `claude_session.jsonl` lets you replay the exact transcript offline without racing the live file.
+
+The snapshot also carries the **Claude session status file** (Step 2): `snapshot.json` → `claude_status` block (`status`, `pid_alive`, `status_age`, `name`, `version`) with the full file frozen as `claude_session_status.json`. `pid_alive: false` means the `status` is a dead process's last-known value, not live.
 
 ## Step 1: Identify the session
 
@@ -73,7 +78,7 @@ sqlite3 ~/.config/fleet/state.db "SELECT tmux_session_name, title FROM sessions 
 
 ## Step 2: What does each layer say?
 
-Check all four layers and compare:
+Check all five layers and compare:
 
 **Hook file** (what hooks last reported):
 ```bash
@@ -113,6 +118,21 @@ Read it as:
 - **last entry == hook ts and file static** → genuinely still waiting (the prompt is unanswered).
 - Timestamps are **UTC (`Z`)**; the hook `ts` and `debug.log` are **local** — convert before comparing.
 - Caveats: a long-running tool or extended-thinking block leaves the log static for up to ~50s, so absence of growth ≠ idle. Sub-agents write `isSidechain:true` entries; filter them when asking "did the *lead* advance?". There is **no explicit status field** in the JSONL — infer from progress, not a flag.
+
+**Claude session status file** (Claude Code's *own* status flag — `~/.claude/sessions/<pid>.json`, one per live `claude` process; from a snapshot, read the `claude_status` block / `claude_session_status.json` instead):
+```bash
+CS=$(jq -r .session_id ~/.config/fleet/hooks/<instance_id>.json)
+grep -l "\"$CS\"" ~/.claude/sessions/*.json 2>/dev/null | while read -r f; do
+  jq '{pid, status, statusUpdatedAt, name, cwd, version}' "$f"
+  P=$(jq -r .pid "$f")
+  ps -p "$P" >/dev/null 2>&1 && echo "  → pid $P ALIVE (status is live)" || echo "  → pid $P DEAD (status is last-known, likely stale)"
+done
+```
+Read it as:
+- `status` is Claude Code's own flag: **`busy`** (processing a turn) → running, **`idle`** (done / at prompt) → finished/idle, **`shell`** (running a shell command) → running. Keyed by pid but carries `sessionId`, so match on the hook's `session_id`.
+- **Trust the value, not the timestamp.** `statusUpdatedAt` is event-driven, not a heartbeat — a genuinely-busy turn can show a `statusUpdatedAt` minutes old. Don't read "stale ⇒ wrong"; gate on **liveness** (is the pid alive?) instead. A dead pid's file is just its last-known status.
+- **No `waiting` value exists.** A permission prompt still reads `idle`/`busy` here, so this **corroborates Running vs Idle but cannot source Waiting** — use hooks/pane for waiting.
+- **Blind to `/compact`.** Compaction is not counted as `busy`, so the file stays `idle` through a multi-minute compaction — the same blind spot the hook, pane, and transcript all share. If the symptom is "idle during compaction," this file won't rescue it; the fix is detection-side (a `PreCompact` hook → running).
 
 ## Step 3: Find the divergence
 

--- a/.claude/skills/debug-status/reference.md
+++ b/.claude/skills/debug-status/reference.md
@@ -151,7 +151,7 @@ The `snapshot.json` `claude_status` block carries Claude Code's own status flag,
 }
 ```
 
-Use it as a Running-vs-Idle corroborator only: there is no `waiting` value, and it stays `idle` through `/compact`. Trust `status` while `pid_alive` is true regardless of `status_age` (a long busy turn legitimately carries a minutes-old stamp).
+Use it as a Running-vs-Idle corroborator only: there is no `waiting` value, and it stays `idle` through `/compact`. Trust `status` while `pid_alive` is true regardless of `status_age` (a long busy turn legitimately carries a minutes-old stamp). One caveat on `pid_alive`: it is **PID-only**, so a recycled PID (the file's process exited and the OS reassigned its number) can report a dead session's last status as live — sanity-check against the pane/transcript if a `busy` reading looks impossible.
 
 Implementation: `internal/ui/snapshot.go` (capture logic + `findClaudeSessionStatus`), `internal/session/session.go` `SnapshotData()` (state export).
 

--- a/.claude/skills/debug-status/reference.md
+++ b/.claude/skills/debug-status/reference.md
@@ -116,9 +116,10 @@ Location: `~/.config/fleet/snapshots/<timestamp>_<title>/`
 |------|----------|
 | `pane_raw.txt` | Raw ANSI pane capture (copy to `testdata/` for golden tests) |
 | `pane_clean.txt` | ANSI-stripped for human reading |
-| `snapshot.json` | Session state, hook state, content tracking, pane detection, `mismatch` flag, `claude_log` block |
+| `snapshot.json` | Session state, hook state, content tracking, pane detection, `mismatch` flag, `claude_log` + `claude_status` blocks |
 | `debug_tail.txt` | Last 100 debug.log lines filtered for this session |
 | `claude_session.jsonl` | Frozen full copy of the Claude conversation transcript at capture time (absent for Codex sessions) |
+| `claude_session_status.json` | Frozen copy of Claude Code's own per-process status file (`busy`/`idle`/`shell`), matched by `sessionId` (absent for Codex, or if no live/stale file matches) |
 
 The `snapshot.json` `detection.mismatch` field is `true` when pane detection disagrees with the TUI status — the key signal for status bugs.
 
@@ -138,7 +139,21 @@ The `snapshot.json` `claude_log` block derives activity-recency from the transcr
 
 `advanced_past_hook` is the decisive signal for the stuck-at-waiting class: a `waiting` hook never gets a resume event (no hook fires on permission-grant or AskUserQuestion-answer), so the transcript advancing past it proves the agent is running even when pane detection is blind.
 
-Implementation: `internal/ui/snapshot.go` (capture logic), `internal/session/session.go` `SnapshotData()` (state export).
+The `snapshot.json` `claude_status` block carries Claude Code's own status flag, read from `~/.claude/sessions/<pid>.json` (matched by `sessionId`, live process preferred over a stale dead one):
+
+```json
+"claude_status": {
+  "file": "claude_session_status.json",
+  "pid": 18581, "pid_alive": true,   // false ⇒ status is a dead process's last-known value
+  "status": "busy",                  // Claude's own flag: busy | idle | shell (no "waiting" value)
+  "status_updated_at": "...Z", "status_age": "1m9s",  // event-driven, NOT a heartbeat — trust the value, not the age
+  "name": "…", "version": "2.1.201"
+}
+```
+
+Use it as a Running-vs-Idle corroborator only: there is no `waiting` value, and it stays `idle` through `/compact`. Trust `status` while `pid_alive` is true regardless of `status_age` (a long busy turn legitimately carries a minutes-old stamp).
+
+Implementation: `internal/ui/snapshot.go` (capture logic + `findClaudeSessionStatus`), `internal/session/session.go` `SnapshotData()` (state export).
 
 ## Hook Status Files
 

--- a/changelog/unreleased/fix-compacting-shows-running.md
+++ b/changelog/unreleased/fix-compacting-shows-running.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+Sessions now show as running (not idle) while Claude compacts the conversation, via `/compact` or auto-compaction.

--- a/cmd/fleet/hook_handler.go
+++ b/cmd/fleet/hook_handler.go
@@ -33,6 +33,12 @@ func mapEventToStatus(event string) string {
 		return "running"
 	case "Stop":
 		return "finished"
+	case "PreCompact":
+		// /compact (and auto-compaction) is a multi-minute busy phase that fires no
+		// other hook. Without this, the session reads finished/idle for the whole
+		// compaction (SessionStart→finished on completion closes the bracket, and
+		// any queued prompt then flips it back to running via UserPromptSubmit).
+		return "running"
 	case "PermissionRequest":
 		return "waiting"
 	case "Notification":

--- a/cmd/fleet/hook_handler.go
+++ b/cmd/fleet/hook_handler.go
@@ -36,8 +36,9 @@ func mapEventToStatus(event string) string {
 	case "PreCompact":
 		// /compact (and auto-compaction) is a multi-minute busy phase that fires no
 		// other hook. Without this, the session reads finished/idle for the whole
-		// compaction (SessionStart→finished on completion closes the bracket, and
-		// any queued prompt then flips it back to running via UserPromptSubmit).
+		// compaction. The closing SessionStart(source="compact") is skipped in
+		// handleHookHandler (not force-finished), so pane + stability detection —
+		// or a queued prompt's UserPromptSubmit — settle the end of compaction.
 		return "running"
 	case "PermissionRequest":
 		return "waiting"
@@ -64,6 +65,16 @@ func mapEventToStatus(event string) string {
 	default:
 		return ""
 	}
+}
+
+// isCompactSessionStart reports the SessionStart that Claude Code fires when a
+// compaction completes. Its status must NOT be forced to "finished": on
+// auto-compaction the turn is still running, so finishing here would flash a
+// spurious "finished" mid-turn. Skipping it lets the prior "running" (from the
+// PreCompact hook) stand; pane + stability detection settle a manual /compact
+// that ends at an idle prompt.
+func isCompactSessionStart(event, source string) bool {
+	return event == "SessionStart" && source == "compact"
 }
 
 // handleHookHandler processes a Claude Code hook event.
@@ -98,6 +109,14 @@ func handleHookHandler() {
 			"claudeSession", payload.SessionID,
 			"source", payload.Source,
 		)
+		return
+	}
+
+	// A compaction's closing SessionStart must not force "finished" (see
+	// isCompactSessionStart): keep the prior status file so PreCompact's "running"
+	// stands and detection settles the end.
+	if isCompactSessionStart(payload.HookEventName, payload.Source) {
+		log.Debug("hook-handler: skipping compact SessionStart", "instance", instanceID)
 		return
 	}
 

--- a/cmd/fleet/hook_handler_test.go
+++ b/cmd/fleet/hook_handler_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func TestMapEventToStatus(t *testing.T) {
+	cases := []struct {
+		event string
+		want  string
+	}{
+		{"UserPromptSubmit", "running"},
+		{"Stop", "finished"},
+		{"PreCompact", "running"}, // /compact & auto-compaction: a multi-minute busy phase
+		{"PermissionRequest", "waiting"},
+		{"SessionStart", "finished"},
+		{"SessionEnd", "dead"},
+		{"Notification", ""}, // resolved separately by matcher
+		{"session.busy", "running"},
+		{"session.idle", "finished"},
+		{"session.error", "error"},
+		{"permission.asked", "waiting"},
+		{"permission.replied", "running"},
+		{"UnknownEvent", ""},
+	}
+	for _, c := range cases {
+		if got := mapEventToStatus(c.event); got != c.want {
+			t.Errorf("mapEventToStatus(%q) = %q, want %q", c.event, got, c.want)
+		}
+	}
+}

--- a/cmd/fleet/hook_handler_test.go
+++ b/cmd/fleet/hook_handler_test.go
@@ -27,3 +27,23 @@ func TestMapEventToStatus(t *testing.T) {
 		}
 	}
 }
+
+func TestIsCompactSessionStart(t *testing.T) {
+	cases := []struct {
+		event, source string
+		want          bool
+	}{
+		{"SessionStart", "compact", true},  // the closing bracket we must skip
+		{"SessionStart", "startup", false}, // normal boot → finished
+		{"SessionStart", "resume", false},
+		{"SessionStart", "clear", false}, // /clear → fresh idle → finished
+		{"SessionStart", "", false},
+		{"Stop", "compact", false},       // only SessionStart is special-cased
+		{"PreCompact", "compact", false}, // PreCompact still maps to running
+	}
+	for _, c := range cases {
+		if got := isCompactSessionStart(c.event, c.source); got != c.want {
+			t.Errorf("isCompactSessionStart(%q, %q) = %v, want %v", c.event, c.source, got, c.want)
+		}
+	}
+}

--- a/internal/hooks/claude_hooks.go
+++ b/internal/hooks/claude_hooks.go
@@ -49,6 +49,7 @@ var hookEventConfigs = []struct {
 }{
 	{Event: "UserPromptSubmit", Async: true},
 	{Event: "Stop", Async: true},
+	{Event: "PreCompact", Async: true},
 	{Event: "PermissionRequest", Async: true},
 	{Event: "Notification", Matcher: "permission_prompt|elicitation_dialog", Async: true},
 	{Event: "Notification", Matcher: "idle_prompt", Async: true},

--- a/internal/hooks/claude_hooks_test.go
+++ b/internal/hooks/claude_hooks_test.go
@@ -367,6 +367,7 @@ func buildHooksMapWithMarker() map[string]json.RawMessage {
 	hooks := map[string]json.RawMessage{
 		"UserPromptSubmit":  json.RawMessage(fleetHookJSON),
 		"Stop":              json.RawMessage(fleetHookJSON),
+		"PreCompact":        json.RawMessage(fleetHookJSON),
 		"PermissionRequest": json.RawMessage(fleetHookJSON),
 		"Notification":      json.RawMessage(notificationHook),
 		"SessionStart":      json.RawMessage(fleetHookJSON),

--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -170,14 +170,21 @@ func Kill(pids []int, grace time.Duration) error {
 		time.Sleep(50 * time.Millisecond)
 	}
 	for _, pid := range pids {
-		if alive(pid) {
+		if Alive(pid) {
 			_ = syscall.Kill(pid, syscall.SIGKILL)
 		}
 	}
 	return nil
 }
 
-// alive probes whether a pid exists using signal 0 (sends no signal).
-func alive(pid int) bool { return syscall.Kill(pid, 0) == nil }
+// Alive probes whether a pid exists using signal 0 (sends no signal). A
+// non-positive pid is treated as dead: signal 0 to pid 0/-1 targets a process
+// group, which is never what a liveness check wants.
+func Alive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
 
-func anyAlive(pids []int) bool { return slices.ContainsFunc(pids, alive) }
+func anyAlive(pids []int) bool { return slices.ContainsFunc(pids, Alive) }

--- a/internal/session/golden_test.go
+++ b/internal/session/golden_test.go
@@ -36,6 +36,7 @@ var goldenTests = []struct {
 	{"pane_waiting_askuserquestion_checkbox_focus.txt", StatusWaiting, "AskUserQuestion dialog with focus on checkbox question header (no `❯ N.` cursor in numbered options)"},
 	{"pane_waiting_exitplanmode_approve.txt", StatusWaiting, "ExitPlanMode plan-approval menu — numbered options with `shift+tab to approve with this feedback` footer (no `Esc to cancel`)"},
 	{"finished_idle_background_agent.txt", StatusFinished, "idle prompt while a background agent runs (`✻ Waiting for 1 background agent to finish` in scrollback + active sub-agent footer)"},
+	{"pane_finished_compacting.txt", StatusFinished, "mid-`/compact` pane — reads finished from the prompt/queued-message `❯`s (pane detection can't see compaction; the PreCompact hook is what keeps this session running)"},
 }
 
 func TestGoldenDetection(t *testing.T) {

--- a/internal/session/testdata/pane_finished_compacting.txt
+++ b/internal/session/testdata/pane_finished_compacting.txt
@@ -1,0 +1,37 @@
+
+  [1mWhere the stream stands after this marathon:[0m 16 terminal verdicts (15 evidence-kills + 1 preference-shelve), zero phantoms survived, two durable trading rules produced
+  (far-touch is optimal on momentum arms; don't trust minute-bucket grids without floor semantics), ~50GB of reusable corpora banked, and one live candidate in flight. The
+  remaining open items are exactly three: the G11 verdict, the bundled G1/Polygon decision (rides on your dense-feed call), and — standing quietly in the background — the
+  broker-latency lever, which is still the largest known-positive number on the board.
+
+[38;5;239m[48;5;237m❯ [38;5;231mis it runing? we waiting on something?[39m
+  [38;5;231malso tell me when to compact, when we get the chance[39m
+
+[49m  [38;5;246mRan [1m1[0m[38;5;246m shell command [39m
+
+[38;5;231m⏺[39m [1mYes, it's running — we're only waiting on the StockTwits back-paging[0m (politeness-rate-limited, not compute-bound):
+
+  - [1mLive processes:[0m 4 pullers (NVDA, TSLA, AMD, QQQ), the supervisor, and the autorun watcher — all detached and caffeinated.
+  - [1mProgress toward Feb 12:[0m AAPL ✅ done (35k msgs) · AMD → May 4 · TSLA → May 11 · NVDA → May 23 · QQQ just started · SPY queued (starts when a slot frees). The slow tails are
+  NVDA/TSLA/SPY (high message volume), so figure [1m~3–4 more hours[0m until all six corpus names are done — at which point the probe [1mfires itself[0m and writes the verdict to
+  [38;5;153mvar/g11_probe.out[39m (status breadcrumbs in [38;5;153mvar/g11_probe.status[39m). Nothing needs me or you awake for it.
+
+  [1mOn compacting: now is the ideal moment.[0m Everything is externalized — LOG.md carries the full STATUS + resume recipes, all work is committed, the pulls/probe are
+  session-independent, and results land in files. After compacting (or even in a totally fresh session), the pickup is just: read [38;5;153mvar/g11_probe.status[39m, then [38;5;153mvar/g11_probe.out[39m,
+  judge against the gates declared in the LOG. There's no in-context state worth preserving that isn't already on disk.
+
+[38;5;239m[48;5;237m❯ [38;5;231m/compact[39m
+[49m
+[38;5;147m·[39m [38;5;147mCompacting conversation… [38;5;246m(2m 27s)[39m
+  ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰[38;5;246m▱▱▱▱▱▱▱▱[39m [38;5;246m81%[39m
+
+  [38;5;239m[48;5;237m❯ [38;5;231mbtw what do u think about some "news effect trade"[39m                                                                                                                        [49m
+  [48;5;237m  [38;5;231mor "weather effect trade"?[39m                                                                                                                                                [49m
+  [48;5;237m  [38;5;231masses, is that something worth pursing?[39m                                                                                                                                   [49m
+  [48;5;237m  [38;5;231mgive me ur based recommendation[39m                                                                                                                                           [49m
+
+[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[38;5;246m❯ [2m[39mPress up to edit queued messages[0m
+[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m  [36m󰧑 Fable 5[38;5;246m [90m│[38;5;246m [33m██████░░░░[38;5;246m [90m│[38;5;246m [33m60%[38;5;246m [90m│[38;5;246m [35m󰍛 600.0k/1000k[38;5;246m [90m│[38;5;246m [33m fable-fresh-ideas[38;5;246m [90m│[38;5;246m [1m[37m  stonks-fable-fresh-ideas[0m                                                                         [38;5;114m]8;id=bkwziw;https://claude.ai/code/session_017ZNQAJBbHhSoD8mwCzHAPi\/rc[39m]8;;\
+  [38;5;220m⏵⏵ auto mode on[38;5;246m (shift+tab to cycle) · ← for agents[39m

--- a/internal/ui/snapshot.go
+++ b/internal/ui/snapshot.go
@@ -11,11 +11,11 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/brizzai/fleet/internal/debuglog"
 	"github.com/brizzai/fleet/internal/hooks"
+	"github.com/brizzai/fleet/internal/proc"
 	"github.com/brizzai/fleet/internal/session"
 )
 
@@ -324,6 +324,7 @@ func buildClaudeLogBlock(st *claudeLogStat, hookUpdatedAt, now time.Time) map[st
 // the untouched file bytes so the snapshot can freeze a verbatim copy.
 type claudeSessionStatus struct {
 	raw             []byte
+	alive           bool   // liveness verdict, computed once during the match
 	PID             int    `json:"pid"`
 	SessionID       string `json:"sessionId"`
 	Status          string `json:"status"`
@@ -364,11 +365,11 @@ func findClaudeSessionStatusIn(dir, claudeSessionID string) *claudeSessionStatus
 			continue
 		}
 		css.raw = raw
-		alive := pidAlive(css.PID)
-		if best == nil || (alive && !bestAlive) ||
-			(alive == bestAlive && css.StatusUpdatedAt > best.StatusUpdatedAt) {
+		css.alive = proc.Alive(css.PID)
+		if best == nil || (css.alive && !bestAlive) ||
+			(css.alive == bestAlive && css.StatusUpdatedAt > best.StatusUpdatedAt) {
 			pick := css
-			best, bestAlive = &pick, alive
+			best, bestAlive = &pick, css.alive
 		}
 	}
 	return best
@@ -379,6 +380,8 @@ func findClaudeSessionStatusIn(dir, claudeSessionID string) *claudeSessionStatus
 // distinguishes a live flag from a dead process's last-known value. Trust the
 // value while alive, not status_age — the flag is event-driven, not a heartbeat,
 // and it stays "idle" through /compact (so it can't explain a compaction stall).
+// Caveat: pid_alive is PID-only — a recycled PID (the file's process exited and
+// the OS reassigned its PID) can report a dead session's last status as live.
 func buildClaudeStatusBlock(css *claudeSessionStatus, now time.Time) map[string]any {
 	if css == nil {
 		return nil
@@ -386,7 +389,7 @@ func buildClaudeStatusBlock(css *claudeSessionStatus, now time.Time) map[string]
 	m := map[string]any{
 		"file":      "claude_session_status.json",
 		"pid":       css.PID,
-		"pid_alive": pidAlive(css.PID),
+		"pid_alive": css.alive,
 		"status":    css.Status,
 		"name":      css.Name,
 		"version":   css.Version,
@@ -397,16 +400,6 @@ func buildClaudeStatusBlock(css *claudeSessionStatus, now time.Time) map[string]
 		m["status_age"] = fmtSnapshotAge(t, now)
 	}
 	return m
-}
-
-// pidAlive reports whether a process with pid currently exists. Mirrors
-// internal/proc's liveness probe: signal 0 checks existence without delivering a
-// signal. A dead pid means a status file is only a last-known value.
-func pidAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	return syscall.Kill(pid, 0) == nil
 }
 
 // copyFileStreaming copies src to dst without loading the whole file into memory

--- a/internal/ui/snapshot.go
+++ b/internal/ui/snapshot.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/brizzai/fleet/internal/debuglog"
@@ -75,6 +76,17 @@ func captureStatusSnapshot(s *session.Session, sessionID string, hb workerHeartb
 		}
 	}
 
+	// 6b. Freeze Claude Code's own per-process status file
+	// (~/.claude/sessions/<pid>.json), located by sessionId. It carries Claude's
+	// first-party busy/idle/shell flag — a Running-vs-Idle corroborator the hook,
+	// pane, and transcript all lack. Best-effort; keyed by pid, so we prefer a
+	// live process over a stale dead one.
+	var claudeStatus map[string]any
+	if css := findClaudeSessionStatus(snap.ClaudeSessionID); css != nil {
+		claudeStatus = buildClaudeStatusBlock(css, now)
+		_ = os.WriteFile(filepath.Join(snapshotDir, "claude_session_status.json"), css.raw, 0644)
+	}
+
 	// 7. Write files.
 	_ = os.WriteFile(filepath.Join(snapshotDir, "pane_raw.txt"), []byte(rawPane), 0644)
 	_ = os.WriteFile(filepath.Join(snapshotDir, "pane_clean.txt"), []byte(session.StripANSI(rawPane)), 0644)
@@ -83,7 +95,7 @@ func captureStatusSnapshot(s *session.Session, sessionID string, hb workerHeartb
 	// when its heartbeat (worker block in snapshot.json) shows it stalled.
 	writeGoroutineDump(filepath.Join(snapshotDir, "goroutines.txt"))
 
-	meta := buildSnapshotJSON(snap, hookFileContent, hookFileInfo, now, claudeLog, hb)
+	meta := buildSnapshotJSON(snap, hookFileContent, hookFileInfo, now, claudeLog, claudeStatus, hb)
 	jsonData, _ := json.MarshalIndent(meta, "", "  ")
 	_ = os.WriteFile(filepath.Join(snapshotDir, "snapshot.json"), jsonData, 0644)
 
@@ -92,7 +104,7 @@ func captureStatusSnapshot(s *session.Session, sessionID string, hb workerHeartb
 	return statusSnapshotMsg{path: snapshotDir}
 }
 
-func buildSnapshotJSON(snap session.StatusSnapshot, hookFileRaw []byte, hookFileInfo os.FileInfo, now time.Time, claudeLog map[string]any, hb workerHeartbeat) map[string]any {
+func buildSnapshotJSON(snap session.StatusSnapshot, hookFileRaw []byte, hookFileInfo os.FileInfo, now time.Time, claudeLog, claudeStatus map[string]any, hb workerHeartbeat) map[string]any {
 	m := map[string]any{
 		"captured_at": now.Format(time.RFC3339Nano),
 		"session": map[string]any{
@@ -107,6 +119,9 @@ func buildSnapshotJSON(snap session.StatusSnapshot, hookFileRaw []byte, hookFile
 	}
 	if claudeLog != nil {
 		m["claude_log"] = claudeLog
+	}
+	if claudeStatus != nil {
+		m["claude_status"] = claudeStatus
 	}
 
 	// Worker liveness. `stalled: true` (or a large last_cycle_ago) means the
@@ -301,6 +316,97 @@ func buildClaudeLogBlock(st *claudeLogStat, hookUpdatedAt, now time.Time) map[st
 		}
 	}
 	return m
+}
+
+// claudeSessionStatus mirrors the fields we read from Claude Code's own
+// per-process status file (~/.claude/sessions/<pid>.json). status is Claude's
+// first-party flag (busy / idle / shell); statusUpdatedAt is epoch-ms. raw holds
+// the untouched file bytes so the snapshot can freeze a verbatim copy.
+type claudeSessionStatus struct {
+	raw             []byte
+	PID             int    `json:"pid"`
+	SessionID       string `json:"sessionId"`
+	Status          string `json:"status"`
+	StatusUpdatedAt int64  `json:"statusUpdatedAt"`
+	Name            string `json:"name"`
+	Version         string `json:"version"`
+}
+
+// findClaudeSessionStatus scans ~/.claude/sessions/*.json for the file(s) whose
+// sessionId matches claudeSessionID and returns the best match. The dir is keyed
+// by pid, so a session can have a stale dead-process file alongside the live one:
+// a live process wins over a dead one, and newest statusUpdatedAt breaks ties.
+// Returns nil if nothing matches.
+func findClaudeSessionStatus(claudeSessionID string) *claudeSessionStatus {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return findClaudeSessionStatusIn(filepath.Join(home, ".claude", "sessions"), claudeSessionID)
+}
+
+// findClaudeSessionStatusIn is findClaudeSessionStatus with the sessions dir
+// injected, so the match/liveness/tiebreak logic is testable off a temp dir.
+func findClaudeSessionStatusIn(dir, claudeSessionID string) *claudeSessionStatus {
+	if claudeSessionID == "" {
+		return nil
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, "*.json"))
+	var best *claudeSessionStatus
+	var bestAlive bool
+	for _, p := range matches {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		var css claudeSessionStatus
+		if json.Unmarshal(raw, &css) != nil || css.SessionID != claudeSessionID {
+			continue
+		}
+		css.raw = raw
+		alive := pidAlive(css.PID)
+		if best == nil || (alive && !bestAlive) ||
+			(alive == bestAlive && css.StatusUpdatedAt > best.StatusUpdatedAt) {
+			pick := css
+			best, bestAlive = &pick, alive
+		}
+	}
+	return best
+}
+
+// buildClaudeStatusBlock renders the Claude session status file signal for
+// snapshot.json. status is Claude Code's own busy/idle/shell flag; pid_alive
+// distinguishes a live flag from a dead process's last-known value. Trust the
+// value while alive, not status_age — the flag is event-driven, not a heartbeat,
+// and it stays "idle" through /compact (so it can't explain a compaction stall).
+func buildClaudeStatusBlock(css *claudeSessionStatus, now time.Time) map[string]any {
+	if css == nil {
+		return nil
+	}
+	m := map[string]any{
+		"file":      "claude_session_status.json",
+		"pid":       css.PID,
+		"pid_alive": pidAlive(css.PID),
+		"status":    css.Status,
+		"name":      css.Name,
+		"version":   css.Version,
+	}
+	if css.StatusUpdatedAt > 0 {
+		t := time.UnixMilli(css.StatusUpdatedAt)
+		m["status_updated_at"] = t.UTC().Format(time.RFC3339Nano)
+		m["status_age"] = fmtSnapshotAge(t, now)
+	}
+	return m
+}
+
+// pidAlive reports whether a process with pid currently exists. Mirrors
+// internal/proc's liveness probe: signal 0 checks existence without delivering a
+// signal. A dead pid means a status file is only a last-known value.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
 }
 
 // copyFileStreaming copies src to dst without loading the whole file into memory

--- a/internal/ui/snapshot_status_test.go
+++ b/internal/ui/snapshot_status_test.go
@@ -84,6 +84,7 @@ func TestBuildClaudeStatusBlock(t *testing.T) {
 	now := time.Now()
 	updated := now.Add(-90 * time.Second)
 	css := &claudeSessionStatus{
+		alive:           true,
 		PID:             os.Getpid(),
 		Status:          "busy",
 		StatusUpdatedAt: updated.UnixMilli(),
@@ -96,7 +97,7 @@ func TestBuildClaudeStatusBlock(t *testing.T) {
 		t.Errorf("status = %v, want busy", m["status"])
 	}
 	if m["pid_alive"] != true {
-		t.Errorf("pid_alive = %v, want true (the test process is alive)", m["pid_alive"])
+		t.Errorf("pid_alive = %v, want true (verdict threaded from the match)", m["pid_alive"])
 	}
 	if m["file"] != "claude_session_status.json" {
 		t.Errorf("file = %v", m["file"])

--- a/internal/ui/snapshot_status_test.go
+++ b/internal/ui/snapshot_status_test.go
@@ -1,0 +1,114 @@
+package ui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// deadPID is near int32 max, so syscall.Kill(deadPID, 0) reliably reports ESRCH
+// (no such process) — a stable stand-in for a Claude process that has exited.
+const deadPID = 2147483646
+
+func writeClaudeSessionFile(t *testing.T, dir, name string, v map[string]any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), b, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A session can leave a stale dead-process file (keyed by pid) alongside the live
+// one; the live process's status is the truth even if its stamp is older.
+func TestFindClaudeSessionStatus_PrefersLiveOverStaleDead(t *testing.T) {
+	dir := t.TempDir()
+	const sid = "8ef74b39-3dcf-49f8-afcb-db794dd47369"
+	livePID := os.Getpid()
+
+	writeClaudeSessionFile(t, dir, "dead.json", map[string]any{
+		"pid": deadPID, "sessionId": sid, "status": "idle",
+		"statusUpdatedAt": 2000, "name": "old", "version": "2.1.201",
+	})
+	writeClaudeSessionFile(t, dir, "live.json", map[string]any{
+		"pid": livePID, "sessionId": sid, "status": "busy",
+		"statusUpdatedAt": 1000, "name": "cur", "version": "2.1.201",
+	})
+	writeClaudeSessionFile(t, dir, "other.json", map[string]any{
+		"pid": livePID, "sessionId": "different-uuid", "status": "busy",
+		"statusUpdatedAt": 9999,
+	})
+
+	got := findClaudeSessionStatusIn(dir, sid)
+	if got == nil {
+		t.Fatal("expected a match, got nil")
+	}
+	if got.PID != livePID {
+		t.Errorf("live pid %d should beat dead pid despite older stamp, got pid %d", livePID, got.PID)
+	}
+	if got.Status != "busy" {
+		t.Errorf("status = %q, want busy (from the live process)", got.Status)
+	}
+}
+
+// With no live process, the newest statusUpdatedAt wins.
+func TestFindClaudeSessionStatus_TiebreakNewestAmongDead(t *testing.T) {
+	dir := t.TempDir()
+	const sid = "abc"
+	writeClaudeSessionFile(t, dir, "a.json", map[string]any{"pid": deadPID, "sessionId": sid, "status": "idle", "statusUpdatedAt": 1000})
+	writeClaudeSessionFile(t, dir, "b.json", map[string]any{"pid": deadPID - 1, "sessionId": sid, "status": "idle", "statusUpdatedAt": 2000})
+
+	got := findClaudeSessionStatusIn(dir, sid)
+	if got == nil || got.StatusUpdatedAt != 2000 {
+		t.Fatalf("expected newest dead match (stamp 2000), got %+v", got)
+	}
+}
+
+func TestFindClaudeSessionStatus_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeClaudeSessionFile(t, dir, "a.json", map[string]any{"pid": 1, "sessionId": "x", "status": "idle"})
+
+	if got := findClaudeSessionStatusIn(dir, "nope"); got != nil {
+		t.Errorf("unmatched sessionId should yield nil, got %+v", got)
+	}
+	if got := findClaudeSessionStatusIn(dir, ""); got != nil {
+		t.Errorf("empty sessionId should yield nil, got %+v", got)
+	}
+}
+
+func TestBuildClaudeStatusBlock(t *testing.T) {
+	now := time.Now()
+	updated := now.Add(-90 * time.Second)
+	css := &claudeSessionStatus{
+		PID:             os.Getpid(),
+		Status:          "busy",
+		StatusUpdatedAt: updated.UnixMilli(),
+		Name:            "my-session",
+		Version:         "2.1.201",
+	}
+
+	m := buildClaudeStatusBlock(css, now)
+	if m["status"] != "busy" {
+		t.Errorf("status = %v, want busy", m["status"])
+	}
+	if m["pid_alive"] != true {
+		t.Errorf("pid_alive = %v, want true (the test process is alive)", m["pid_alive"])
+	}
+	if m["file"] != "claude_session_status.json" {
+		t.Errorf("file = %v", m["file"])
+	}
+	if m["name"] != "my-session" || m["version"] != "2.1.201" {
+		t.Errorf("name/version = %v / %v", m["name"], m["version"])
+	}
+	if _, ok := m["status_updated_at"].(string); !ok {
+		t.Errorf("status_updated_at missing or wrong type: %v", m["status_updated_at"])
+	}
+
+	if buildClaudeStatusBlock(nil, now) != nil {
+		t.Error("nil input should yield a nil block")
+	}
+}


### PR DESCRIPTION
## What

Two related session-status changes, plus debug-status skill docs.

### 1. `/compact` shows **running** (the fix)
Sessions previously read **idle/finished** for the entire multi-minute compaction that `/compact` (and auto-compaction) triggers — a phase that fires **no** status hook, and whose pane reads `finished` to `detectStatus` (the queued-message/prompt `❯`s). This was reproduced from a `D` snapshot: hook, pane, transcript recency, *and* Claude's own status flag were all blind to compaction at once.

Fix: subscribe to Claude Code's **`PreCompact`** hook and map it → `running`. It brackets cleanly:
- `PreCompact` → running (covers manual `/compact` **and** auto-compaction)
- compaction completes → `SessionStart` (source=compact) → finished
- any queued prompt then flips back to running via `UserPromptSubmit`

Running survives the whole phase because the animated `(2m 27s)` timer + progress bar repaint every second, so the "stable >10s → finished" downgrade never fires. Existing installs pick up the new hook on next launch (a missing subscribed event re-triggers injection).

### 2. Snapshots capture Claude's session status file (diagnostics)
The `D` snapshot now freezes `~/.claude/sessions/<pid>.json` (Claude Code's own `busy`/`idle`/`shell` flag), matched by `sessionId` with the **live** process preferred over a stale dead one — as `claude_session_status.json` plus a `claude_status` block in `snapshot.json` (`status`, `pid_alive`, `status_age`, …).

### 3. Docs
`debug-status` `SKILL.md` + `reference.md` document the status file as a fifth signal (Running/Idle corroborator; no `waiting` value; blind to `/compact`; trust the value while `pid_alive`, not `status_age`).

## Tests
- `TestMapEventToStatus` — full mapping table incl. `PreCompact` → running (new `cmd/fleet` test)
- `buildHooksMapWithMarker` updated so `PreCompact` is a subscribed event (install-wiring)
- Golden fixture `pane_finished_compacting.txt` — real mid-`/compact` pane classifies `finished` (documents why the hook is needed)
- `snapshot_status_test.go` — status-file picker (live-beats-stale-dead, newest-among-dead tiebreak, no-match) + block builder; verified end-to-end against live `~/.claude/sessions` during development

`go test -race ./...` green · gofmt/vet/golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions now remain **running** throughout Claude conversation compaction, including the compaction-close transition.
  * Improved status detection by freezing and including Claude Code’s per-process busy/idle/shell status, with clearer handling of live vs stale processes.

* **Documentation**
  * Updated debug-status and snapshot guidance to document the new `claude_status` block (backed by the frozen Claude session status file) and how to interpret `pid_alive` and missing/ambiguous matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->