### PR TITLE
feat(ui): re-viewable What's New, Shift+W label, Tab to full notes

### DIFF
--- a/changelog/unreleased/whats-new-reviewable.md
+++ b/changelog/unreleased/whats-new-reviewable.md
@@ -1,4 +1,4 @@
 ---
 type: improved
 ---
-**What's New is re-viewable now.** Reopening it shows the recent highlights again instead of "you're all caught up", the badge spells the shortcut `Shift+W` so it's not mistaken for lowercase `w` (new worktree), and `Tab` flips between the highlights reel and the full release notes.
+**Re-viewable now.** Reopening What's New shows the recent highlights again instead of "you're all caught up". The badge spells the key `Shift+W` (so it's not read as lowercase `w`), and `Tab` flips between the highlights reel and the full release notes.

--- a/changelog/unreleased/whats-new-reviewable.md
+++ b/changelog/unreleased/whats-new-reviewable.md
@@ -1,0 +1,4 @@
+---
+type: improved
+---
+**What's New is re-viewable now.** Reopening it shows the recent highlights again instead of "you're all caught up", the badge spells the shortcut `Shift+W` so it's not mistaken for lowercase `w` (new worktree), and `Tab` flips between the highlights reel and the full release notes.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -6545,8 +6545,9 @@ func (h *Home) newestKnownVersion() string {
 }
 
 // recomputeWhatsNew refreshes hasUnseenWhatsNew from the cached releases and the
