### PR TITLE
feat(ui): drawer shells labeled by last command + shown in collapsed bottom border

### DIFF
--- a/changelog/unreleased/drawer-shell-command-labels.md
+++ b/changelog/unreleased/drawer-shell-command-labels.md
@@ -1,0 +1,4 @@
+---
+type: improved
+---
+Terminal drawer tabs are now labeled with the latest command each shell ran (e.g. `npm run dev`), the selected tab gets a highlighted background, and when the drawer is closed its 1–3 shells show inline in the panel's bottom border.

--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -154,10 +154,10 @@ func normalizeCmd(s string) string {
 }
 
 // ForegroundCommands maps each given pane-shell pid to the command line of the
-// process it is currently running — the shell's own child process (e.g. a
-// `pane_pid` shell running "npm run dev" has an npm child). Shells sitting at a
-// prompt have no child and are absent from the result. One `ps` call regardless
-// of how many pids are passed. macOS-only.
+// process it is currently running — the leader of its tty's foreground process
+// group (e.g. a `pane_pid` shell running "npm run dev" reports "npm run dev").
+// Background jobs are excluded and a shell sitting at its prompt is absent from
+// the result. One `ps` call regardless of how many pids are passed. macOS-only.
 func ForegroundCommands(shellPIDs []int) map[int]string {
 	if len(shellPIDs) == 0 {
 		return nil
@@ -174,61 +174,74 @@ func ForegroundCommands(shellPIDs []int) map[int]string {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	// pid, ppid, then the full argv (command= is last so it may contain spaces).
-	out, err := exec.CommandContext(ctx, "ps", "-axo", "pid=,ppid=,command=").Output()
+	// pid, ppid, tpgid (the tty's foreground process group), then the full argv
+	// (command= is last so it may contain spaces).
+	out, err := exec.CommandContext(ctx, "ps", "-axo", "pid=,ppid=,tpgid=,command=").Output()
 	if len(out) == 0 || err != nil {
 		return nil
 	}
 	return parseForeground(string(out), want)
 }
 
-// parseForeground is the pure core of ForegroundCommands: it maps each wanted
-// shell pid to its child's command line. When a shell has several children (a
-// pipeline), the lowest child pid wins — the leftmost, first-started command.
+// parseForeground is the pure core of ForegroundCommands. A shell's tpgid is the
+// process group its tty currently gives keyboard input to; the leader of that
+// group (pid == tpgid) is a direct child of the shell and the command it is
+// running. Reading the leader by tpgid means background jobs (a different group)
+// never win, a pipeline resolves to its first stage (the group leader), and an
+// idle shell — whose foreground group is the shell itself, not a child — yields
+// nothing so its previous command persists.
 func parseForeground(psOut string, want map[int]bool) map[int]string {
-	type child struct {
-		pid int
-		cmd string
+	type proc struct {
+		ppid int
+		cmd  string
 	}
-	best := make(map[int]child) // shell pid -> chosen child
+	byPID := make(map[int]proc)
+	fgPgrp := make(map[int]int) // wanted shell pid -> its tty's foreground process group
 	for line := range strings.SplitSeq(psOut, "\n") {
-		line = strings.TrimLeft(line, " ")
-		if line == "" {
-			continue
-		}
-		pidStr, rest, ok := strings.Cut(line, " ")
+		pidStr, rest, ok := cutField(line)
 		if !ok {
 			continue
 		}
-		rest = strings.TrimLeft(rest, " ")
-		ppidStr, cmd, ok := strings.Cut(rest, " ")
+		ppidStr, rest, ok := cutField(rest)
 		if !ok {
 			continue
 		}
-		ppid, err := strconv.Atoi(ppidStr)
-		if err != nil || !want[ppid] {
+		tpgidStr, rest, ok := cutField(rest)
+		if !ok {
 			continue
 		}
-		pid, err := strconv.Atoi(pidStr)
-		if err != nil {
+		pid, e1 := strconv.Atoi(pidStr)
+		ppid, e2 := strconv.Atoi(ppidStr)
+		tpgid, e3 := strconv.Atoi(tpgidStr)
+		if e1 != nil || e2 != nil || e3 != nil {
 			continue
 		}
-		cmd = strings.TrimSpace(cmd)
-		if cmd == "" {
-			continue
-		}
-		if cur, seen := best[ppid]; !seen || pid < cur.pid {
-			best[ppid] = child{pid: pid, cmd: cmd}
+		byPID[pid] = proc{ppid: ppid, cmd: strings.TrimSpace(rest)}
+		if want[pid] {
+			fgPgrp[pid] = tpgid
 		}
 	}
-	if len(best) == 0 {
+
+	out := make(map[int]string)
+	for shellPID, pgrp := range fgPgrp {
+		// The foreground group's leader has pid == pgrp. Require it to be a direct
+		// child of the shell — an idle shell is its own foreground group, so its
+		// leader is the shell (parented elsewhere) and is correctly skipped.
+		if leader, ok := byPID[pgrp]; ok && leader.ppid == shellPID && leader.cmd != "" {
+			out[shellPID] = leader.cmd
+		}
+	}
+	if len(out) == 0 {
 		return nil
 	}
-	out := make(map[int]string, len(best))
-	for ppid, c := range best {
-		out[ppid] = c.cmd
-	}
 	return out
+}
+
+// cutField splits off the first space-delimited field from s (skipping any
+// leading spaces, as ps right-pads numeric columns). ok is false when s has no
+// field separator left.
+func cutField(s string) (field, rest string, ok bool) {
+	return strings.Cut(strings.TrimLeft(s, " "), " ")
 }
 
 // Kill sends SIGTERM to each pid, waits up to grace for them to exit, then

--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -153,6 +153,84 @@ func normalizeCmd(s string) string {
 	return strings.ToLower(filepath.Base(s))
 }
 
+// ForegroundCommands maps each given pane-shell pid to the command line of the
+// process it is currently running — the shell's own child process (e.g. a
+// `pane_pid` shell running "npm run dev" has an npm child). Shells sitting at a
+// prompt have no child and are absent from the result. One `ps` call regardless
+// of how many pids are passed. macOS-only.
+func ForegroundCommands(shellPIDs []int) map[int]string {
+	if len(shellPIDs) == 0 {
+		return nil
+	}
+	want := make(map[int]bool, len(shellPIDs))
+	for _, p := range shellPIDs {
+		if p > 0 {
+			want[p] = true
+		}
+	}
+	if len(want) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// pid, ppid, then the full argv (command= is last so it may contain spaces).
+	out, err := exec.CommandContext(ctx, "ps", "-axo", "pid=,ppid=,command=").Output()
+	if len(out) == 0 || err != nil {
+		return nil
+	}
+	return parseForeground(string(out), want)
+}
+
+// parseForeground is the pure core of ForegroundCommands: it maps each wanted
+// shell pid to its child's command line. When a shell has several children (a
+// pipeline), the lowest child pid wins — the leftmost, first-started command.
+func parseForeground(psOut string, want map[int]bool) map[int]string {
+	type child struct {
+		pid int
+		cmd string
+	}
+	best := make(map[int]child) // shell pid -> chosen child
+	for line := range strings.SplitSeq(psOut, "\n") {
+		line = strings.TrimLeft(line, " ")
+		if line == "" {
+			continue
+		}
+		pidStr, rest, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		rest = strings.TrimLeft(rest, " ")
+		ppidStr, cmd, ok := strings.Cut(rest, " ")
+		if !ok {
+			continue
+		}
+		ppid, err := strconv.Atoi(ppidStr)
+		if err != nil || !want[ppid] {
+			continue
+		}
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+		cmd = strings.TrimSpace(cmd)
+		if cmd == "" {
+			continue
+		}
+		if cur, seen := best[ppid]; !seen || pid < cur.pid {
+			best[ppid] = child{pid: pid, cmd: cmd}
+		}
+	}
+	if len(best) == 0 {
+		return nil
+	}
+	out := make(map[int]string, len(best))
+	for ppid, c := range best {
+		out[ppid] = c.cmd
+	}
+	return out
+}
+
 // Kill sends SIGTERM to each pid, waits up to grace for them to exit, then
 // SIGKILLs any survivors. Pids already gone are ignored. macOS-only.
 func Kill(pids []int, grace time.Duration) error {

--- a/internal/proc/proc_test.go
+++ b/internal/proc/proc_test.go
@@ -90,3 +90,44 @@ func TestNormalizeCmd(t *testing.T) {
 		}
 	}
 }
+
+func TestParseForeground(t *testing.T) {
+	// Mirrors `ps -axo pid=,ppid=,command=`: leading-padded pid, ppid, then the
+	// full argv (which may contain spaces). want = the pane-shell pids.
+	out := "" +
+		"  100     1 /sbin/launchd\n" + // unrelated root process
+		"  200   100 -zsh\n" + // shell A itself (its own ppid isn't a shell we track)
+		"  350   200 npm run dev --port 3000\n" + // A's child: the running command
+		"  360   350 node /repo/server.js\n" + // grandchild: NOT a direct child of 200
+		"  400   999 -zsh\n" + // shell B (pid 999 not tracked)
+		"  510   400 tail -f app.log\n" // B's child
+	want := map[int]bool{200: true, 400: true}
+	got := parseForeground(out, want)
+	expect := map[int]string{
+		200: "npm run dev --port 3000",
+		400: "tail -f app.log",
+	}
+	if !reflect.DeepEqual(got, expect) {
+		t.Fatalf("parseForeground = %+v, want %+v", got, expect)
+	}
+}
+
+func TestParseForegroundPicksLowestChildPid(t *testing.T) {
+	// A pipeline `a | b` gives the shell two children; the lowest pid (leftmost,
+	// first-started) wins.
+	out := "" +
+		"  700   300 sort -u\n" +
+		"  650   300 grep foo\n"
+	got := parseForeground(out, map[int]bool{300: true})
+	if got[300] != "grep foo" {
+		t.Fatalf("parseForeground pipeline = %q, want %q", got[300], "grep foo")
+	}
+}
+
+func TestParseForegroundIdleShellHasNoChild(t *testing.T) {
+	// A shell at a prompt has no child rows → absent from the result.
+	out := "  200     1 -zsh\n"
+	if got := parseForeground(out, map[int]bool{200: true}); len(got) != 0 {
+		t.Fatalf("idle shell should have no foreground command, got %+v", got)
+	}
+}

--- a/internal/proc/proc_test.go
+++ b/internal/proc/proc_test.go
@@ -92,15 +92,17 @@ func TestNormalizeCmd(t *testing.T) {
 }
 
 func TestParseForeground(t *testing.T) {
-	// Mirrors `ps -axo pid=,ppid=,command=`: leading-padded pid, ppid, then the
-	// full argv (which may contain spaces). want = the pane-shell pids.
+	// Mirrors `ps -axo pid=,ppid=,tpgid=,command=`: leading-padded pid, ppid,
+	// tpgid (the tty's foreground process group), then the full argv (which may
+	// contain spaces). A shell's row carries its tpgid; the child whose pid ==
+	// that tpgid is the foreground command. want = the pane-shell pids.
 	out := "" +
-		"  100     1 /sbin/launchd\n" + // unrelated root process
-		"  200   100 -zsh\n" + // shell A itself (its own ppid isn't a shell we track)
-		"  350   200 npm run dev --port 3000\n" + // A's child: the running command
-		"  360   350 node /repo/server.js\n" + // grandchild: NOT a direct child of 200
-		"  400   999 -zsh\n" + // shell B (pid 999 not tracked)
-		"  510   400 tail -f app.log\n" // B's child
+		"  100     1     0 /sbin/launchd\n" + // unrelated root process (no tty)
+		"  200   100   350 -zsh\n" + // shell A: foreground group is 350
+		"  350   200   350 npm run dev --port 3000\n" + // A's fg leader (pid == tpgid)
+		"  360   350   350 node /repo/server.js\n" + // grandchild in the group: not the leader
+		"  400   999   510 -zsh\n" + // shell B: foreground group is 510
+		"  510   400   510 tail -f app.log\n" // B's fg leader
 	want := map[int]bool{200: true, 400: true}
 	got := parseForeground(out, want)
 	expect := map[int]string{
@@ -112,12 +114,27 @@ func TestParseForeground(t *testing.T) {
 	}
 }
 
-func TestParseForegroundPicksLowestChildPid(t *testing.T) {
-	// A pipeline `a | b` gives the shell two children; the lowest pid (leftmost,
-	// first-started) wins.
+func TestParseForegroundExcludesBackgroundJob(t *testing.T) {
+	// `some-server &` (lower pid, its own group) then `npm run dev` (foreground):
+	// tpgid points at the foreground group, so the background job never wins even
+	// though it has the lower pid.
 	out := "" +
-		"  700   300 sort -u\n" +
-		"  650   300 grep foo\n"
+		"  300   100   650 -zsh\n" + // shell: foreground group is 650
+		"  500   300   500 some-server\n" + // backgrounded: its own group, not foreground
+		"  650   300   650 npm run dev\n" // foreground leader (pid == tpgid)
+	got := parseForeground(out, map[int]bool{300: true})
+	if got[300] != "npm run dev" {
+		t.Fatalf("parseForeground bg job = %q, want %q", got[300], "npm run dev")
+	}
+}
+
+func TestParseForegroundPipelinePicksLeader(t *testing.T) {
+	// A pipeline `grep foo | sort -u` shares one foreground group led by the first
+	// stage; tpgid resolves to that leader.
+	out := "" +
+		"  300   100   650 -zsh\n" +
+		"  650   300   650 grep foo\n" + // group leader (pid == tpgid)
+		"  700   300   650 sort -u\n" // same group, not the leader
 	got := parseForeground(out, map[int]bool{300: true})
 	if got[300] != "grep foo" {
 		t.Fatalf("parseForeground pipeline = %q, want %q", got[300], "grep foo")
@@ -125,8 +142,9 @@ func TestParseForegroundPicksLowestChildPid(t *testing.T) {
 }
 
 func TestParseForegroundIdleShellHasNoChild(t *testing.T) {
-	// A shell at a prompt has no child rows → absent from the result.
-	out := "  200     1 -zsh\n"
+	// At a prompt the shell is its own foreground group (tpgid == its pid), so the
+	// group leader is the shell — not a child — and is excluded.
+	out := "  200     1   200 -zsh\n"
 	if got := parseForeground(out, map[int]bool{200: true}); len(got) != 0 {
 		t.Fatalf("idle shell should have no foreground command, got %+v", got)
 	}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -9,6 +9,7 @@ package shell
 import (
 	"crypto/rand"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -56,6 +57,7 @@ type Shell struct {
 	mu       sync.Mutex
 	status   Status
 	exitCode string // set when status == StatusExited (from tmux PaneDeadInfo)
+	lastCmd  string // latest foreground command line the shell ran (drives the tab label)
 	tmuxName string
 	tmux     *tmux.Session
 }
@@ -163,6 +165,31 @@ func (s *Shell) ExitInfo() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.exitCode
+}
+
+// SetLastCommand records the latest foreground command line the shell ran. Empty
+// input is ignored so the last real command persists while the shell sits idle.
+// Called off the render thread (status worker).
+func (s *Shell) SetLastCommand(cmd string) {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return
+	}
+	s.mu.Lock()
+	s.lastCmd = cmd
+	s.mu.Unlock()
+}
+
+// DisplayName is the user-facing tab label: the latest command the shell ran,
+// falling back to the creation Name ("shell", "shell 2", …) before it has run
+// anything. Immutable Name is the stable identity; DisplayName is cosmetic.
+func (s *Shell) DisplayName() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lastCmd != "" {
+		return s.lastCmd
+	}
+	return s.Name
 }
 
 // RefreshStatus recomputes the shell's status from the tmux caches and returns

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -46,6 +46,7 @@ var (
 	sessionCacheData map[string]int64  // session_name -> window_activity timestamp
 	sessionDeadData  map[string]bool   // session_name -> pane_dead
 	sessionCmdData   map[string]string // session_name -> pane_current_command (foreground proc)
+	sessionPidData   map[string]int    // session_name -> pane_pid (the pane's shell process)
 	sessionCacheTime time.Time
 )
 
@@ -634,7 +635,10 @@ func captureSentinel() string {
 // call feeds Exists, GetActivity and IsPaneDead for every session, so the
 // status worker never shells out per-session for these.
 func RefreshSessionCache() {
-	cmd := exec.Command("tmux", "list-panes", "-a", "-F", "#{session_name}\t#{window_activity}\t#{pane_dead}\t#{pane_current_command}")
+	// pane_current_command stays LAST because a dead pane reports it empty, so its
+	// line ends in a trailing tab; keeping the always-present pane_pid ahead of it
+	// preserves the "possibly-empty trailing field" parsing below.
+	cmd := exec.Command("tmux", "list-panes", "-a", "-F", "#{session_name}\t#{window_activity}\t#{pane_dead}\t#{pane_pid}\t#{pane_current_command}")
 	output, err := cmd.Output()
 	if err != nil {
 		return // tmux server may not be running.
@@ -642,17 +646,18 @@ func RefreshSessionCache() {
 
 	activityCache := make(map[string]int64)
 	deadCache := make(map[string]bool)
+	pidCache := make(map[string]int)
 	cmdCache := make(map[string]string)
 	// Do NOT TrimSpace the whole output: a dead pane has an empty
-	// pane_current_command, so its line ends in a trailing tab ("name\t<act>\t1\t").
-	// Trimming the final line's tab would make SplitN yield 3 fields, dropping a
+	// pane_current_command, so its line ends in a trailing tab ("name\t<act>\t1\t<pid>\t").
+	// Trimming the final line's tab would make SplitN yield 4 fields, dropping a
 	// dead pane that happens to be last. The line == "" guard handles blanks.
 	for _, line := range strings.Split(string(output), "\n") {
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "\t", 4)
-		if len(parts) < 4 {
+		parts := strings.SplitN(line, "\t", 5)
+		if len(parts) < 5 {
 			continue
 		}
 		name := parts[0]
@@ -660,12 +665,16 @@ func RefreshSessionCache() {
 		fmt.Sscanf(parts[1], "%d", &activity)
 		activityCache[name] = activity
 		deadCache[name] = parts[2] == "1"
-		cmdCache[name] = parts[3]
+		var pid int
+		fmt.Sscanf(parts[3], "%d", &pid)
+		pidCache[name] = pid
+		cmdCache[name] = parts[4]
 	}
 
 	sessionCacheMu.Lock()
 	sessionCacheData = activityCache
 	sessionDeadData = deadCache
+	sessionPidData = pidCache
 	sessionCmdData = cmdCache
 	sessionCacheTime = time.Now()
 	sessionCacheMu.Unlock()
@@ -683,6 +692,19 @@ func PaneCurrentCommand(name string) string {
 		return ""
 	}
 	return sessionCmdData[name]
+}
+
+// PanePID returns the cached pane process id (the pane's shell) for a session,
+// or 0 when unknown. Cache-only; RefreshSessionCache populates it once per tick.
+// Used by the shells feature to find each shell's foreground child process (the
+// command it's running) via proc.ForegroundCommands.
+func PanePID(name string) int {
+	sessionCacheMu.RLock()
+	defer sessionCacheMu.RUnlock()
+	if sessionPidData == nil {
+		return 0
+	}
+	return sessionPidData[name]
 }
 
 // ListSessions returns all fleet managed tmux session names.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -4391,16 +4391,16 @@ func (h *Home) statusWorkerCycle() {
 	// at a prompt has no child, so its last command persists. Heavy cadence
 	// only — a tab label doesn't need sub-second freshness.
 	if heavy && len(shells) > 0 {
+		byPID := make(map[int]*shell.Shell, len(shells))
 		pids := make([]int, 0, len(shells))
 		for _, sh := range shells {
 			if pid := tmux.PanePID(sh.TmuxName()); pid > 0 {
+				byPID[pid] = sh
 				pids = append(pids, pid)
 			}
 		}
-		if fg := proc.ForegroundCommands(pids); len(fg) > 0 {
-			for _, sh := range shells {
-				sh.SetLastCommand(fg[tmux.PanePID(sh.TmuxName())])
-			}
+		for pid, cmd := range proc.ForegroundCommands(pids) {
+			byPID[pid].SetLastCommand(cmd)
 		}
 	}
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1566,6 +1566,11 @@ func (h *Home) renderBody() string {
 	// longer renders them.
 	statusTitle := h.statusCountsLine(nil)
 
+	// When the drawer is closed, the selected repo's shells ride the bottom
+	// border of whichever panel the drawer would open from (preview in
+	// dual/stacked, sidebar in single). "" while the drawer is open/absent.
+	shellChips := h.collapsedShellChips()
+
 	switch mode {
 	case "single":
 		// Inner content area = total - 2 for the border on each side.
@@ -1574,7 +1579,9 @@ func (h *Home) renderBody() string {
 		sidebar := RenderSidebar(h.flatItems, h.sessions, gitInfoSnap, h.slotBindings, h.cursor, h.viewOffset, innerW, innerH, !h.drawerHasFocus())
 		sidebar = ensureExactHeight(sidebar, innerH)
 		sidebar = ensureExactWidth(sidebar, innerW)
-		b.WriteString(RenderBorderedPanelTopRight(sidebar, "Sessions", statusTitle, h.width, contentHeight, h.focusMode))
+		// Single layout: the sidebar is the only (bottom-most) panel, so the
+		// collapsed shell chips ride its bottom border.
+		b.WriteString(RenderBorderedPanelInsets(sidebar, "Sessions", statusTitle, shellChips, "", h.width, contentHeight, h.focusMode))
 	case "stacked":
 		sidebarHeight := (contentHeight * 55) / 100
 		if sidebarHeight < 3 {
@@ -1596,7 +1603,8 @@ func (h *Home) renderBody() string {
 		previewInner = ensureExactWidth(previewInner, innerW)
 		previewTitle := BuildPreviewTitle(s, previewRepoInfo, h.focusMode, h.width-6)
 		previewFooter := BuildPreviewFooter(s, h.width-6)
-		b.WriteString(RenderBorderedPanelFooter(previewInner, previewTitle, previewFooter, h.width, previewHeight, h.focusMode))
+		// Stacked: preview is the bottom-most panel, so it carries the chips.
+		b.WriteString(RenderBorderedPanelInsets(previewInner, previewTitle, "", shellChips, previewFooter, h.width, previewHeight, h.focusMode))
 	default: // dual
 		gap := 1 // single-column gap between the two bordered panels
 		// Sidebar wants a ~target absolute width that's comfortable for long
@@ -1654,7 +1662,10 @@ func (h *Home) renderBody() string {
 		previewInner = ensureExactWidth(previewInner, previewInnerW)
 		previewTitle := BuildPreviewTitle(s, previewRepoInfo, h.focusMode, previewWidth-6)
 		previewFooter := BuildPreviewFooter(s, previewWidth-6)
-		rightPanel := RenderBorderedPanelFooter(previewInner, previewTitle, previewFooter, previewWidth, previewPanelH, h.focusMode)
+		// Dual: the drawer opens from the bottom of this right column, so its
+		// collapsed chips ride the preview's bottom-left border (shellChips is
+		// "" while the drawer is open, since the drawer then shows the shells).
+		rightPanel := RenderBorderedPanelInsets(previewInner, previewTitle, "", shellChips, previewFooter, previewWidth, previewPanelH, h.focusMode)
 		if rightDrawer != "" {
 			rightPanel = lipgloss.JoinVertical(lipgloss.Left, rightPanel, rightDrawer)
 		}
@@ -4373,6 +4384,24 @@ func (h *Home) statusWorkerCycle() {
 	// h.sessions, so they get their own pass.
 	for _, sh := range shells {
 		sh.RefreshStatus()
+	}
+
+	// Label each shell with the latest command it ran. One `ps` call resolves
+	// every shell's foreground child process from its cached pane pid; a shell
+	// at a prompt has no child, so its last command persists. Heavy cadence
+	// only — a tab label doesn't need sub-second freshness.
+	if heavy && len(shells) > 0 {
+		pids := make([]int, 0, len(shells))
+		for _, sh := range shells {
+			if pid := tmux.PanePID(sh.TmuxName()); pid > 0 {
+				pids = append(pids, pid)
+			}
+		}
+		if fg := proc.ForegroundCommands(pids); len(fg) > 0 {
+			for _, sh := range shells {
+				sh.SetLastCommand(fg[tmux.PanePID(sh.TmuxName())])
+			}
+		}
 	}
 
 	// 3. Sync hook status (fast: in-memory map lookups; worker may resolve a

--- a/internal/ui/drawer.go
+++ b/internal/ui/drawer.go
@@ -765,26 +765,46 @@ func (h *Home) renderDrawer(width, maxOuterH int) string {
 
 // drawerTitle is the top-border-left: the tab chips. Takes the active-repo shell
 // slice (computed once per render by renderDrawer) to avoid re-filtering h.shells.
+// The active tab renders as a filled accent pill — the same selected-row
+// vocabulary as the sidebar — so the focused shell reads at a glance.
 func (h *Home) drawerTitle(shells []*shell.Shell) string {
 	active := h.clampTab(len(shells))
+	selStyle := lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent).Bold(true).Padding(0, 1)
 	parts := []string{lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Render("Terminal")}
 	for i, sh := range shells {
-		name := sh.Name
+		name := truncCmd(sh.DisplayName(), drawerTabNameMax)
 		if sh.Status() == shell.StatusExited {
 			if c := sh.ExitInfo(); c != "" {
 				name += "(" + c + ")"
 			}
 		}
-		chip := drawerDot(sh.Status()) + " "
 		if i == active {
-			chip += lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(name)
+			parts = append(parts, drawerDot(sh.Status())+selStyle.Render(name))
 		} else {
-			chip += lipgloss.NewStyle().Foreground(ColorTextDim).Render(name)
+			parts = append(parts, drawerDot(sh.Status())+" "+lipgloss.NewStyle().Foreground(ColorTextDim).Render(name))
 		}
-		parts = append(parts, chip)
 	}
 	parts = append(parts, lipgloss.NewStyle().Foreground(ColorTextDim).Render("+"))
 	return strings.Join(parts, "  ")
+}
+
+// drawerTabNameMax caps a shell tab/chip label — command lines can be long, so
+// they're truncated to keep the tab bar and collapsed border readable.
+const drawerTabNameMax = 22
+
+// truncCmd shortens a command-line label to max runes, appending an ellipsis.
+func truncCmd(s string, max int) string {
+	if max < 1 {
+		max = 1
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	if max == 1 {
+		return "…"
+	}
+	return string(r[:max-1]) + "…"
 }
 
 // drawerModeLabel is the loud top-border-right indicator: the live target, or
@@ -793,7 +813,7 @@ func (h *Home) drawerTitle(shells []*shell.Shell) string {
 func (h *Home) drawerModeLabel(shells []*shell.Shell) string {
 	name := "shell"
 	if sh := h.activeShellIn(shells); sh != nil {
-		name = sh.Name
+		name = truncCmd(sh.DisplayName(), drawerTabNameMax)
 	}
 	if h.drawerCloseArmed {
 		return lipgloss.NewStyle().Foreground(ColorYellow).Bold(true).Render("kill " + name + "? ⌃W again")
@@ -804,6 +824,39 @@ func (h *Home) drawerModeLabel(shells []*shell.Shell) string {
 // drawerCwdLabel is the bottom-border-right cwd hint.
 func (h *Home) drawerCwdLabel() string {
 	return lipgloss.NewStyle().Foreground(ColorTextDim).Render(shortenPath(h.drawerScopeRepo()))
+}
+
+// collapsedShellMax caps how many shell chips ride a panel's bottom border while
+// the drawer is closed — a glance-able summary, not the whole list.
+const collapsedShellMax = 3
+
+// collapsedShellChips renders the selected repo's shells as a compact
+// dot + name summary for a panel's bottom border, shown while the drawer is
+// closed. Returns "" when the drawer is open/sliding (the drawer itself shows
+// the shells) or the scope repo has no shells. Capped at collapsedShellMax with
+// a "+N" overflow marker.
+func (h *Home) collapsedShellChips() string {
+	if h.drawerVisible() {
+		return ""
+	}
+	shells := h.shellsForActiveRepo()
+	if len(shells) == 0 {
+		return ""
+	}
+	nameStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+	n := len(shells)
+	shown := n
+	if shown > collapsedShellMax {
+		shown = collapsedShellMax
+	}
+	parts := make([]string, 0, shown+1)
+	for _, sh := range shells[:shown] {
+		parts = append(parts, drawerDot(sh.Status())+" "+nameStyle.Render(truncCmd(sh.DisplayName(), drawerTabNameMax)))
+	}
+	if n > shown {
+		parts = append(parts, nameStyle.Render(fmt.Sprintf("+%d", n-shown)))
+	}
+	return strings.Join(parts, "  ")
 }
 
 func drawerEmptyCTA() string {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -235,20 +235,28 @@ func ApplyPalette(p Palette) {
 // Use RenderBorderedPanelTopRight to embed a right-aligned status pill into
 // the top border, or RenderBorderedPanelFooter for the bottom-border variant.
 func RenderBorderedPanel(content, title string, width, height int, accent bool) string {
-	return renderBorderedPanel(content, title, "", "", width, height, accent)
+	return renderBorderedPanel(content, title, "", "", "", width, height, accent)
 }
 
 // RenderBorderedPanelTopRight is like RenderBorderedPanel but also embeds a
 // right-aligned status pill into the TOP border (after the title).
 func RenderBorderedPanelTopRight(content, title, titleRight string, width, height int, accent bool) string {
-	return renderBorderedPanel(content, title, titleRight, "", width, height, accent)
+	return renderBorderedPanel(content, title, titleRight, "", "", width, height, accent)
 }
 
 // RenderBorderedPanelFooter is like RenderBorderedPanel but also embeds a
 // right-aligned status pill into the bottom border. Empty footer renders an
 // unbroken bottom border.
 func RenderBorderedPanelFooter(content, title, footerRight string, width, height int, accent bool) string {
-	return renderBorderedPanel(content, title, "", footerRight, width, height, accent)
+	return renderBorderedPanel(content, title, "", "", footerRight, width, height, accent)
+}
+
+// RenderBorderedPanelInsets embeds all four optional insets: title + titleRight
+// in the top border, footerLeft + footerRight in the bottom border. Used to ride
+// the collapsed-shell chips on a panel's bottom-left while keeping its existing
+// footer (cwd / status). Any inset may be "".
+func RenderBorderedPanelInsets(content, title, titleRight, footerLeft, footerRight string, width, height int, accent bool) string {
+	return renderBorderedPanel(content, title, titleRight, footerLeft, footerRight, width, height, accent)
 }
 
 // selTitle returns the selected-row title style — muted when the sidebar is
@@ -272,10 +280,10 @@ func selStatus() lipgloss.Style {
 // (after the title) and the bottom border. Used by the terminal drawer for a
 // top-border mode label + a bottom-border cwd/hint.
 func RenderBorderedPanelFull(content, title, titleRight, footerRight string, width, height int, accent bool) string {
-	return renderBorderedPanel(content, title, titleRight, footerRight, width, height, accent)
+	return renderBorderedPanel(content, title, titleRight, "", footerRight, width, height, accent)
 }
 
-func renderBorderedPanel(content, title, titleRight, footerRight string, width, height int, accent bool) string {
+func renderBorderedPanel(content, title, titleRight, footerLeft, footerRight string, width, height int, accent bool) string {
 	if width < 6 || height < 3 {
 		return content
 	}
@@ -301,10 +309,10 @@ func renderBorderedPanel(content, title, titleRight, footerRight string, width, 
 		dashes := width - 8 - titleWidth - rightW
 		if dashes < 1 {
 			// Top is too tight; drop the trailing right text rather than wrap.
-			return renderBorderedPanel(content, title, "", footerRight, width, height, accent)
+			return renderBorderedPanel(content, title, "", footerLeft, footerRight, width, height, accent)
 		}
 		top := borderStyle.Render("╭─ ") + titleText + borderStyle.Render(" "+strings.Repeat("─", dashes)+" ") + rightText + borderStyle.Render(" ─╮")
-		return finishBorderedPanel(top, content, footerRight, width, height, borderStyle)
+		return finishBorderedPanel(top, content, footerLeft, footerRight, width, height, borderStyle)
 	}
 	// Layout: ╭ ─ ' ' title ' ' ─*K ╮ — leading dash count is 1, K fills the rest.
 	fillRight := width - 2 /*corners*/ - 1 /*leading dash*/ - 1 /*space*/ - titleWidth - 1 /*space*/
@@ -317,7 +325,7 @@ func renderBorderedPanel(content, title, titleRight, footerRight string, width, 
 		fillRight = max(width-5-titleWidth, 1)
 	}
 	top := borderStyle.Render("╭─ ") + titleText + borderStyle.Render(" "+strings.Repeat("─", fillRight)+"╮")
-	return finishBorderedPanel(top, content, footerRight, width, height, borderStyle)
+	return finishBorderedPanel(top, content, footerLeft, footerRight, width, height, borderStyle)
 }
 
 // styleIfPlain renders s with style only when s is plain text. If s already
@@ -330,12 +338,40 @@ func styleIfPlain(s string, style lipgloss.Style) string {
 	return style.Render(s)
 }
 
-func finishBorderedPanel(top, content, footerRight string, width, height int, borderStyle lipgloss.Style) string {
+func finishBorderedPanel(top, content, footerLeft, footerRight string, width, height int, borderStyle lipgloss.Style) string {
 
-	// Bottom border, optionally with a right-aligned status pill inset.
+	footerStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+
+	// Bottom border, optionally with a left-aligned inset (footerLeft, e.g. the
+	// collapsed-shell chips) and/or a right-aligned inset (footerRight, e.g. the
+	// preview cwd). The left/right and both-insets layouts mirror the top border.
 	var bottom string
-	if footerRight != "" {
-		footerStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+	switch {
+	case footerLeft != "" && footerRight != "":
+		leftText := styleIfPlain(footerLeft, footerStyle)
+		leftW := lipgloss.Width(leftText)
+		rightText := styleIfPlain(footerRight, footerStyle)
+		rightW := lipgloss.Width(rightText)
+		// Layout: ╰ ─ ' ' left ' ' ─*K ' ' right ' ' ─ ╯ — 8 fixed chars.
+		dashes := width - 8 - leftW - rightW
+		if dashes < 1 {
+			// Too tight for both — keep the right (cwd) and drop the left (chips).
+			return finishBorderedPanel(top, content, "", footerRight, width, height, borderStyle)
+		}
+		bottom = borderStyle.Render("╰─ ") + leftText + borderStyle.Render(" "+strings.Repeat("─", dashes)+" ") + rightText + borderStyle.Render(" ─╯")
+	case footerLeft != "":
+		leftText := styleIfPlain(footerLeft, footerStyle)
+		leftW := lipgloss.Width(leftText)
+		// Layout: ╰ ─ ' ' left ' ' ─*K ╯ — leading dash count is 1.
+		fillRight := width - 2 /*corners*/ - 1 /*leading dash*/ - 1 /*space*/ - leftW - 1 /*space*/
+		if fillRight < 1 {
+			maxLeft := max(width-6, 1)
+			leftText = styleIfPlain(ansi.Truncate(footerLeft, maxLeft, ""), footerStyle)
+			leftW = lipgloss.Width(leftText)
+			fillRight = max(width-5-leftW, 1)
+		}
+		bottom = borderStyle.Render("╰─ ") + leftText + borderStyle.Render(" "+strings.Repeat("─", fillRight)+"╯")
+	case footerRight != "":
 		footerText := styleIfPlain(footerRight, footerStyle)
 		footerW := lipgloss.Width(footerText)
 		// Layout: ╰─*K ' ' footer ' '─╯ — trailing dash count is 1.
@@ -348,7 +384,7 @@ func finishBorderedPanel(top, content, footerRight string, width, height int, bo
 			fillLeft = max(width-5-footerW, 1)
 		}
 		bottom = borderStyle.Render("╰"+strings.Repeat("─", fillLeft)+" ") + footerText + borderStyle.Render(" ─╯")
-	} else {
+	default:
 		bottom = borderStyle.Render("╰" + strings.Repeat("─", width-2) + "╯")
 	}
 

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -233,7 +233,8 @@ func ApplyPalette(p Palette) {
 // When accent is true, the border is drawn in the accent color (used for the
 // focused panel in dual mode); otherwise it uses the muted border color.
 // Use RenderBorderedPanelTopRight to embed a right-aligned status pill into
-// the top border, or RenderBorderedPanelFooter for the bottom-border variant.
+// the top border, or RenderBorderedPanelInsets to also embed footer insets in
+// the bottom border.
 func RenderBorderedPanel(content, title string, width, height int, accent bool) string {
 	return renderBorderedPanel(content, title, "", "", "", width, height, accent)
 }
@@ -242,13 +243,6 @@ func RenderBorderedPanel(content, title string, width, height int, accent bool) 
 // right-aligned status pill into the TOP border (after the title).
 func RenderBorderedPanelTopRight(content, title, titleRight string, width, height int, accent bool) string {
 	return renderBorderedPanel(content, title, titleRight, "", "", width, height, accent)
-}
-
-// RenderBorderedPanelFooter is like RenderBorderedPanel but also embeds a
-// right-aligned status pill into the bottom border. Empty footer renders an
-// unbroken bottom border.
-func RenderBorderedPanelFooter(content, title, footerRight string, width, height int, accent bool) string {
-	return renderBorderedPanel(content, title, "", "", footerRight, width, height, accent)
 }
 
 // RenderBorderedPanelInsets embeds all four optional insets: title + titleRight


### PR DESCRIPTION
Three related drawer/shell improvements.

## 1. Shell tab name = latest command it ran (truncated)
- `tmux.RefreshSessionCache` now also caches each pane's `pane_pid` (new `tmux.PanePID`).
- New `proc.ForegroundCommands` — one `ps` call maps every shell's pane-shell PID to its foreground child's full command line (pipeline → leftmost/first command wins).
- `shell.Shell` gains `lastCmd` + `SetLastCommand`/`DisplayName`. Resolved on the **2s heavy** worker cadence and **held while idle**, so a stopped dev server keeps its label with an idle (○) dot. `Name` stays the stable fallback (`shell`, `shell 2`).
- Labels truncate to 22 runes with `…`; exited tabs show e.g. `npm run dev…(1)`.

## 2. Collapsed shells inline in the bottom border
- New `collapsedShellChips` renders the selected repo's **1–3 shells** (status dot + name, `+N` overflow); empty while the drawer is open (the drawer shows them then).
- Chips ride the **bottom-most panel where the drawer opens**: preview in dual/stacked, sidebar in single. Added a `footerLeft` inset to the bordered-panel renderer (`RenderBorderedPanelInsets`), mirroring the top border's title+right logic; when the border is too tight it drops the chips and keeps the cwd.

```
╰─ ● npm run dev  ○ tail -f app.…  +2 ── ~/code/fleet ─╯
```

## 3. Selected shell tab gets a background
- The active drawer tab now renders as the sidebar's filled accent pill (`Foreground(ColorBg).Background(ColorAccent)`, bold, padded) instead of plain bold text.

## Tests
- `parseForeground` unit tests (idle shell → no child, pipeline picks lowest pid, grandchildren excluded).
- Verified panel border widths line up exactly with the new insets across widths 24–60, including the tight-drop fallback.
- `make build` + full `make test` (`-race`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGr6N867gHLZQaohsnLdge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drawer tabs now show the most recent command run in each shell.
  * The active drawer tab is highlighted more clearly.
  * When the drawer is closed, the panel border now shows a compact summary of active shell commands, with overflow handling for extra shells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->