### PR TITLE
fix(ui): show What's New to users who update into the feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ on:
     branches: [master]
 
 env:
-  # Pinned to 1.26.4: 1.26.3 has stdlib vulns GO-2026-5037/5039 (govulncheck).
-  # Exact pin so setup-go pulls 1.26.4 from go.dev until the actions manifest
+  # Pinned to 1.26.5: 1.26.4 has stdlib vuln GO-2026-5856 (crypto/tls, govulncheck).
+  # Exact pin so setup-go pulls 1.26.5 from go.dev until the actions manifest
   # lists it; revert to floating "1.26" once it does.
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ on:
         type: string
 
 env:
-  # Pinned to 1.26.4: 1.26.3 has stdlib vulns GO-2026-5037/5039 (govulncheck).
-  # Exact pin so setup-go pulls 1.26.4 from go.dev until the actions manifest
+  # Pinned to 1.26.5: 1.26.4 has stdlib vuln GO-2026-5856 (crypto/tls, govulncheck).
+  # Exact pin so setup-go pulls 1.26.5 from go.dev until the actions manifest
   # lists it; revert to floating "1.26" once it does.
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 permissions:
   contents: write

--- a/changelog/unreleased/whats-new-redux.md
+++ b/changelog/unreleased/whats-new-redux.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+highlight: true
+---
+**What's New, now actually visible.** If you updated *into* the release that introduced this reel, its own debut got marked read before you ever saw it — so `W` just said "nothing new". Existing installs now light up the `✦ What's New` badge for the release you updated to, instead of only fresh installs. (Fittingly, this highlight is that fix — saying hello.)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -487,9 +487,13 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string, ident
 		startTime:              time.Now(),
 	}
 	h.drawerHeight = cfg.GetDrawerHeight()
-	// Seed the What's New "seen" version on first run so a fresh install doesn't
-	// light up the badge for releases that predate it.
-	if cfg.GetReleaseNotesSeenVersion() == "" {
+	// Seed the What's New "seen" version only on a genuinely fresh install, so a
+	// brand-new install doesn't light up the badge for releases that predate it.
+	// An existing user meeting this feature for the first time also has an empty
+	// seen version, but IsFirstRun is false for them — so they still get the
+	// current release's highlights (including What's New's own announcement)
+	// instead of being silently stamped as caught-up.
+	if cfg.IsFirstRun() && cfg.GetReleaseNotesSeenVersion() == "" {
 		cfg.MarkReleaseNotesSeen(releasenotes.NormalizeVersion(version))
 	}
 	emptyCache := make(map[string]*git.RepoInfo)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -51,6 +51,57 @@ func TestHomeInitializes(t *testing.T) {
 	}
 }
 
+// TestNewHomeSeedsReleaseNotesOnlyOnFirstRun guards the whats-new-failed
+// regression: NewHome must seed the "seen" version only on a genuinely fresh
+// install. An existing user meeting What's New for the first time also has an
+// empty seen version, but stamping them as caught-up hid the very release that
+// introduced the feature.
+func TestNewHomeSeedsReleaseNotesOnlyOnFirstRun(t *testing.T) {
+	newStorage := func(t *testing.T) *session.StateDB {
+		t.Helper()
+		db, err := session.Open(filepath.Join(t.TempDir(), "test.db"))
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		t.Cleanup(func() { db.Close() })
+		return db
+	}
+
+	t.Run("existing user is not seeded", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		if err := os.MkdirAll(filepath.Dir(config.DefaultConfigPath()), 0700); err != nil {
+			t.Fatalf("mkdir config dir: %v", err)
+		}
+		if err := os.WriteFile(config.DefaultConfigPath(), []byte(`{"tick_interval_sec":2}`), 0600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		cfg := config.Load()
+		if cfg.IsFirstRun() {
+			t.Fatal("precondition: a loaded config file should not report IsFirstRun")
+		}
+
+		NewHome(newStorage(t), cfg, "2.16.1", analytics.Identity{})
+
+		if got := cfg.GetReleaseNotesSeenVersion(); got != "" {
+			t.Errorf("existing user was seeded to %q; want empty so the new release's highlights still show", got)
+		}
+	})
+
+	t.Run("fresh install is seeded to running version", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		cfg := config.Load()
+		if !cfg.IsFirstRun() {
+			t.Fatal("precondition: no config file should report IsFirstRun")
+		}
+
+		NewHome(newStorage(t), cfg, "2.16.1", analytics.Identity{})
+
+		if got := cfg.GetReleaseNotesSeenVersion(); got != "2.16.1" {
+			t.Errorf("fresh install seeded to %q; want %q", got, "2.16.1")
+		}
+	})
+}
+
 // TestViewGitInfoCacheRace guards against the "concurrent map read and map write"
 // fatal that happens if View() reads h.gitInfoCache while the status worker writes
 // it. Run with `go test -race` — pre-fix this trips the race detector reliably.


### PR DESCRIPTION
## What & why

When the What's New feature shipped in **v2.16.0**, users who *updated into* it opened `W` and saw **"nothing new"** — the reel ate its own announcement (including the self-referential "What's New about What's New" highlight).

**Root cause** — `NewHome` seeded `ReleaseNotesSeenVersion` to the running version whenever it was empty:

```go
if cfg.GetReleaseNotesSeenVersion() == "" {
    cfg.MarkReleaseNotesSeen(releasenotes.NormalizeVersion(version))
}
```

That empty value covers **two populations the code couldn't distinguish**:
1. A genuinely fresh install (the intended target — don't nag about a release they just installed).
2. An existing user meeting What's New for the first time — the config field simply didn't exist before this feature.

Population #2 got stamped `seen = 2.16.0`, and `isUnseenHighlight` requires `release.Version > seen`, so v2.16.0's own highlight was filtered out. `MarkReleaseNotesSeen` also calls `Save()`, so the bad value was persisted on first launch.

## The fix

Gate the seed on `cfg.IsFirstRun()` (false once a config file exists at startup):

```go
if cfg.IsFirstRun() && cfg.GetReleaseNotesSeenVersion() == "" {
    cfg.MarkReleaseNotesSeen(releasenotes.NormalizeVersion(version))
}
```

Existing users keep an empty `seen` version, so future releases' highlights reach them.

## Reaching already-affected users

A highlighted changelog fragment (`changelog/unreleased/whats-new-redux.md`) re-announces What's New. It rolls into **2.16.1**, so it carries a fresh date and a version `> 2.16.0` — everyone who updates sees it, no fragile seen-value migration:

| Population | Stamped `seen` | On 2.16.1 launch |
|---|---|---|
| Launched 2.16.0 (broken path) | `"2.16.0"` | `2.16.1 > 2.16.0` → **badge lights, sees it** |
| Skipped 2.16.0, returning user | `""` | version check skipped → **sees it** |
| Fresh install of 2.16.1 | seeded to `"2.16.1"` | filtered — correct, they just installed it |

## Tests

`TestNewHomeSeedsReleaseNotesOnlyOnFirstRun` locks in both cases: an existing (loaded) config is not seeded; a fresh install is seeded to the running version.

## Note on versioning

The `fix:` commit computes to a patch bump → **2.16.1**, which is what the version math above assumes. Keep an unrelated `feat:` out of this release so it doesn't bump to 2.17.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcZVtLAZLUpKgYRAEqNthR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the “What’s New” badge so it appears correctly for updated installs.
  * Existing installs are no longer marked as already read when they update into a new release.
  * Fresh installs still initialize the read state correctly on first run.

* **Tests**
  * Added regression coverage to ensure the badge state is only seeded for truly new installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->