### PR TITLE
chore(demo): fix screenshot mode leaking pinned repos, add worktree fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ BINARY := fleet
 BUILD_DIR := build
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 
-.PHONY: build run clean test fmt install lint coverage deps vet setup
+.PHONY: build run clean test fmt install lint coverage deps vet setup demo demo-setup demo-clean
+
+DEMO_PREFIX := /tmp/fleet-demo
 
 build:
 	go build -v -ldflags "-s -w -X main.version=$(VERSION)" -o $(BUILD_DIR)/$(BINARY) ./cmd/fleet
@@ -44,3 +46,18 @@ install: build
 
 setup:
 	pre-commit install
+
+# --- Demo / screenshot mode -------------------------------------------------
+# demo-setup builds a throwaway fleet under $(DEMO_PREFIX): fake repos, one
+# worktree grouped under its origin, and 5 sessions. `make demo` then launches
+# fleet filtered to just those repos (FLEET_DEMO_PREFIX) with the fake gh on
+# PATH so PR badges render. `make demo-clean` tears it all down.
+#   Typical flow:  make demo-setup   (wait ~30s)   make demo
+demo-setup:
+	bash demo/setup.sh
+
+demo: build
+	FLEET_DEMO_PREFIX=$(DEMO_PREFIX) PATH="$(CURDIR)/demo:$$PATH" $(BUILD_DIR)/$(BINARY)
+
+demo-clean:
+	bash demo/cleanup.sh

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -66,8 +66,19 @@ type User struct {
 // TODO: add authentication middleware
 EOF
 git add -A && git commit -q -m "init: basic Go web API"
-git checkout -q -b feat/auth
-echo "// wip" >> internal/handlers/users.go
+
+# Fake remote so the main clone and its worktree share ONE origin in fleet's
+# sidebar. Origin identity comes from remote.origin.url (git.GetOriginKey);
+# without a remote each folder falls back to a distinct local:<basename> and
+# the two checkouts split into separate groups instead of grouping together.
+git remote add origin https://github.com/example/api-server.git
+
+# Feature work lives in a linked worktree (the real fleet flow), not the main
+# checkout — this is what yields the "origin → main repo + worktree" grouping.
+# Main stays on `main` (clean); the worktree holds feat/auth (dirty + PR #42).
+WT1="$DEMO_DIR/api-server-feat-auth"
+git worktree add -q "$WT1" -b feat/auth
+echo "// wip" >> "$WT1/internal/handlers/users.go"
 
 # Repo 2: React dashboard
 REPO2="$DEMO_DIR/dashboard-ui"
@@ -233,10 +244,10 @@ PROMPTS=(
     "What does this project do? Summarize in one sentence."
     "Implement the full training pipeline: data preprocessing with missing value handling, model training with scikit-learn, cross-validation, and evaluation metrics"
 )
-REPOS=("$REPO1" "$REPO1" "$REPO2" "$REPO2" "$REPO3")
+REPOS=("$REPO1" "$WT1" "$REPO2" "$REPO2" "$REPO3")
 LABELS=(
     "api-server: architecture review"
-    "api-server: add auth middleware"
+    "api-server (feat/auth worktree): add auth middleware"
     "dashboard-ui: analytics component"
     "dashboard-ui: quick question"
     "ml-pipeline: implement training"

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1384,9 +1384,13 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
-		// Load pinned repos from storage.
+		// Load pinned repos from storage. Honor the demo screenshot filter so
+		// pinned-but-empty regular repos don't leak into a FLEET_DEMO_PREFIX run.
 		if pinnedPaths, err := h.storage.LoadPinnedRepos(); err == nil {
 			for _, p := range pinnedPaths {
+				if !demoPathVisible(p) {
+					continue
+				}
 				h.pinnedRepos[p] = true
 			}
 		}
@@ -6093,6 +6097,15 @@ func (h *Home) syncViewport() {
 	}
 }
 
+// demoPathVisible reports whether a repo/session path should be shown given the
+// optional FLEET_DEMO_PREFIX screenshot filter. An empty prefix (the default)
+// shows everything. Shared by the session filter and the pinned-repo load so the
+// two can't drift and leak regular repos into a demo run.
+func demoPathVisible(path string) bool {
+	prefix := os.Getenv("FLEET_DEMO_PREFIX")
+	return prefix == "" || strings.HasPrefix(path, prefix)
+}
+
 func (h *Home) loadSessions() tea.Msg {
 	rows, err := h.storage.LoadSessions()
 	if err != nil {
@@ -6106,10 +6119,10 @@ func (h *Home) loadSessions() tea.Msg {
 	}
 
 	// Demo mode: only show sessions under the specified path prefix.
-	if prefix := os.Getenv("FLEET_DEMO_PREFIX"); prefix != "" {
+	if os.Getenv("FLEET_DEMO_PREFIX") != "" {
 		filtered := make([]*session.Session, 0, len(sessions))
 		for _, s := range sessions {
-			if strings.HasPrefix(s.ProjectPath, prefix) {
+			if demoPathVisible(s.ProjectPath) {
 				filtered = append(filtered, s)
 			}
 		}


### PR DESCRIPTION
## What

Fixes fleet's demo/screenshot mode and makes it a one-command flow.

### The bug
`FLEET_DEMO_PREFIX` filtered **sessions** but never **pinned repos**, so all your real pinned repos still rendered as sidebar headers in a demo run — the sidebar wasn't clean for a screenshot. Confirmed against a real DB (28 pinned repos all leaking through).

**Fix:** a shared `demoPathVisible()` helper now gates both the session filter and the pinned-repo load, so they can't drift apart.

### Demo fixture: real worktree grouping
`demo/setup.sh` now gives `api-server` a fake `origin` remote plus a linked worktree on `feat/auth`. Because origin identity comes from `remote.origin.url`, the main clone and the worktree share one `OriginKey` and group under a single origin — instead of splitting into two `local:<basename>` groups. Result:

```
▾ api-server                 2
    ⎇ main
      ● architecture review
    ⎇ feat/auth *  #42 ✓       ← worktree (italic), dirty, approved PR
      ◐ add auth middleware
```

Main clone stays clean; the worktree carries the dirty edit + green PR badge.

### Makefile targets
```
make demo-setup     # build fake repos + worktree + 5 sessions
make demo           # launch fleet filtered to the demo repos (fake gh for PR badges)
make demo-clean     # tear it down
```

## Notes
- Dev-only tooling — no user-facing change (all behavior is gated behind `FLEET_DEMO_PREFIX`, which is unset in normal use). Commenting `/no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2kWH9hdd7ZN8NF1rxh42U
