### PR TITLE
feat(ui): release notes viewer in the command palette

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Use [conventional commits](https://www.conventionalcommits.org/). Version is aut
 ## Changelog
 - Each PR adds a fragment file: `changelog/unreleased/<name>.md` with `type:` frontmatter (added/improved/fixed/changed/removed)
 - **Keep fragments concise: 1–2 sentences, lead with the user-facing change.** No implementation detail, marketing tone, or exhaustive sub-points — a user skimming the release notes should grasp it at a glance. e.g. "Status updates now respond in ~150ms instead of up to 2s."
+- **Voice — fun via honest specificity, not hype.** Fragments render in-app (Ctrl+K → "Release Notes", which formats `` `code` `` + `**bold**`), so write for a reader: open each bullet with a **bold 2–4 word headline** so a release skims in one pass; write in second person ("You can now…", "Sessions now…"); name the annoyance you killed ("…instead of a cryptic 'Operation not permitted'"); numbers over adjectives ("~150ms instead of 2s"); `code`-format keys/commands/paths (`Ctrl+K`, `~/Documents`); one idea per bullet; ban hype words (seamless, powerful, delightful, blazing). Full guide + examples: `changelog/README.md`.
 - CI checks for fragment presence; comment `/no-changelog` to skip
 - At release time, fragments are merged into CHANGELOG.md and deleted
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -22,6 +22,33 @@ skimming the release notes should grasp it at a glance:
 - If a change is genuinely large, link the PR rather than narrating every facet.
 - Prefer "what changed for the user" over "how it was built."
 
+## Voice — make it fun to read
+
+Fragments are rendered in-app by the Release Notes viewer (`Ctrl+K` → "Release
+Notes"), which formats `` `code` `` and `**bold**`. Write for someone skimming
+that dialog. The delight comes from **honest specificity, not marketing** —
+being vivid and true about what changed, never hype.
+
+- **Open with a bold headline.** Start each entry with a 2–4 word `**bold**`
+  hook, then the detail — so someone reading only the bold text gets the whole
+  release. e.g. `**Worktree names stop snowballing.** …`
+- **Lead with the payoff, in second person.** "You can now…", "Sessions now…" —
+  not "Added support for…".
+- **Name the pain you killed.** The wit is in being honest about the annoyance:
+  `…instead of a cryptic "Operation not permitted".`
+- **Numbers, not adjectives.** "~150ms instead of up to 2s" — never "much faster".
+- **`code`-format the concretes.** Keys, commands, paths: `` `Ctrl+K` ``,
+  `` `npm run dev` ``, `` `~/Documents` ``.
+- **One idea per bullet.** Split compound changes; scannability beats completeness.
+- **Ban hype words:** _seamless, powerful, delightful, robust, blazing_. A dry
+  wink is welcome; a sales pitch is not.
+
+Before → after (same fix, feature-first vs. reader-first):
+
+> ~~Creating a new worktree from an existing worktree no longer snowballs the name (repo-a → repo-a-b → repo-a-b-c).~~
+>
+> **Worktree names stop snowballing.** New worktrees are named as siblings of the main repo — a worktree-of-a-worktree is `repo-b`, not `repo-a-b-c`.
+
 ## Valid Types
 
 | Type | Section |
@@ -41,7 +68,7 @@ skimming the release notes should grasp it at a glance:
 ---
 type: improved
 ---
-Status updates now respond in ~150ms instead of up to 2s
+**Status keeps pace with your sessions.** Updates now land in ~150ms, down from up to 2s.
 ```
 
 `changelog/unreleased/fix-detach-stale.md`:
@@ -49,7 +76,7 @@ Status updates now respond in ~150ms instead of up to 2s
 ---
 type: fixed
 ---
-Status showing stale data immediately after detaching from a session
+**No more stale status after detaching.** The sidebar refreshes the moment you leave, instead of showing the last frame.
 ```
 
 ## Skip

--- a/changelog/unreleased/release-notes-viewer.md
+++ b/changelog/unreleased/release-notes-viewer.md
@@ -1,0 +1,4 @@
+---
+type: added
+---
+A new "Release Notes" command in the Ctrl+K palette opens a scrollable changelog of every release — marking the version you're running and grouping newer releases you can update to.

--- a/internal/releasenotes/releasenotes.go
+++ b/internal/releasenotes/releasenotes.go
@@ -1,0 +1,286 @@
+// Package releasenotes fetches fleet's GitHub Releases so the TUI can show an
+// in-app changelog. Content is cached to ~/.config/fleet so reopening is instant
+// and works offline. Each release body is the curated CHANGELOG section (the
+// release workflow feeds GoReleaser --release-notes built from CHANGELOG.md), so
+// what we render reads exactly like the changelog.
+package releasenotes
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	repo         = "brizzai/fleet"
+	apiURL       = "https://api.github.com/repos/" + repo + "/releases?per_page=100"
+	cacheFile    = "releases.json"
+	cacheMaxAge  = time.Hour // reuse the cache within this window; older triggers a refresh
+	fetchTimeout = 3 * time.Second
+)
+
+// Section is one "### Added"/"### Fixed" group parsed from a release body.
+type Section struct {
+	Title   string   `json:"title"`
+	Bullets []string `json:"bullets"`
+}
+
+// Release is a normalized GitHub release ready for rendering.
+type Release struct {
+	Version    string    `json:"version"` // normalized, e.g. "2.15.0"
+	Name       string    `json:"name"`    // release name / tag as shown by GitHub
+	Date       string    `json:"date"`    // "2006-01-02", from published_at
+	Sections   []Section `json:"sections"`
+	Prerelease bool      `json:"prerelease"`
+	URL        string    `json:"url"` // html_url
+}
+
+// configDir returns ~/.config/fleet/, matching internal/update and the rest of fleet.
+func configDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "fleet")
+}
+
+// Load returns the release list, preferring a fresh on-disk cache and otherwise
+// fetching from GitHub. On a network error it falls back to a stale cache; it
+// only returns an error when there's no cache to fall back to.
+func Load() ([]Release, error) {
+	cached, cachedAt, haveCache := readCache()
+	if haveCache && time.Since(cachedAt) < cacheMaxAge {
+		return cached, nil
+	}
+
+	fresh, err := fetch()
+	if err != nil {
+		if haveCache {
+			return cached, nil // offline / rate-limited: stale is better than nothing
+		}
+		return nil, err
+	}
+	writeCache(fresh)
+	return fresh, nil
+}
+
+// ghRelease is the subset of the GitHub Releases API response we use.
+type ghRelease struct {
+	TagName     string `json:"tag_name"`
+	Name        string `json:"name"`
+	PublishedAt string `json:"published_at"`
+	Body        string `json:"body"`
+	Prerelease  bool   `json:"prerelease"`
+	Draft       bool   `json:"draft"`
+	HTMLURL     string `json:"html_url"`
+}
+
+// fetch pulls all releases from GitHub and normalizes them, newest-first.
+func fetch() ([]Release, error) {
+	client := &http.Client{Timeout: fetchTimeout}
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if token := ghToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var raw []ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, err
+	}
+	return normalizeReleases(raw), nil
+}
+
+// normalizeReleases converts raw API rows into Releases, dropping drafts and
+// sorting newest-first by version.
+func normalizeReleases(raw []ghRelease) []Release {
+	releases := make([]Release, 0, len(raw))
+	for _, r := range raw {
+		if r.Draft {
+			continue
+		}
+		name := r.Name
+		if name == "" {
+			name = r.TagName
+		}
+		releases = append(releases, Release{
+			Version:    NormalizeVersion(r.TagName),
+			Name:       name,
+			Date:       formatDate(r.PublishedAt),
+			Sections:   parseBody(r.Body),
+			Prerelease: r.Prerelease,
+			URL:        r.HTMLURL,
+		})
+	}
+	sort.SliceStable(releases, func(i, j int) bool {
+		return CompareVersions(releases[i].Version, releases[j].Version) > 0
+	})
+	return releases
+}
+
+// formatDate turns an RFC3339 published_at into "2006-01-02"; on any parse
+// failure it returns the leading date-looking prefix (or the raw string).
+func formatDate(published string) string {
+	if published == "" {
+		return ""
+	}
+	if t, err := time.Parse(time.RFC3339, published); err == nil {
+		return t.Format("2006-01-02")
+	}
+	if len(published) >= 10 {
+		return published[:10]
+	}
+	return published
+}
+
+// parseBody extracts the changelog sections from a release body. The body is
+// "## fleet vX" + an "Install / Update" block + a "---" divider + the changelog
+// sections, so we parse only what's after the first "---". If there's no divider
+// (older/odd releases) we parse the whole body defensively.
+func parseBody(body string) []Section {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	lines := strings.Split(body, "\n")
+
+	start := 0
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "---" {
+			start = i + 1
+			break
+		}
+	}
+
+	var sections []Section
+	var cur *Section
+	ensure := func() {
+		if cur == nil {
+			sections = append(sections, Section{})
+			cur = &sections[len(sections)-1]
+		}
+	}
+	for _, line := range lines[start:] {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "":
+			continue
+		case strings.HasPrefix(trimmed, "### "):
+			sections = append(sections, Section{Title: strings.TrimSpace(trimmed[4:])})
+			cur = &sections[len(sections)-1]
+		case strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* "):
+			ensure()
+			cur.Bullets = append(cur.Bullets, strings.TrimSpace(trimmed[2:]))
+		default:
+			// Continuation of the previous bullet (wrapped line) — join with a space.
+			if cur != nil && len(cur.Bullets) > 0 {
+				last := len(cur.Bullets) - 1
+				cur.Bullets[last] += " " + trimmed
+			}
+		}
+	}
+	return sections
+}
+
+// cacheEnvelope is what we persist: the parsed releases plus a fetch timestamp.
+type cacheEnvelope struct {
+	FetchedAt int64     `json:"fetched_at"`
+	Releases  []Release `json:"releases"`
+}
+
+// readCache loads the on-disk cache, reporting whether it was present.
+func readCache() (releases []Release, fetchedAt time.Time, ok bool) {
+	data, err := os.ReadFile(filepath.Join(configDir(), cacheFile))
+	if err != nil {
+		return nil, time.Time{}, false
+	}
+	var env cacheEnvelope
+	if err := json.Unmarshal(data, &env); err != nil || len(env.Releases) == 0 {
+		return nil, time.Time{}, false
+	}
+	return env.Releases, time.Unix(env.FetchedAt, 0), true
+}
+
+// writeCache persists the releases with the current timestamp (best-effort).
+func writeCache(releases []Release) {
+	env := cacheEnvelope{FetchedAt: time.Now().Unix(), Releases: releases}
+	data, err := json.Marshal(env)
+	if err != nil {
+		return
+	}
+	dir := configDir()
+	_ = os.MkdirAll(dir, 0700)
+	_ = os.WriteFile(filepath.Join(dir, cacheFile), data, 0600)
+}
+
+// ghToken returns a GitHub token from env or the gh CLI. The repo is public so a
+// token is optional; it only raises the API rate limit.
+func ghToken() string {
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		return token
+	}
+	out, err := exec.Command("gh", "auth", "token").Output()
+	if err == nil {
+		if t := strings.TrimSpace(string(out)); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// NormalizeVersion strips a leading "v" and any git-describe suffix so build-time
+// version strings ("v2.15.0", "v2.15.0-3-gabc-dirty", "2.15.0") compare against
+// CHANGELOG-style "2.15.0". "dev" is returned unchanged.
+func NormalizeVersion(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}
+
+// CompareVersions compares two normalized dotted versions numerically.
+// Returns -1 if a < b, 0 if equal, +1 if a > b. Non-numeric or unequal-length
+// versions fall back to a segment-wise numeric compare (missing segments = 0).
+func CompareVersions(a, b string) int {
+	as := strings.Split(a, ".")
+	bs := strings.Split(b, ".")
+	n := max(len(as), len(bs))
+	for i := range n {
+		av, bv := segment(as, i), segment(bs, i)
+		if av != bv {
+			if av < bv {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// segment returns the integer value of the i-th dotted segment, or 0 if missing
+// or non-numeric.
+func segment(parts []string, i int) int {
+	if i >= len(parts) {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(parts[i]))
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/releasenotes/releasenotes.go
+++ b/internal/releasenotes/releasenotes.go
@@ -241,6 +241,41 @@ func ghToken() string {
 	return ""
 }
 
+// Ago returns a short, human "time ago" for a "2006-01-02" date string, e.g.
+// "3 days ago". Returns "" if the date can't be parsed.
+func Ago(date string) string {
+	t, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return ""
+	}
+	return ago(t, time.Now())
+}
+
+// ago is the testable core of Ago: how long before now the date was.
+func ago(then, now time.Time) string {
+	days := int(now.Sub(then).Hours() / 24)
+	switch {
+	case days <= 0:
+		return "today"
+	case days == 1:
+		return "yesterday"
+	case days < 30:
+		return fmt.Sprintf("%d days ago", days)
+	case days < 365:
+		m := days / 30
+		if m <= 1 {
+			return "1 month ago"
+		}
+		return fmt.Sprintf("%d months ago", m)
+	default:
+		y := days / 365
+		if y <= 1 {
+			return "1 year ago"
+		}
+		return fmt.Sprintf("%d years ago", y)
+	}
+}
+
 // NormalizeVersion strips a leading "v" and any git-describe suffix so build-time
 // version strings ("v2.15.0", "v2.15.0-3-gabc-dirty", "2.15.0") compare against
 // CHANGELOG-style "2.15.0". "dev" is returned unchanged.

--- a/internal/releasenotes/releasenotes_test.go
+++ b/internal/releasenotes/releasenotes_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNormalizeVersion(t *testing.T) {
@@ -83,6 +84,31 @@ func TestParseBodyJoinsWrappedBullet(t *testing.T) {
 	want := []Section{{Title: "Added", Bullets: []string{"First line continuation line"}}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("parseBody() = %#v\nwant %#v", got, want)
+	}
+}
+
+func TestAgo(t *testing.T) {
+	now := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		days int
+		want string
+	}{
+		{0, "today"},
+		{1, "yesterday"},
+		{5, "5 days ago"},
+		{40, "1 month ago"},
+		{70, "2 months ago"},
+		{400, "1 year ago"},
+		{800, "2 years ago"},
+	}
+	for _, c := range cases {
+		then := now.AddDate(0, 0, -c.days)
+		if got := ago(then, now); got != c.want {
+			t.Errorf("ago(%d days) = %q, want %q", c.days, got, c.want)
+		}
+	}
+	if got := ago(now.Add(24*time.Hour), now); got != "today" {
+		t.Errorf("future date should read %q, got %q", "today", got)
 	}
 }
 

--- a/internal/releasenotes/releasenotes_test.go
+++ b/internal/releasenotes/releasenotes_test.go
@@ -1,0 +1,113 @@
+package releasenotes
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeVersion(t *testing.T) {
+	cases := map[string]string{
+		"v2.15.0":              "2.15.0",
+		"2.15.0":               "2.15.0",
+		"v2.15.0-3-gabc-dirty": "2.15.0",
+		"2.15.0-next":          "2.15.0",
+		"  v1.0.0 ":            "1.0.0",
+		"dev":                  "dev",
+	}
+	for in, want := range cases {
+		if got := NormalizeVersion(in); got != want {
+			t.Errorf("NormalizeVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"2.15.0", "2.14.0", 1},
+		{"2.14.0", "2.15.0", -1},
+		{"2.15.0", "2.15.0", 0},
+		{"2.15.1", "2.15.0", 1},
+		{"2.9.0", "2.15.0", -1}, // numeric, not lexical
+		{"3.0.0", "2.99.99", 1},
+		{"2.15", "2.15.0", 0}, // missing segment == 0
+	}
+	for _, c := range cases {
+		if got := CompareVersions(c.a, c.b); got != c.want {
+			t.Errorf("CompareVersions(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestParseBodyStripsInstallBoilerplate(t *testing.T) {
+	body := "## fleet v2.15.0\n\n" +
+		"### Install / Update\n\n" +
+		"```bash\nbrew install brizzai/tap/fleet\n```\n\n" +
+		"---\n\n" +
+		"### Added\n\n" +
+		"- Fleet can now auto-suspend idle sessions.\n" +
+		"- A second added thing.\n\n" +
+		"### Fixed\n\n" +
+		"- Worktree name no longer snowballs.\n"
+
+	got := parseBody(body)
+	want := []Section{
+		{Title: "Added", Bullets: []string{"Fleet can now auto-suspend idle sessions.", "A second added thing."}},
+		{Title: "Fixed", Bullets: []string{"Worktree name no longer snowballs."}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseBody() = %#v\nwant %#v", got, want)
+	}
+}
+
+func TestParseBodyNoDividerFallback(t *testing.T) {
+	// No "---": parse the whole body. A bullet before any heading lands in an
+	// untitled section.
+	body := "- Just a bullet, no heading.\n### Added\n- Under a heading.\n"
+	got := parseBody(body)
+	want := []Section{
+		{Bullets: []string{"Just a bullet, no heading."}},
+		{Title: "Added", Bullets: []string{"Under a heading."}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseBody() = %#v\nwant %#v", got, want)
+	}
+}
+
+func TestParseBodyJoinsWrappedBullet(t *testing.T) {
+	body := "---\n### Added\n- First line\n  continuation line\n"
+	got := parseBody(body)
+	want := []Section{{Title: "Added", Bullets: []string{"First line continuation line"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseBody() = %#v\nwant %#v", got, want)
+	}
+}
+
+func TestNormalizeReleasesSortsAndDropsDrafts(t *testing.T) {
+	fixture := `[
+		{"tag_name":"v2.14.0","name":"v2.14.0","published_at":"2026-07-05T10:00:00Z","body":"---\n### Improved\n- Faster quit.","prerelease":false,"draft":false,"html_url":"https://x/2.14.0"},
+		{"tag_name":"v2.15.0","name":"v2.15.0","published_at":"2026-07-06T10:00:00Z","body":"---\n### Added\n- Suspend idle.","prerelease":false,"draft":false,"html_url":"https://x/2.15.0"},
+		{"tag_name":"v2.16.0-rc1","name":"v2.16.0-rc1","published_at":"2026-07-10T10:00:00Z","body":"draft body","prerelease":true,"draft":true,"html_url":"https://x/2.16.0"}
+	]`
+	var raw []ghRelease
+	if err := json.Unmarshal([]byte(fixture), &raw); err != nil {
+		t.Fatalf("fixture unmarshal: %v", err)
+	}
+
+	got := normalizeReleases(raw)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 releases (draft dropped), got %d", len(got))
+	}
+	if got[0].Version != "2.15.0" || got[1].Version != "2.14.0" {
+		t.Errorf("expected newest-first [2.15.0, 2.14.0], got [%s, %s]", got[0].Version, got[1].Version)
+	}
+	if got[0].Date != "2026-07-06" {
+		t.Errorf("date = %q, want 2026-07-06", got[0].Date)
+	}
+	if len(got[0].Sections) != 1 || got[0].Sections[0].Title != "Added" {
+		t.Errorf("unexpected sections for newest release: %#v", got[0].Sections)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -30,6 +30,7 @@ import (
 	"github.com/brizzai/fleet/internal/naming"
 	"github.com/brizzai/fleet/internal/perfwatch"
 	"github.com/brizzai/fleet/internal/proc"
+	"github.com/brizzai/fleet/internal/releasenotes"
 	"github.com/brizzai/fleet/internal/session"
 	"github.com/brizzai/fleet/internal/shell"
 	"github.com/brizzai/fleet/internal/tmux"
@@ -210,6 +211,7 @@ type Home struct {
 	sessionCreateDialog   *SessionCreateDialog
 	consentDialog         *ConsentDialog
 	onboardingDialog      *OnboardingDialog
+	releaseNotes          *ReleaseNotesDialog
 
 	// launchpad is the first-run experience shown when the fleet is empty:
 	// recent repos mined from Claude Code history, ready to resume.
@@ -449,6 +451,7 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string, ident
 		sessionCreateDialog:    NewSessionCreateDialog(),
 		consentDialog:          NewConsentDialog(),
 		onboardingDialog:       NewOnboardingDialog(cfg),
+		releaseNotes:           NewReleaseNotesDialog(),
 		launchpad:              NewLaunchpad(),
 		bugReport:              NewBugReportDialog(),
 		previewCache:           make(map[string]string),
@@ -598,6 +601,7 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.consentDialog.SetSize(msg.Width, msg.Height)
 		h.onboardingDialog.SetSize(msg.Width, msg.Height)
 		h.bugReport.SetSize(msg.Width, msg.Height)
+		h.releaseNotes.SetSize(msg.Width, msg.Height)
 		h.syncViewport()
 		return h, nil
 
@@ -955,6 +959,10 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.fireStartupAnalytics(repoCount)
 		// First-run theme onboarding follows the consent prompt.
 		h.maybeShowOnboarding()
+		return h, nil
+
+	case releaseNotesLoadedMsg:
+		h.releaseNotes.SetData(msg.releases, msg.err)
 		return h, nil
 
 	case bugReportClosedMsg:
@@ -1559,6 +1567,7 @@ func (h *Home) modalOpen() bool {
 	return h.consentDialog.IsVisible() ||
 		h.onboardingDialog.IsVisible() ||
 		h.helpOverlay.IsVisible() ||
+		h.releaseNotes.IsVisible() ||
 		h.bugReport.IsVisible() ||
 		h.settingsDialog.IsVisible() ||
 		h.createWorkspaceDialog.IsVisible() ||
@@ -1583,6 +1592,9 @@ func (h *Home) renderBody() string {
 	}
 	if h.helpOverlay.IsVisible() {
 		return h.helpOverlay.View()
+	}
+	if h.releaseNotes.IsVisible() {
+		return h.releaseNotes.View()
 	}
 	if h.bugReport.IsVisible() {
 		return h.bugReport.View()
@@ -1846,6 +1858,10 @@ func (h *Home) routeToModal(msg tea.Msg) (tea.Cmd, bool) {
 	case h.helpOverlay.IsVisible():
 		overlay, cmd := h.helpOverlay.Update(msg)
 		h.helpOverlay = overlay
+		return cmd, true
+	case h.releaseNotes.IsVisible():
+		dialog, cmd := h.releaseNotes.Update(msg)
+		h.releaseNotes = dialog
 		return cmd, true
 	case h.consentDialog.IsVisible():
 		dialog, cmd := h.consentDialog.Update(msg)
@@ -6137,6 +6153,7 @@ func (h *Home) buildPaletteItems() []PaletteItem {
 		{Kind: PaletteKindCommand, ID: "settings", Name: "Settings", Shortcut: "S"},
 		{Kind: PaletteKindCommand, ID: "bug_report", Name: "Bug Report", Shortcut: "!"},
 		{Kind: PaletteKindCommand, ID: "help", Name: "Help", Shortcut: "?"},
+		{Kind: PaletteKindCommand, ID: "release_notes", Name: "Release Notes"},
 		{Kind: PaletteKindCommand, ID: "reload_all", Name: "Reload All Sessions"},
 		{Kind: PaletteKindCommand, ID: "suspend_session", Name: "Suspend This Session"},
 		{Kind: PaletteKindCommand, ID: "suspend_now", Name: "Suspend Idle Sessions Now"},
@@ -6365,6 +6382,10 @@ func (h *Home) dispatchCommand(id string) (tea.Model, tea.Cmd) {
 	case "help":
 		h.helpOverlay.Show()
 		return h, nil
+	case "release_notes":
+		h.actionLog.Add("open release notes", "", true)
+		h.releaseNotes.Show(h.version)
+		return h, h.loadReleaseNotes()
 	case "reload_all":
 		analytics.Track(analytics.EventReloadAll, nil)
 		return h, h.reloadAll()
@@ -6409,6 +6430,21 @@ func (h *Home) dispatchCommand(id string) (tea.Model, tea.Cmd) {
 		return h, h.beginQuit("command-palette")
 	}
 	return h, nil
+}
+
+// releaseNotesLoadedMsg carries the async result of loading the changelog.
+type releaseNotesLoadedMsg struct {
+	releases []releasenotes.Release
+	err      error
+}
+
+// loadReleaseNotes fetches (or reads the cached) GitHub releases off the Update
+// goroutine and delivers them via releaseNotesLoadedMsg.
+func (h *Home) loadReleaseNotes() tea.Cmd {
+	return func() tea.Msg {
+		rs, err := releasenotes.Load()
+		return releaseNotesLoadedMsg{releases: rs, err: err}
+	}
 }
 
 // reloadAll restarts all dead/error sessions concurrently.

--- a/internal/ui/releasenotes.go
+++ b/internal/ui/releasenotes.go
@@ -228,10 +228,12 @@ func (d *ReleaseNotesDialog) contentLines() []string {
 		installed := !devBuild && cmp == 0 && !r.Prerelease
 
 		if !devBuild && cmp > 0 && !newerEmitted {
+			// First newer release: the header separates it, so no divider here.
+			// (No sep reset needed — releases are newest-first, so this only fires
+			// on the first iteration, and sep is set true at the loop's end anyway.)
 			fit(lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Render("◆ NEWER — update to get these"))
 			raw("")
 			newerEmitted = true
-			sep = false // the header already separates the first newer release
 		} else if sep {
 			raw("")
 			raw(d.rule(inner))

--- a/internal/ui/releasenotes.go
+++ b/internal/ui/releasenotes.go
@@ -222,10 +222,13 @@ func (d *ReleaseNotesDialog) contentLines() []string {
 		if !devBuild {
 			cmp = releasenotes.CompareVersions(r.Version, d.installed)
 		}
-		installed := !devBuild && cmp == 0
+		// Gate the INSTALLED marker on !Prerelease: NormalizeVersion strips the
+		// pre-release suffix, so a prerelease and its GA collapse to the same
+		// version — without this both would claim the badge.
+		installed := !devBuild && cmp == 0 && !r.Prerelease
 
 		if !devBuild && cmp > 0 && !newerEmitted {
-			raw(lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Render("◆ NEWER — update to get these"))
+			fit(lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Render("◆ NEWER — update to get these"))
 			raw("")
 			newerEmitted = true
 			sep = false // the header already separates the first newer release
@@ -256,12 +259,13 @@ func (d *ReleaseNotesDialog) appendRelease(out *[]string, r releasenotes.Release
 		left += "  " + lipgloss.NewStyle().Foreground(ColorYellow).Render("pre-release")
 	}
 	// Version left, date (+ relative age) right — a clean column down the right
-	// edge. This row is already padded to inner, so append it raw.
+	// edge. Truncate to inner so a very narrow terminal (right cluster wider than
+	// inner) can't wrap it to two rows and desync the scroll window.
 	right := DimStyle.Render(r.Date)
 	if a := releasenotes.Ago(r.Date); a != "" {
 		right += DimStyle.Render(fmt.Sprintf("  (%s)", a))
 	}
-	*out = append(*out, padLR(left, right, inner))
+	fit(padLR(left, right, inner))
 
 	if len(r.Sections) == 0 {
 		fit(DimStyle.Render("  (no notes)"))

--- a/internal/ui/releasenotes.go
+++ b/internal/ui/releasenotes.go
@@ -1,0 +1,279 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/brizzai/fleet/internal/releasenotes"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// ReleaseNotesDialog is a scrollable changelog: every release, newest-first,
+// with the running version marked INSTALLED and anything newer grouped up top as
+// "update to get these". Data is loaded async (see loadReleaseNotes in app.go);
+// the dialog shows a loading state until SetData arrives.
+type ReleaseNotesDialog struct {
+	visible   bool
+	width     int
+	height    int
+	scroll    int
+	installed string // normalized running version, e.g. "2.15.0" or "dev"
+	releases  []releasenotes.Release
+	loading   bool
+	err       error
+}
+
+// NewReleaseNotesDialog creates an empty release-notes dialog.
+func NewReleaseNotesDialog() *ReleaseNotesDialog {
+	return &ReleaseNotesDialog{}
+}
+
+// Show opens the dialog in its loading state; installedVersion is the running
+// build's version (raw — it's normalized here for matching).
+func (d *ReleaseNotesDialog) Show(installedVersion string) {
+	d.visible = true
+	d.loading = true
+	d.err = nil
+	d.releases = nil
+	d.scroll = 0
+	d.installed = releasenotes.NormalizeVersion(installedVersion)
+}
+
+// SetData installs the loaded releases (or the load error) and stops loading.
+func (d *ReleaseNotesDialog) SetData(rs []releasenotes.Release, err error) {
+	d.loading = false
+	d.releases = rs
+	d.err = err
+	d.scroll = clampInt(d.scroll, 0, d.maxScroll())
+}
+
+func (d *ReleaseNotesDialog) Hide()           { d.visible = false }
+func (d *ReleaseNotesDialog) IsVisible() bool { return d.visible }
+
+// SetSize records the terminal size and re-clamps scroll so View stays read-only.
+func (d *ReleaseNotesDialog) SetSize(w, h int) {
+	d.width, d.height = w, h
+	d.scroll = clampInt(d.scroll, 0, d.maxScroll())
+}
+
+// Update scrolls when the notes overflow; esc/q close. Keys are ignored while
+// loading. Unlike the help overlay, stray keys don't close — this dialog scrolls
+// a lot, so closing is deliberate (esc/q).
+func (d *ReleaseNotesDialog) Update(msg tea.Msg) (*ReleaseNotesDialog, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return d, nil
+	}
+	if d.loading {
+		if s := key.String(); s == "esc" || s == "q" {
+			d.Hide()
+		}
+		return d, nil
+	}
+	maxScroll := d.maxScroll()
+	switch key.String() {
+	case "esc", "q":
+		d.Hide()
+		return d, nil
+	case "up", "k":
+		d.scroll--
+	case "down", "j":
+		d.scroll++
+	case "pgup":
+		d.scroll -= d.pageStep()
+	case "pgdown":
+		d.scroll += d.pageStep()
+	case "home", "g":
+		d.scroll = 0
+	case "end", "G":
+		d.scroll = maxScroll
+	}
+	d.scroll = clampInt(d.scroll, 0, maxScroll)
+	return d, nil
+}
+
+// --- geometry ---------------------------------------------------------------
+
+// dialogWidth targets 72 cols, clamped to the screen with a sane minimum.
+func (d *ReleaseNotesDialog) dialogWidth() int {
+	return clampInt(72, 48, max(48, d.width-4))
+}
+
+// innerWidth is the content width inside the border+padding frame.
+func (d *ReleaseNotesDialog) innerWidth() int {
+	return max(20, d.dialogWidth()-DialogStyle.GetHorizontalFrameSize())
+}
+
+// visibleRows is how many content rows fit in the scroll window (leaving room
+// for the title, hint, and the two ⋮ indicator lines).
+func (d *ReleaseNotesDialog) visibleRows() int {
+	const chrome = 2 /*title+blank*/ + 2 /*blank+hint*/ + 2 /*⋮ above/below*/
+	return max(1, d.height-DialogStyle.GetVerticalFrameSize()-chrome)
+}
+
+func (d *ReleaseNotesDialog) maxScroll() int {
+	return max(0, len(d.contentLines())-d.visibleRows())
+}
+
+func (d *ReleaseNotesDialog) pageStep() int {
+	return max(1, d.visibleRows()-1)
+}
+
+// --- rendering --------------------------------------------------------------
+
+// View renders the dialog centered over the screen.
+func (d *ReleaseNotesDialog) View() string {
+	if d.loading {
+		return d.box(TitleStyle.Render("Release Notes") + "\n\n" + DimStyle.Render("Loading release notes…"))
+	}
+	if d.err != nil {
+		msg := TitleStyle.Render("Release Notes") + "\n\n" +
+			ErrorStyle.Render("Couldn't load release notes.") + "\n" +
+			DimStyle.Render(ansi.Truncate(d.err.Error(), d.innerWidth(), "…"))
+		return d.box(msg)
+	}
+
+	content := d.contentLines()
+	var lines []string
+	lines = append(lines, TitleStyle.Render("Release Notes"), "")
+
+	visible := d.visibleRows()
+	if len(content) <= visible {
+		lines = append(lines, content...)
+	} else {
+		scroll := clampInt(d.scroll, 0, len(content)-visible)
+		above, below := scroll, len(content)-visible-scroll
+		if above > 0 {
+			lines = append(lines, DimStyle.Render(fmt.Sprintf("⋮ +%d above", above)))
+		} else {
+			lines = append(lines, "")
+		}
+		lines = append(lines, content[scroll:scroll+visible]...)
+		if below > 0 {
+			lines = append(lines, DimStyle.Render(fmt.Sprintf("⋮ +%d below", below)))
+		} else {
+			lines = append(lines, "")
+		}
+	}
+
+	hint := "↑↓ scroll · esc close"
+	lines = append(lines, "", DimStyle.Render(hint))
+	return d.box(strings.Join(lines, "\n"))
+}
+
+// box wraps content in the standard dialog frame at a stable width and centers it.
+func (d *ReleaseNotesDialog) box(content string) string {
+	b := DialogStyle.Width(d.dialogWidth()).Render(content)
+	b = lipgloss.NewStyle().MaxWidth(d.width).MaxHeight(d.height).Render(b)
+	return lipgloss.Place(d.width, d.height, lipgloss.Center, lipgloss.Center, b)
+}
+
+// contentLines builds the full (unscrolled) list of rendered content rows. Every
+// line is guaranteed to fit innerWidth so it never wraps and throws off the
+// scroll math.
+func (d *ReleaseNotesDialog) contentLines() []string {
+	inner := d.innerWidth()
+	if len(d.releases) == 0 {
+		return []string{DimStyle.Render("No releases found.")}
+	}
+
+	var out []string
+	add := func(s string) { out = append(out, ansi.Truncate(s, inner, "…")) }
+
+	devBuild := d.installed == "dev" || d.installed == ""
+	if devBuild {
+		add(DimStyle.Render("Running a dev build — no installed release to match."))
+		add("")
+	}
+
+	newerEmitted := false
+	installedSeen := false
+	for _, r := range d.releases {
+		cmp := 0
+		if !devBuild {
+			cmp = releasenotes.CompareVersions(r.Version, d.installed)
+		}
+		switch {
+		case !devBuild && cmp > 0 && !newerEmitted:
+			add(lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Render("◆ NEWER — update to get these"))
+			add("")
+			newerEmitted = true
+		case !devBuild && cmp <= 0 && newerEmitted && !installedSeen:
+			// Transition out of the newer block into installed/past.
+			installedSeen = true
+		}
+		d.appendRelease(&out, r, !devBuild && cmp == 0, inner)
+		add("")
+	}
+	// Trim a trailing blank for a tidy bottom.
+	if len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// appendRelease renders one release (version line + sections + bullets) into out.
+func (d *ReleaseNotesDialog) appendRelease(out *[]string, r releasenotes.Release, installed bool, inner int) {
+	add := func(s string) { *out = append(*out, ansi.Truncate(s, inner, "…")) }
+
+	verStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorText)
+	if installed {
+		verStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
+	}
+	header := verStyle.Render("v" + r.Version)
+	if r.Date != "" {
+		header += "  " + DimStyle.Render(r.Date)
+	}
+	if r.Prerelease {
+		header += "  " + DimStyle.Render("(prerelease)")
+	}
+	if installed {
+		badge := lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent).Bold(true).Padding(0, 1).Render("INSTALLED")
+		header += "  " + badge
+	}
+	add(header)
+
+	if len(r.Sections) == 0 {
+		add(DimStyle.Render("  (no notes)"))
+		return
+	}
+	textWidth := max(8, inner-4) // "  • " / "    " indent
+	for _, sec := range r.Sections {
+		if sec.Title != "" {
+			add("  " + sectionTitleStyle(sec.Title).Render(sec.Title))
+		}
+		for _, bullet := range sec.Bullets {
+			wrapped := strings.Split(ansi.Wordwrap(bullet, textWidth, ""), "\n")
+			for i, ln := range wrapped {
+				prefix := "    "
+				if i == 0 {
+					prefix = "  " + lipgloss.NewStyle().Foreground(ColorAccent).Render("•") + " "
+				}
+				add(prefix + HelpDescStyle.Render(ln))
+			}
+		}
+	}
+}
+
+// sectionTitleStyle colors a changelog section label by type, muted so the
+// bullets stay the focus.
+func sectionTitleStyle(title string) lipgloss.Style {
+	c := ColorTextDim
+	switch strings.ToLower(strings.TrimSpace(title)) {
+	case "added":
+		c = ColorGreen
+	case "improved":
+		c = ColorBlue
+	case "changed":
+		c = ColorYellow
+	case "fixed":
+		c = ColorOrange
+	case "removed", "deprecated":
+		c = ColorGray
+	case "security":
+		c = ColorRed
+	}
+	return lipgloss.NewStyle().Bold(true).Foreground(c)
+}

--- a/internal/ui/releasenotes.go
+++ b/internal/ui/releasenotes.go
@@ -96,9 +96,20 @@ func (d *ReleaseNotesDialog) Update(msg tea.Msg) (*ReleaseNotesDialog, tea.Cmd) 
 
 // --- geometry ---------------------------------------------------------------
 
-// dialogWidth targets 72 cols, clamped to the screen with a sane minimum.
+// Fixed chrome around the scrollable content region. The two indicator slots are
+// always rendered (blank when there's nothing hidden), so one of them doubles as
+// the gap under the header rule — no stacked blank lines.
+const (
+	rnHeaderLines    = 2 // title row + rule
+	rnFooterLines    = 2 // blank + hint
+	rnIndicatorLines = 2 // ⋮ above / ⋮ below
+)
+
+// dialogWidth uses most of the terminal width (~80%) so the notes get a wide
+// reading pane, clamped so it always fits and never gets uselessly narrow.
 func (d *ReleaseNotesDialog) dialogWidth() int {
-	return clampInt(72, 48, max(48, d.width-4))
+	maxW := max(20, d.width-4)
+	return clampInt(d.width*4/5, min(72, maxW), maxW)
 }
 
 // innerWidth is the content width inside the border+padding frame.
@@ -106,19 +117,25 @@ func (d *ReleaseNotesDialog) innerWidth() int {
 	return max(20, d.dialogWidth()-DialogStyle.GetHorizontalFrameSize())
 }
 
-// visibleRows is how many content rows fit in the scroll window (leaving room
-// for the title, hint, and the two ⋮ indicator lines).
-func (d *ReleaseNotesDialog) visibleRows() int {
-	const chrome = 2 /*title+blank*/ + 2 /*blank+hint*/ + 2 /*⋮ above/below*/
-	return max(1, d.height-DialogStyle.GetVerticalFrameSize()-chrome)
+// scrollGeometry returns the content lines plus the scroll window sizing,
+// computed once so Update (paging/clamping) and View (rendering) never disagree.
+func (d *ReleaseNotesDialog) scrollGeometry() (content []string, visible, maxScroll int) {
+	content = d.contentLines()
+	availH := max(1, d.height-DialogStyle.GetVerticalFrameSize()-rnHeaderLines-rnFooterLines-rnIndicatorLines)
+	if len(content) <= availH {
+		return content, len(content), 0
+	}
+	return content, availH, len(content) - availH
 }
 
 func (d *ReleaseNotesDialog) maxScroll() int {
-	return max(0, len(d.contentLines())-d.visibleRows())
+	_, _, m := d.scrollGeometry()
+	return m
 }
 
 func (d *ReleaseNotesDialog) pageStep() int {
-	return max(1, d.visibleRows()-1)
+	_, visible, _ := d.scrollGeometry()
+	return max(1, visible-1)
 }
 
 // --- rendering --------------------------------------------------------------
@@ -135,32 +152,41 @@ func (d *ReleaseNotesDialog) View() string {
 		return d.box(msg)
 	}
 
-	content := d.contentLines()
-	var lines []string
-	lines = append(lines, TitleStyle.Render("Release Notes"), "")
+	inner := d.innerWidth()
+	content, visible, maxScroll := d.scrollGeometry()
+	scroll := clampInt(d.scroll, 0, maxScroll)
+	above, below := scroll, maxScroll-scroll
 
-	visible := d.visibleRows()
-	if len(content) <= visible {
-		lines = append(lines, content...)
-	} else {
-		scroll := clampInt(d.scroll, 0, len(content)-visible)
-		above, below := scroll, len(content)-visible-scroll
-		if above > 0 {
-			lines = append(lines, DimStyle.Render(fmt.Sprintf("⋮ +%d above", above)))
-		} else {
-			lines = append(lines, "")
-		}
-		lines = append(lines, content[scroll:scroll+visible]...)
-		if below > 0 {
-			lines = append(lines, DimStyle.Render(fmt.Sprintf("⋮ +%d below", below)))
-		} else {
-			lines = append(lines, "")
-		}
-	}
-
-	hint := "↑↓ scroll · esc close"
-	lines = append(lines, "", DimStyle.Render(hint))
+	// Header, then the always-present "above" slot (blank at the top, so it also
+	// serves as the gap under the rule), the content window, the "below" slot,
+	// and the footer hint.
+	lines := []string{d.titleRow(inner), d.rule(inner), indicator(above, "above")}
+	lines = append(lines, content[scroll:scroll+visible]...)
+	lines = append(lines, indicator(below, "below"))
+	lines = append(lines, "", DimStyle.Render("↑↓ scroll · esc close"))
 	return d.box(strings.Join(lines, "\n"))
+}
+
+// titleRow is the header: "Release Notes" on the left, release count on the right.
+func (d *ReleaseNotesDialog) titleRow(inner int) string {
+	right := ""
+	if n := len(d.releases); n > 0 {
+		right = DimStyle.Render(fmt.Sprintf("%d releases", n))
+	}
+	return padLR(TitleStyle.Render("Release Notes"), right, inner)
+}
+
+// rule renders a full-width dim horizontal divider.
+func (d *ReleaseNotesDialog) rule(w int) string {
+	return lipgloss.NewStyle().Foreground(ColorBorder).Render(strings.Repeat("─", w))
+}
+
+// indicator renders a dim "⋮ +N above/below" line (blank when count is zero).
+func indicator(n int, where string) string {
+	if n <= 0 {
+		return ""
+	}
+	return DimStyle.Render(fmt.Sprintf("⋮ +%d %s", n, where))
 }
 
 // box wraps content in the standard dialog frame at a stable width and centers it.
@@ -170,9 +196,9 @@ func (d *ReleaseNotesDialog) box(content string) string {
 	return lipgloss.Place(d.width, d.height, lipgloss.Center, lipgloss.Center, b)
 }
 
-// contentLines builds the full (unscrolled) list of rendered content rows. Every
-// line is guaranteed to fit innerWidth so it never wraps and throws off the
-// scroll math.
+// contentLines builds the full (unscrolled) list of rendered content rows.
+// Version-header and divider rows are pre-fit to innerWidth; every other line is
+// truncated to it, so no line ever wraps and throws off the scroll math.
 func (d *ReleaseNotesDialog) contentLines() []string {
 	inner := d.innerWidth()
 	if len(d.releases) == 0 {
@@ -180,81 +206,186 @@ func (d *ReleaseNotesDialog) contentLines() []string {
 	}
 
 	var out []string
-	add := func(s string) { out = append(out, ansi.Truncate(s, inner, "…")) }
+	fit := func(s string) { out = append(out, ansi.Truncate(s, inner, "…")) }
+	raw := func(s string) { out = append(out, s) } // pre-fit rows (rules, padded headers)
 
 	devBuild := d.installed == "dev" || d.installed == ""
 	if devBuild {
-		add(DimStyle.Render("Running a dev build — no installed release to match."))
-		add("")
+		fit(DimStyle.Render("· Running a dev build — no installed release to match."))
+		raw("")
 	}
 
 	newerEmitted := false
-	installedSeen := false
+	sep := false // emit a divider before the next release?
 	for _, r := range d.releases {
 		cmp := 0
 		if !devBuild {
 			cmp = releasenotes.CompareVersions(r.Version, d.installed)
 		}
-		switch {
-		case !devBuild && cmp > 0 && !newerEmitted:
-			add(lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Render("◆ NEWER — update to get these"))
-			add("")
+		installed := !devBuild && cmp == 0
+
+		if !devBuild && cmp > 0 && !newerEmitted {
+			raw(lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Render("◆ NEWER — update to get these"))
+			raw("")
 			newerEmitted = true
-		case !devBuild && cmp <= 0 && newerEmitted && !installedSeen:
-			// Transition out of the newer block into installed/past.
-			installedSeen = true
+			sep = false // the header already separates the first newer release
+		} else if sep {
+			raw("")
+			raw(d.rule(inner))
+			raw("")
 		}
-		d.appendRelease(&out, r, !devBuild && cmp == 0, inner)
-		add("")
-	}
-	// Trim a trailing blank for a tidy bottom.
-	if len(out) > 0 && out[len(out)-1] == "" {
-		out = out[:len(out)-1]
+		d.appendRelease(&out, r, installed, inner)
+		sep = true
 	}
 	return out
 }
 
-// appendRelease renders one release (version line + sections + bullets) into out.
+// appendRelease renders one release (header row + sections + bullets) into out.
 func (d *ReleaseNotesDialog) appendRelease(out *[]string, r releasenotes.Release, installed bool, inner int) {
-	add := func(s string) { *out = append(*out, ansi.Truncate(s, inner, "…")) }
+	fit := func(s string) { *out = append(*out, ansi.Truncate(s, inner, "…")) }
 
 	verStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorText)
 	if installed {
 		verStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
 	}
-	header := verStyle.Render("v" + r.Version)
-	if r.Date != "" {
-		header += "  " + DimStyle.Render(r.Date)
+	left := verStyle.Render("v" + r.Version)
+	if installed {
+		left += "  " + lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent).Bold(true).Padding(0, 1).Render("INSTALLED")
 	}
 	if r.Prerelease {
-		header += "  " + DimStyle.Render("(prerelease)")
+		left += "  " + lipgloss.NewStyle().Foreground(ColorYellow).Render("pre-release")
 	}
-	if installed {
-		badge := lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent).Bold(true).Padding(0, 1).Render("INSTALLED")
-		header += "  " + badge
+	// Version left, date (+ relative age) right — a clean column down the right
+	// edge. This row is already padded to inner, so append it raw.
+	right := DimStyle.Render(r.Date)
+	if a := releasenotes.Ago(r.Date); a != "" {
+		right += DimStyle.Render(fmt.Sprintf("  (%s)", a))
 	}
-	add(header)
+	*out = append(*out, padLR(left, right, inner))
 
 	if len(r.Sections) == 0 {
-		add(DimStyle.Render("  (no notes)"))
+		fit(DimStyle.Render("  (no notes)"))
 		return
 	}
 	textWidth := max(8, inner-4) // "  • " / "    " indent
+	dot := lipgloss.NewStyle().Foreground(ColorAccent).Render("•")
 	for _, sec := range r.Sections {
 		if sec.Title != "" {
-			add("  " + sectionTitleStyle(sec.Title).Render(sec.Title))
+			fit("  " + sectionTitleStyle(sec.Title).Render(sec.Title))
 		}
 		for _, bullet := range sec.Bullets {
-			wrapped := strings.Split(ansi.Wordwrap(bullet, textWidth, ""), "\n")
+			// Render inline markdown (`code`, **bold**) first, then wrap: ansi's
+			// wrapper is ANSI-aware so it keeps the styling intact across breaks.
+			wrapped := strings.Split(ansi.Wordwrap(renderInlineMarkdown(bullet), textWidth, ""), "\n")
 			for i, ln := range wrapped {
 				prefix := "    "
 				if i == 0 {
-					prefix = "  " + lipgloss.NewStyle().Foreground(ColorAccent).Render("•") + " "
+					prefix = "  " + dot + " "
 				}
-				add(prefix + HelpDescStyle.Render(ln))
+				fit(prefix + ln)
 			}
 		}
 	}
+}
+
+// renderInlineMarkdown styles a subset of inline markdown found in changelog
+// bullets: `code` spans and **bold** runs. Normal text keeps the body color, so
+// the returned string is fully styled and shouldn't be re-wrapped in a base
+// style. Backtick/asterisk markers are ASCII, so byte scanning is multibyte-safe
+// for the surrounding text.
+func renderInlineMarkdown(s string) string {
+	base := HelpDescStyle
+	codeStyle := lipgloss.NewStyle().Foreground(ColorOrange)
+	boldStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorText)
+
+	var out, buf strings.Builder
+	flush := func() {
+		if buf.Len() > 0 {
+			out.WriteString(base.Render(buf.String()))
+			buf.Reset()
+		}
+	}
+	for i := 0; i < len(s); {
+		switch {
+		case s[i] == '`':
+			// A code span opens with a run of N backticks and closes on the next
+			// run of exactly N — so `` ` `` (double-backtick delimiters) can hold a
+			// literal backtick. Fall back to literal text if there's no closer.
+			n := backtickRun(s, i)
+			end := findBacktickRun(s, i+n, n)
+			if end < 0 {
+				buf.WriteString(s[i : i+n])
+				i += n
+				continue
+			}
+			flush()
+			out.WriteString(codeStyle.Render(trimCodeSpan(s[i+n : end])))
+			i = end + n
+		case strings.HasPrefix(s[i:], "**"):
+			rest := s[i+2:]
+			j := strings.Index(rest, "**")
+			if j < 0 {
+				buf.WriteString("**")
+				i += 2
+				continue
+			}
+			flush()
+			out.WriteString(boldStyle.Render(rest[:j]))
+			i = i + 2 + j + 2
+		default:
+			buf.WriteByte(s[i])
+			i++
+		}
+	}
+	flush()
+	return out.String()
+}
+
+// backtickRun returns the number of consecutive backticks starting at i.
+func backtickRun(s string, i int) int {
+	n := 0
+	for i+n < len(s) && s[i+n] == '`' {
+		n++
+	}
+	return n
+}
+
+// findBacktickRun returns the start index of the next run of exactly n backticks
+// at or after from, or -1 if there is none.
+func findBacktickRun(s string, from, n int) int {
+	for i := from; i < len(s); {
+		if s[i] != '`' {
+			i++
+			continue
+		}
+		run := backtickRun(s, i)
+		if run == n {
+			return i
+		}
+		i += run
+	}
+	return -1
+}
+
+// trimCodeSpan applies CommonMark's rule: if a code span both begins and ends
+// with a space and isn't all spaces, one space is trimmed from each end (so
+// “ ` “ yields a literal backtick).
+func trimCodeSpan(c string) string {
+	if len(c) >= 2 && c[0] == ' ' && c[len(c)-1] == ' ' && strings.TrimSpace(c) != "" {
+		return c[1 : len(c)-1]
+	}
+	return c
+}
+
+// padLR places left and right on one row padded to width, truncating left if the
+// two would collide.
+func padLR(left, right string, width int) string {
+	gap := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		left = ansi.Truncate(left, max(1, width-lipgloss.Width(right)-1), "…")
+		gap = max(1, width-lipgloss.Width(left)-lipgloss.Width(right))
+	}
+	return left + strings.Repeat(" ", gap) + right
 }
 
 // sectionTitleStyle colors a changelog section label by type, muted so the

--- a/internal/ui/releasenotes_test.go
+++ b/internal/ui/releasenotes_test.go
@@ -1,0 +1,99 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/brizzai/fleet/internal/releasenotes"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func sampleReleases() []releasenotes.Release {
+	return []releasenotes.Release{
+		{Version: "2.15.0", Date: "2026-07-06", Sections: []releasenotes.Section{
+			{Title: "Added", Bullets: []string{"Auto-suspend idle sessions under memory pressure so a big fleet can't OOM-crash every session at once."}},
+			{Title: "Fixed", Bullets: []string{"Worktree names no longer snowball."}},
+		}},
+		{Version: "2.14.0", Date: "2026-07-05", Sections: []releasenotes.Section{
+			{Title: "Improved", Bullets: []string{"Quitting shows a shutting-down indicator and exits faster."}},
+		}},
+		{Version: "2.13.0", Date: "2026-07-02", Sections: []releasenotes.Section{
+			{Title: "Added", Bullets: []string{"New terminal drawer for live repo-scoped shells."}},
+		}},
+	}
+}
+
+// strip returns s with ANSI styling removed, for substring/width assertions.
+func strip(s string) string { return ansi.Strip(s) }
+
+func TestReleaseNotesInstalledAndNewerGrouping(t *testing.T) {
+	d := NewReleaseNotesDialog()
+	d.SetSize(100, 40)
+	d.Show("v2.14.0") // installed is the middle release
+	d.SetData(sampleReleases(), nil)
+
+	joined := strip(strings.Join(d.contentLines(), "\n"))
+	if !strings.Contains(joined, "NEWER") {
+		t.Errorf("expected a NEWER group header (2.15.0 is newer than installed 2.14.0)\n%s", joined)
+	}
+	if !strings.Contains(joined, "INSTALLED") {
+		t.Errorf("expected an INSTALLED badge on 2.14.0\n%s", joined)
+	}
+	// The installed badge must sit on the 2.14.0 line, and 2.15.0 must appear
+	// above it (newest-first).
+	iNewer := strings.Index(joined, "v2.15.0")
+	iInstalled := strings.Index(joined, "INSTALLED")
+	if iNewer < 0 || iInstalled < 0 || iNewer > iInstalled {
+		t.Errorf("expected v2.15.0 to render above the INSTALLED badge; got newer@%d installed@%d", iNewer, iInstalled)
+	}
+}
+
+func TestReleaseNotesNoLineOverflows(t *testing.T) {
+	d := NewReleaseNotesDialog()
+	d.SetSize(90, 40)
+	d.Show("2.14.0")
+	d.SetData(sampleReleases(), nil)
+
+	inner := d.innerWidth()
+	for _, line := range d.contentLines() {
+		if w := lipgloss.Width(line); w > inner {
+			t.Errorf("content line width %d exceeds inner width %d: %q", w, inner, strip(line))
+		}
+	}
+}
+
+func TestReleaseNotesDevBuildHasNoInstalledMarker(t *testing.T) {
+	d := NewReleaseNotesDialog()
+	d.SetSize(100, 40)
+	d.Show("dev")
+	d.SetData(sampleReleases(), nil)
+
+	joined := strip(strings.Join(d.contentLines(), "\n"))
+	if strings.Contains(joined, "INSTALLED") {
+		t.Errorf("dev build should not mark any release INSTALLED\n%s", joined)
+	}
+	if !strings.Contains(joined, "dev build") {
+		t.Errorf("dev build should show an explanatory note\n%s", joined)
+	}
+}
+
+func TestReleaseNotesLoadingAndError(t *testing.T) {
+	d := NewReleaseNotesDialog()
+	d.SetSize(100, 40)
+	d.Show("2.15.0")
+	if !strings.Contains(strip(d.View()), "Loading") {
+		t.Error("expected a loading state before data arrives")
+	}
+
+	d.SetData(nil, errTest)
+	if !strings.Contains(strip(d.View()), "Couldn't load") {
+		t.Error("expected an error state when load fails with no data")
+	}
+}
+
+var errTest = errTestType("network unreachable")
+
+type errTestType string
+
+func (e errTestType) Error() string { return string(e) }

--- a/internal/ui/releasenotes_test.go
+++ b/internal/ui/releasenotes_test.go
@@ -78,6 +78,22 @@ func TestReleaseNotesDevBuildHasNoInstalledMarker(t *testing.T) {
 	}
 }
 
+func TestRenderInlineMarkdown(t *testing.T) {
+	cases := map[string]string{
+		"plain text":                     "plain text",
+		"a `code` span":                  "a code span",
+		"press `` ` ``)":                 "press `)",               // double-backtick span holds a literal backtick
+		"press `` ` ``) then `Ctrl+T` x": "press `) then Ctrl+T x", // parser resyncs after the tricky span
+		"**bold** rest":                  "bold rest",
+		"unclosed `code":                 "unclosed `code", // no closer → literal
+	}
+	for in, want := range cases {
+		if got := strip(renderInlineMarkdown(in)); got != want {
+			t.Errorf("renderInlineMarkdown(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestReleaseNotesLoadingAndError(t *testing.T) {
 	d := NewReleaseNotesDialog()
 	d.SetSize(100, 40)

--- a/internal/ui/releasenotes_test.go
+++ b/internal/ui/releasenotes_test.go
@@ -50,16 +50,42 @@ func TestReleaseNotesInstalledAndNewerGrouping(t *testing.T) {
 }
 
 func TestReleaseNotesNoLineOverflows(t *testing.T) {
-	d := NewReleaseNotesDialog()
-	d.SetSize(90, 40)
-	d.Show("2.14.0")
-	d.SetData(sampleReleases(), nil)
+	// Very narrow widths exercise the overflow-prone rows (the "◆ NEWER" header
+	// and the padded version/date row); installed 2.13.0 puts 2.14/2.15 in the
+	// NEWER group so that header is emitted.
+	for _, w := range []int{28, 38, 60, 90, 200} {
+		d := NewReleaseNotesDialog()
+		d.SetSize(w, 40)
+		d.Show("2.13.0")
+		d.SetData(sampleReleases(), nil)
 
-	inner := d.innerWidth()
-	for _, line := range d.contentLines() {
-		if w := lipgloss.Width(line); w > inner {
-			t.Errorf("content line width %d exceeds inner width %d: %q", w, inner, strip(line))
+		inner := d.innerWidth()
+		for _, line := range d.contentLines() {
+			if lw := lipgloss.Width(line); lw > inner {
+				t.Errorf("width %d: content line width %d exceeds inner %d: %q", w, lw, inner, strip(line))
+			}
 		}
+	}
+}
+
+func TestReleaseNotesPrereleaseDoesNotDoubleBadge(t *testing.T) {
+	// A prerelease and its GA collapse to the same normalized version; only the
+	// GA should carry the INSTALLED badge.
+	rs := []releasenotes.Release{
+		{Version: "2.16.0", Date: "2026-07-10", Prerelease: false, Sections: []releasenotes.Section{{Title: "Added", Bullets: []string{"GA."}}}},
+		{Version: "2.16.0", Date: "2026-07-08", Prerelease: true, Sections: []releasenotes.Section{{Title: "Added", Bullets: []string{"Release candidate."}}}},
+	}
+	d := NewReleaseNotesDialog()
+	d.SetSize(100, 40)
+	d.Show("2.16.0")
+	d.SetData(rs, nil)
+
+	joined := strip(strings.Join(d.contentLines(), "\n"))
+	if n := strings.Count(joined, "INSTALLED"); n != 1 {
+		t.Errorf("expected exactly 1 INSTALLED badge (GA only), got %d\n%s", n, joined)
+	}
+	if !strings.Contains(joined, "pre-release") {
+		t.Errorf("the prerelease row should keep its pre-release tag\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
## What

Adds a **Release Notes** command to the `Ctrl+K` palette that opens a scrollable, in-app changelog of every release — the running version is marked `INSTALLED`, newer releases are grouped up top as "update to get these", and older ones follow.

## Why

Nothing surfaced the changelog inside the running app — you couldn't see what's new, what shipped, or what's coming without leaving the TUI.

## How

- **`internal/releasenotes/`** — fetches `GET /repos/brizzai/fleet/releases` (public repo, no auth needed; a token is used only if present to raise rate limits), caches to `~/.config/fleet/releases.json` with a 1h freshness window, and falls back to stale cache when offline. Release bodies are the curated `CHANGELOG.md` sections (the release workflow feeds GoReleaser `--release-notes`), so the notes read as polished as the changelog. Parses out the install boilerplate before the `---`, then `### Section` + bullets. Includes version normalize/compare and a relative-time `Ago` helper.
- **`internal/ui/releasenotes.go`** — a scrollable dialog cloning `help.go`'s scroll idiom (`↑↓ j/k PgUp/PgDn g/G`, `⋮ +N above/below`). Uses ~80% of the terminal width, right-aligns the date into a column with a relative `(3 days ago)`, frames the header with a rule + release count, dim dividers between releases, an `INSTALLED` badge, color-coded section labels, and inline markdown rendering for `` `code` `` and `**bold**` (proper CommonMark code-span handling so `` `` ` `` `` literal-backtick spans don't bleed).
- **`internal/ui/app.go`** — the 8 standard dialog integration points + palette entry + a `dispatchCommand` case + an async `loadReleaseNotes()` command (network runs off the Update goroutine).
- **`changelog/README.md` + `CLAUDE.md`** — since fragments now render in-app, codify a "fun to read" voice guide (bold headline, second person, name the pain, numbers over adjectives, `code`-format concretes, no hype).

## Testing

- `go build ./...` clean; `go test -race` green for both packages.
- Unit tests: release parsing/normalize/compare/`ago`, dialog grouping, INSTALLED marker, dev-build handling, no-line-overflow, loading/error states, and inline-markdown (single/double-backtick/bold/unclosed).
- Verified with live renders against the real GitHub API.

To try it: `Ctrl+K` → type "release" → Enter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZBN2UXd2x1U4etNuKyzRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app Release Notes viewer accessible from the command palette.
  * Release notes now open in a scrollable modal that highlights the current version and newer available releases.
  * Notes support clear formatting for headings, code snippets, and emphasized text.

* **Documentation**
  * Updated contributor guidance for writing changelog entries with a more readable, reader-focused style.
  * Expanded examples to show the preferred release-note format and tone.

* **Bug Fixes**
  * Improved version handling so installed, newer, and prerelease releases are shown more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->