-// stored seen version. Shares isUnseenHighlight with the dialog so the badge and
-// the reel always agree on what counts.
+// stored seen version, using isUnseenHighlight — the seen-aware, badge-only
+// predicate. The reel filters by isRecentHighlight (window only) instead, so the
+// badge clears once seen while the reel stays re-viewable.
 func (h *Home) recomputeWhatsNew() {
 	seen := releasenotes.NormalizeVersion(h.cfg.GetReleaseNotesSeenVersion())
 	h.hasUnseenWhatsNew = false

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -6218,7 +6218,7 @@ func (h *Home) buildPaletteItems() []PaletteItem {
 		{Kind: PaletteKindCommand, ID: "settings", Name: "Settings", Shortcut: "S"},
 		{Kind: PaletteKindCommand, ID: "bug_report", Name: "Bug Report", Shortcut: "!"},
 		{Kind: PaletteKindCommand, ID: "help", Name: "Help", Shortcut: "?"},
-		{Kind: PaletteKindCommand, ID: "whats_new", Name: "What's New", Shortcut: "W"},
+		{Kind: PaletteKindCommand, ID: "whats_new", Name: "What's New", Shortcut: "Shift+W"},
 		{Kind: PaletteKindCommand, ID: "release_notes", Name: "Release Notes"},
 		{Kind: PaletteKindCommand, ID: "reload_all", Name: "Reload All Sessions"},
 		{Kind: PaletteKindCommand, ID: "suspend_session", Name: "Suspend This Session"},
@@ -6523,7 +6523,7 @@ func (h *Home) loadReleaseNotes() tea.Cmd {
 func (h *Home) openReleaseNotes(whatsNew bool) (tea.Model, tea.Cmd) {
 	h.actionLog.Add("open release notes", "", true)
 	if whatsNew {
-		h.releaseNotes.ShowWhatsNew(h.version, h.cfg.GetReleaseNotesSeenVersion())
+		h.releaseNotes.ShowWhatsNew(h.version)
 	} else {
 		h.releaseNotes.Show(h.version)
 	}

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -51,7 +51,7 @@ var allKeyBindings = []KeyBinding{
 	{Key: "`", BarKey: "`", BarDesc: "Term", Desc: "Toggle terminal drawer", Section: "global"},
 	{Key: "Ctrl+K", BarKey: "⌃K", BarDesc: "Cmd", Desc: "Command palette", Section: "global"},
 	{Key: "S", BarKey: "S", BarDesc: "Set", Desc: "Open settings", Section: "global"},
-	{Key: "W", Desc: "What's New / release notes", Section: "global"},
+	{Key: "Shift+W", Desc: "What's New / release notes", Section: "global"},
 	{Key: "X", Desc: "Dismiss on-screen tip", Section: "global"},
 	{Key: "!", BarKey: "!", BarDesc: "Bug", Desc: "Bug report / diagnostics", Section: "global"},
 	{Key: "?", BarKey: "?", BarDesc: "Help", Desc: "Toggle help", Section: "global"},

--- a/internal/ui/releasenotes.go
+++ b/internal/ui/releasenotes.go
@@ -24,11 +24,11 @@ type ReleaseNotesDialog struct {
 	loading   bool
 	err       error
 
-	// whatsNew scopes the dialog to the curated "What's New" reel: only the
-	// Highlights of releases newer than seenVersion within the last 7 days.
-	// When false the dialog is the full changelog.
-	whatsNew    bool
-	seenVersion string // normalized; releases at or below this are already seen
+	// whatsNew scopes the dialog to the curated "What's New" reel: the Highlights
+	// of releases within the last 7 days. It's re-viewable regardless of whether
+	// they've been seen — the top-right badge owns the "unseen" cue. When false
+	// the dialog is the full changelog.
+	whatsNew bool
 }
 
 // whatsNewWindowDays caps the What's New reel: highlights older than this never
@@ -50,16 +50,14 @@ func (d *ReleaseNotesDialog) Show(installedVersion string) {
 	d.scroll = 0
 	d.installed = releasenotes.NormalizeVersion(installedVersion)
 	d.whatsNew = false
-	d.seenVersion = ""
 }
 
-// ShowWhatsNew opens the dialog scoped to the What's New reel: only highlights
-// of releases newer than seenVersion within the last 7 days. seenVersion is
-// normalized here.
-func (d *ReleaseNotesDialog) ShowWhatsNew(installedVersion, seenVersion string) {
+// ShowWhatsNew opens the dialog scoped to the What's New reel: the highlights of
+// releases within the last 7 days. It's re-viewable regardless of the seen
+// version — the top-right badge owns the "unseen" signal.
+func (d *ReleaseNotesDialog) ShowWhatsNew(installedVersion string) {
 	d.Show(installedVersion)
 	d.whatsNew = true
-	d.seenVersion = releasenotes.NormalizeVersion(seenVersion)
 }
 
 // SetData installs the loaded releases (or the load error) and stops loading.
@@ -97,6 +95,13 @@ func (d *ReleaseNotesDialog) Update(msg tea.Msg) (*ReleaseNotesDialog, tea.Cmd) 
 	switch key.String() {
 	case "esc", "q":
 		d.Hide()
+		return d, nil
+	case "tab", "shift+tab":
+		// Toggle between the What's New reel and the full changelog. A pure view
+		// switch — "seen" was already recorded when the dialog opened — so just
+		// flip the mode and reset scroll for the different content.
+		d.whatsNew = !d.whatsNew
+		d.scroll = 0
 		return d, nil
 	case "up", "k":
 		d.scroll--
@@ -180,11 +185,18 @@ func (d *ReleaseNotesDialog) View() string {
 
 	// Header, then the always-present "above" slot (blank at the top, so it also
 	// serves as the gap under the rule), the content window, the "below" slot,
-	// and the footer hint.
+	// and the footer hint. The hint's middle segment toggles the two views with
+	// Tab, naming whichever view you'd switch to. Truncated to inner width so it
+	// stays one line (scrollGeometry budgets rnFooterLines = 2 = blank + hint).
+	toggle := "tab what's new"
+	if d.whatsNew {
+		toggle = "tab all release notes"
+	}
+	hint := ansi.Truncate("↑↓ scroll · "+toggle+" · esc close", inner, "…")
 	lines := []string{d.titleRow(inner), d.rule(inner), indicator(above, "above")}
 	lines = append(lines, content[scroll:scroll+visible]...)
 	lines = append(lines, indicator(below, "below"))
-	lines = append(lines, "", DimStyle.Render("↑↓ scroll · esc close"))
+	lines = append(lines, "", DimStyle.Render(hint))
 	return d.box(strings.Join(lines, "\n"))
 }
 
@@ -336,15 +348,17 @@ func (d *ReleaseNotesDialog) appendRelease(out *[]string, r releasenotes.Release
 	}
 }
 
-// whatsNewLines renders the curated reel: the Highlights of every unseen
-// release within the window, newest-first. appendRelease (in What's New mode)
-// emits only each release's Highlights section, so this just filters and spaces.
+// whatsNewLines renders the curated reel: the Highlights of every release within
+// the window, newest-first. It filters by the window only (not the seen
+// version), so the reel stays re-viewable after the badge is dismissed.
+// appendRelease (in What's New mode) emits only each release's Highlights
+// section, so this just filters and spaces.
 func (d *ReleaseNotesDialog) whatsNewLines() []string {
 	inner := d.innerWidth()
 	var out []string
 	sep := false
 	for _, r := range d.releases {
-		if !isUnseenHighlight(r, d.seenVersion) {
+		if !isRecentHighlight(r) {
 			continue
 		}
 		if sep {
@@ -354,7 +368,7 @@ func (d *ReleaseNotesDialog) whatsNewLines() []string {
 		sep = true
 	}
 	if len(out) == 0 {
-		return []string{DimStyle.Render("✨ You're all caught up — no new highlights in the last 7 days.")}
+		return []string{DimStyle.Render("✨ No release highlights in the last 7 days — press Tab for all release notes.")}
 	}
 	return out
 }
@@ -370,17 +384,21 @@ func hasHighlights(r releasenotes.Release) bool {
 	return false
 }
 
-// isUnseenHighlight reports whether a release qualifies for the What's New reel:
-// within the window, newer than seenVersion, and carrying highlights. Shared by
-// the dialog's content filter and the top-right badge so they never disagree.
+// isRecentHighlight reports whether a release belongs in the What's New reel:
+// it carries highlights and falls within the window. Unlike isUnseenHighlight it
+// ignores the seen version, so the reel stays re-viewable after the badge (which
+// owns the "unseen" signal) has been dismissed.
+func isRecentHighlight(r releasenotes.Release) bool {
+	return releasenotes.WithinLastDays(r.Date, whatsNewWindowDays) && hasHighlights(r)
+}
+
+// isUnseenHighlight reports whether a release should light the top-right badge:
+// a recent highlight (isRecentHighlight) that is also newer than seenVersion.
 func isUnseenHighlight(r releasenotes.Release, seenVersion string) bool {
-	if !releasenotes.WithinLastDays(r.Date, whatsNewWindowDays) {
+	if !isRecentHighlight(r) {
 		return false
 	}
-	if seenVersion != "" && releasenotes.CompareVersions(r.Version, seenVersion) <= 0 {
-		return false
-	}
-	return hasHighlights(r)
+	return seenVersion == "" || releasenotes.CompareVersions(r.Version, seenVersion) > 0
 }
 
 // renderInlineMarkdown styles a subset of inline markdown found in changelog

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -70,8 +70,10 @@ func renderWhatsNewBadge(frame int) string {
 			Bold(true).
 			Render(string(r)))
 	}
-	// Trailing "press W" hint: "press" dimmed, the key itself styled like the
-	// footer bar's keybindings (accent + bold) so it's unmistakably a keybind.
-	b.WriteString(DimStyle.Render(" · press ") + HelpKeyStyle.Render("W"))
+	// Trailing "press Shift+W" hint: "press" dimmed, the key itself styled like
+	// the footer bar's keybindings (accent + bold) so it's unmistakably a
+	// keybind. Spelled "Shift+W" (not bare "W") so it isn't misread as lowercase
+	// w, which opens the worktree dialog.
+	b.WriteString(DimStyle.Render(" · press ") + HelpKeyStyle.Render("Shift+W"))
 	return b.String()
 }

--- a/internal/ui/whatsnew_test.go
+++ b/internal/ui/whatsnew_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/brizzai/fleet/internal/releasenotes"
 	"github.com/charmbracelet/x/ansi"
@@ -12,8 +13,8 @@ import (
 
 func TestRenderWhatsNewBadge(t *testing.T) {
 	// The visible text (ANSI stripped) is stable regardless of frame — the
-	// rainbow label plus the "· press W" key hint.
-	const wantText = whatsNewText + " · press W"
+	// rainbow label plus the "· press Shift+W" key hint.
+	const wantText = whatsNewText + " · press Shift+W"
 	for _, frame := range []int{0, 1, 7, 13, 100} {
 		got := ansi.Strip(renderWhatsNewBadge(frame))
 		if got != wantText {
@@ -51,17 +52,19 @@ func TestReleaseNotesWhatsNewReel(t *testing.T) {
 		},
 	}
 
-	render := func(seen string) string {
+	reelFor := func(r releasenotes.Release) string {
 		d := NewReleaseNotesDialog()
 		d.SetSize(90, 30)
-		d.ShowWhatsNew("2.16.0", seen)
-		d.SetData([]releasenotes.Release{fresh}, nil)
+		d.ShowWhatsNew("2.16.0")
+		d.SetData([]releasenotes.Release{r}, nil)
 		return ansi.Strip(d.View())
 	}
 
-	// Unseen: the reel shows the Highlights bullet, titles as "What's New", and
-	// does NOT leak the non-highlight "Fixed" bullet.
-	out := render("2.15.0")
+	// A recent highlighted release: the reel shows the Highlights bullet, titles
+	// as "What's New", and does NOT leak the non-highlight "Fixed" bullet. This
+	// holds regardless of any seen version — the reel is re-viewable; the badge
+	// (not the reel) tracks "seen".
+	out := reelFor(fresh)
 	if !strings.Contains(out, "What's New") {
 		t.Error("reel should be titled What's New")
 	}
@@ -72,13 +75,54 @@ func TestReleaseNotesWhatsNewReel(t *testing.T) {
 		t.Errorf("reel should NOT show non-highlight bullets, got:\n%s", out)
 	}
 
-	// Already seen: empty state, no highlight bullet.
-	caughtUp := render("2.16.0")
-	if !strings.Contains(caughtUp, "caught up") {
-		t.Errorf("seen reel should show the caught-up empty state, got:\n%s", caughtUp)
+	// A release older than the 7-day window drops out, leaving the empty state.
+	old := fresh
+	old.Date = "2000-01-01"
+	caughtUp := reelFor(old)
+	if !strings.Contains(caughtUp, "in the last 7 days") {
+		t.Errorf("out-of-window reel should show the empty state, got:\n%s", caughtUp)
 	}
 	if strings.Contains(caughtUp, "Shiny thing.") {
-		t.Error("seen reel should not show the highlight bullet")
+		t.Error("out-of-window reel should not show the highlight bullet")
+	}
+}
+
+func TestReleaseNotesTabToggle(t *testing.T) {
+	rel := releasenotes.Release{
+		Version: "2.16.0",
+		Date:    time.Now().Format("2006-01-02"),
+		Sections: []releasenotes.Section{
+			{Title: "Highlights", Bullets: []string{"**Reel bullet.** Shown in the reel."}},
+			{Title: "Fixed", Bullets: []string{"**Full-only fix.** Only in full notes."}},
+		},
+	}
+	d := NewReleaseNotesDialog()
+	d.SetSize(90, 30)
+	d.ShowWhatsNew("2.16.0")
+	d.SetData([]releasenotes.Release{rel}, nil)
+	tab := tea.KeyPressMsg{Code: tea.KeyTab}
+
+	// Starts on the reel: the highlight shows, the non-highlight is hidden.
+	out := ansi.Strip(d.View())
+	if !strings.Contains(out, "What's New") || !strings.Contains(out, "Reel bullet.") {
+		t.Errorf("expected the What's New reel with the highlight, got:\n%s", out)
+	}
+	if strings.Contains(out, "Full-only fix.") {
+		t.Errorf("reel should hide non-highlight bullets, got:\n%s", out)
+	}
+
+	// Tab -> full Release Notes: title flips and the non-highlight bullet appears.
+	d.Update(tab)
+	out = ansi.Strip(d.View())
+	if !strings.Contains(out, "Release Notes") || !strings.Contains(out, "Full-only fix.") {
+		t.Errorf("after Tab expected full Release Notes with the fix, got:\n%s", out)
+	}
+
+	// Tab again -> back to the reel.
+	d.Update(tab)
+	out = ansi.Strip(d.View())
+	if !strings.Contains(out, "What's New") || !strings.Contains(out, "Reel bullet.") {
+		t.Errorf("second Tab should return to the reel, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## What & why

Three usability follow-ups on the What's New reel (shipped in v2.16.0/2.16.1).

### 1. What's New is re-viewable
**Problem:** opening the reel stamped "seen", and the reel filtered its *content* by that same seen version — so the first open showed highlights, but every re-open showed the empty "you're all caught up" state. Users saw it, exited, tried again, and lost it.

**Fix:** the reel now filters by the **7-day window only** (`isRecentHighlight`), independent of the seen version. The badge keeps owning the "unseen" signal via `isUnseenHighlight` (refactored to reuse `isRecentHighlight`). Opening still stamps seen (badge clears), but the content stays viewable. The dead `seenVersion` field is removed from the dialog and `ShowWhatsNew`.

### 2. `Shift+W` label
**Problem:** the badge said "press W"; users hit lowercase `w`, which opens the new-worktree dialog.

**Fix:** the badge, the help entry, and the `Ctrl+K` palette shortcut all spell it `Shift+W`. Key matching is unchanged (`handleKey` still switches on `msg.String()`).

### 3. `Tab` toggles reel ↔ full release notes
**Problem:** the reel and the full changelog were separate modes set only from `app.go`; no in-dialog way to move between them.

**Fix:** `Tab` (either direction) flips `whatsNew` and resets scroll; the footer hint is mode-aware (`tab all release notes` / `tab what's new`) and truncated so it can't wrap and break scroll math.

## Files
- `internal/ui/releasenotes.go` — window-only reel filter, `isRecentHighlight` helper, `ShowWhatsNew` signature, `Tab` case, mode-aware footer.
- `internal/ui/whatsnew.go` — badge hint → `Shift+W`.
- `internal/ui/keybindings.go`, `internal/ui/app.go` — help + palette shortcut label; updated call site.
- `internal/ui/whatsnew_test.go` — updated badge/reel tests, new `TestReleaseNotesTabToggle`.

## Tests
`go test -race ./internal/ui/ ./internal/releasenotes/ ./internal/config/` all pass. Unit tests assert the rendered `View()` for each flow: badge shows `Shift+W`; reel shows highlights regardless of seen; out-of-window → empty state; `Tab` flips title + content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcZVtLAZLUpKgYRAEqNthR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “What’s New” now reopens to recent highlights instead of an “all caught up” view.
  * You can press **Tab** to switch between the highlights reel and the full release notes.
* **Bug Fixes**
  * The keyboard hint now displays **Shift+W** to better match the actual shortcut.
  * The “What’s New” action and related UI labels now use **Shift+W** consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->