### PR TITLE
fix(ui): stop the status worker from eating hook transitions

### DIFF
--- a/changelog/unreleased/status-lag-after-detach.md
+++ b/changelog/unreleased/status-lag-after-detach.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Status updates right after you detach.** Prompting a session and detaching left its row on the old status for up to ~25 seconds. It now updates in ~100ms.

--- a/changelog/unreleased/status-lag-after-detach.md
+++ b/changelog/unreleased/status-lag-after-detach.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**Status updates right after you detach.** Prompting a session and detaching left its row on the old status for up to ~25 seconds. It now updates in ~100ms.
+**Fresh status on detach.** Even after the freeze was fixed, a session you prompted while attached kept its old status for up to ~26 seconds after you detached. It now updates in ~100ms.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -5240,14 +5240,24 @@ func (h *Home) statusWorkerCycle() {
 	// 3. Sync hook status (fast: in-memory map lookups; worker may resolve a
 	// session-id rotation here — off the UI loop, so its transcript I/O is safe).
 	//
-	// The returned IDs MUST be carried into this cycle's priority set below.
-	// syncHookStatuses diffs against the session's in-memory hook state and then
-	// overwrites it, so a transition is consume-once: whichever caller syncs first
-	// eats it. During an attach tea.Exec suspends the Update loop, so hookChangedMsg
-	// never runs and this worker call is always the first to observe — dropping the
-	// result here left the session on the round-robin (≈26s at 65 sessions), and the
-	// post-detach catch-up sync in statusUpdateMsg found nothing left to enqueue.
+	// The returned IDs MUST be carried into this cycle's priority set, and the merge
+	// below stays adjacent to this call on purpose. syncHookStatuses diffs against
+	// the session's in-memory hook state and then overwrites it, so a transition is
+	// consume-once: whichever caller syncs first eats it. During an attach tea.Exec
+	// suspends the Update loop, so hookChangedMsg never runs and this worker call is
+	// always the first to observe — dropping the result here left the session on the
+	// round-robin (≈26s at 65 sessions), and the post-detach catch-up sync in
+	// statusUpdateMsg found nothing left to enqueue.
+	//
+	// Nothing may come between the consume and the merge: the cycle's defer recover()
+	// swallows a panic from anything in between (step 3b reads transcripts and writes
+	// SQLite), and the transitions this call already ate would be gone for good —
+	// the same failure reached a different way.
 	hookChanged := h.syncHookStatuses(sessions, true)
+	priorityIDs := make(map[string]bool, len(hookChanged))
+	for _, id := range hookChanged {
+		priorityIDs[id] = true
+	}
 
 	// 3b. Auto-name: generate title for ONE session per cycle (heavy cadence).
 	// Priority: manual (R key) > the agent's own title (Claude custom-title, then
@@ -5305,10 +5315,10 @@ func (h *Home) statusWorkerCycle() {
 		}
 	}
 
-	// 4. Priority updates first — sessions whose hook file just changed.
+	// 4. Priority updates first — sessions whose hook just changed, seeded above
+	// from this cycle's own sync and topped up here from the UI path's queue.
 	// These bypass round-robin so the UI reflects fresh hook status within
 	// ~100ms of the hook firing (vs. up to (N/statusRoundRobin)*tickInterval seconds).
-	priorityIDs := make(map[string]bool)
 drainPriority:
 	for {
 		select {
@@ -5318,21 +5328,27 @@ drainPriority:
 			break drainPriority
 		}
 	}
-	// Hooks this cycle's own sync (step 3) observed. Merged directly rather than
-	// pushed through priorityStatusUpdates: the channel drops on full, and a
-	// send-then-drain round trip through our own queue buys nothing.
-	for _, id := range hookChanged {
-		priorityIDs[id] = true
-	}
 	processed := make(map[string]bool, len(priorityIDs))
 	// Sessions whose status flipped on the fast (non-heavy) path; their tmux
 	// status bars are repainted immediately below so the in-pane pill tracks
 	// the sidebar within ~500ms instead of lagging until the next heavy cycle.
 	var changedBars []*session.Session
+	prio := make([]*session.Session, 0, len(priorityIDs))
 	for _, s := range sessions {
-		if !priorityIDs[s.ID] {
-			continue
+		if priorityIDs[s.ID] {
+			prio = append(prio, s)
 		}
+	}
+	// Batch-capture their panes in one tmux call, exactly as the fast pass does
+	// below. This loop marks them processed and fastPassSessions skips processed,
+	// so without this they never reach that batch and each shells out to its own
+	// capture-pane inside UpdateStatus — captureCacheTTL (400ms) is already stale
+	// against the ~500ms cycle. That cost scales with hook bursts, not session
+	// count: the startup pass (loadExisting seeds every session's hook file before
+	// the first cycle, so every session reports changed) or Reload All Sessions
+	// would fork one capture-pane per session, serially, inside a single cycle.
+	h.seedActiveCaptures(prio)
+	for _, s := range prio {
 		if h.updateAndPersistStatus(s) {
 			changedBars = append(changedBars, s)
 		}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -5239,7 +5239,15 @@ func (h *Home) statusWorkerCycle() {
 
 	// 3. Sync hook status (fast: in-memory map lookups; worker may resolve a
 	// session-id rotation here — off the UI loop, so its transcript I/O is safe).
-	h.syncHookStatuses(sessions, true)
+	//
+	// The returned IDs MUST be carried into this cycle's priority set below.
+	// syncHookStatuses diffs against the session's in-memory hook state and then
+	// overwrites it, so a transition is consume-once: whichever caller syncs first
+	// eats it. During an attach tea.Exec suspends the Update loop, so hookChangedMsg
+	// never runs and this worker call is always the first to observe — dropping the
+	// result here left the session on the round-robin (≈26s at 65 sessions), and the
+	// post-detach catch-up sync in statusUpdateMsg found nothing left to enqueue.
+	hookChanged := h.syncHookStatuses(sessions, true)
 
 	// 3b. Auto-name: generate title for ONE session per cycle (heavy cadence).
 	// Priority: manual (R key) > the agent's own title (Claude custom-title, then
@@ -5309,6 +5317,12 @@ drainPriority:
 		default:
 			break drainPriority
 		}
+	}
+	// Hooks this cycle's own sync (step 3) observed. Merged directly rather than
+	// pushed through priorityStatusUpdates: the channel drops on full, and a
+	// send-then-drain round trip through our own queue buys nothing.
+	for _, id := range hookChanged {
+		priorityIDs[id] = true
 	}
 	processed := make(map[string]bool, len(priorityIDs))
 	// Sessions whose status flipped on the fast (non-heavy) path; their tmux

--- a/internal/ui/worker_cadence_test.go
+++ b/internal/ui/worker_cadence_test.go
@@ -349,3 +349,101 @@ func mentions(t *testing.T, fnName, ident string) bool {
 	t.Fatalf("func %s not found in app.go — renamed?", fnName)
 	return false
 }
+
+// calleeName returns the called function's bare name (`h.foo(...)` → "foo").
+func calleeName(call *ast.CallExpr) string {
+	switch c := call.Fun.(type) {
+	case *ast.Ident:
+		return c.Name
+	case *ast.SelectorExpr:
+		return c.Sel.Name
+	}
+	return ""
+}
+
+// TestStatusWorkerFeedsHookChangesIntoPriority pins the fix for a 24s status lag:
+// statusWorkerCycle's own syncHookStatuses call must not drop its return value.
+//
+// syncHookStatuses diffs the hook against the session's in-memory hook state and then
+// overwrites it, so a transition is consume-once — whichever caller syncs first eats
+// it. During an attach tea.Exec suspends the Update loop, so hookChangedMsg never runs
+// and this worker call is always the first to observe. Discarding the result dropped
+// the transition entirely: the session fell back to the round-robin (≈26s at 65
+// sessions) and statusUpdateMsg's post-detach catch-up sync found nothing left to
+// enqueue, which is precisely the case it exists to cover.
+//
+// AST-based for the same reason the guards above are: the damage only appears when a
+// real attach suspends the Tea loop while the worker keeps cycling, and UpdateStatus
+// needs a live tmux pane to reach Running at all — neither is reachable from a unit
+// test, and Session.paneCapturer is package-private to internal/session.
+func TestStatusWorkerFeedsHookChangesIntoPriority(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "app.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse app.go: %v", err)
+	}
+	var fn *ast.FuncDecl
+	for _, decl := range f.Decls {
+		if d, ok := decl.(*ast.FuncDecl); ok && d.Name.Name == "statusWorkerCycle" {
+			fn = d
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("statusWorkerCycle not found in app.go — renamed?")
+	}
+
+	// 1. The result must be bound. A bare `h.syncHookStatuses(...)` expression
+	// statement is the original bug verbatim.
+	var bound string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.ExprStmt:
+			if call, ok := s.X.(*ast.CallExpr); ok && calleeName(call) == "syncHookStatuses" {
+				t.Error("statusWorkerCycle discards syncHookStatuses' return value — the hook " +
+					"transitions this call consumed are lost, so sessions whose status changed " +
+					"during an attach wait for the round-robin instead of the priority pass")
+			}
+		case *ast.AssignStmt:
+			for i, rhs := range s.Rhs {
+				call, ok := rhs.(*ast.CallExpr)
+				if !ok || calleeName(call) != "syncHookStatuses" || i >= len(s.Lhs) {
+					continue
+				}
+				if id, ok := s.Lhs[i].(*ast.Ident); ok {
+					bound = id.Name
+				}
+			}
+		}
+		return true
+	})
+	if bound == "" {
+		t.Fatal("no `x := h.syncHookStatuses(...)` in statusWorkerCycle — either the worker " +
+			"stopped syncing hooks, or the result is bound in a form this guard cannot see")
+	}
+
+	// 2. Binding it is not enough: it has to reach the priority set. Without this arm
+	// a log-only use (or `_ = hookChanged`) would satisfy the check above while the
+	// changed sessions still starved on the round-robin.
+	fed := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		rng, ok := n.(*ast.RangeStmt)
+		if !ok {
+			return true
+		}
+		if id, ok := rng.X.(*ast.Ident); !ok || id.Name != bound {
+			return true
+		}
+		ast.Inspect(rng.Body, func(b ast.Node) bool {
+			if id, ok := b.(*ast.Ident); ok && id.Name == "priorityIDs" {
+				fed = true
+			}
+			return true
+		})
+		return true
+	})
+	if !fed {
+		t.Errorf("statusWorkerCycle binds syncHookStatuses' result to %q but never merges it "+
+			"into priorityIDs — the sessions it consumed still wait for the round-robin", bound)
+	}
+}

--- a/internal/ui/worker_cadence_test.go
+++ b/internal/ui/worker_cadence_test.go
@@ -396,6 +396,7 @@ func TestStatusWorkerFeedsHookChangesIntoPriority(t *testing.T) {
 	// 1. The result must be bound. A bare `h.syncHookStatuses(...)` expression
 	// statement is the original bug verbatim.
 	var bound string
+	bindings := 0
 	ast.Inspect(fn, func(n ast.Node) bool {
 		switch s := n.(type) {
 		case *ast.ExprStmt:
@@ -412,6 +413,7 @@ func TestStatusWorkerFeedsHookChangesIntoPriority(t *testing.T) {
 				}
 				if id, ok := s.Lhs[i].(*ast.Ident); ok {
 					bound = id.Name
+					bindings++
 				}
 			}
 		}
@@ -421,11 +423,45 @@ func TestStatusWorkerFeedsHookChangesIntoPriority(t *testing.T) {
 		t.Fatal("no `x := h.syncHookStatuses(...)` in statusWorkerCycle — either the worker " +
 			"stopped syncing hooks, or the result is bound in a form this guard cannot see")
 	}
+	if bindings > 1 {
+		// Checking only the last binding would leave the others unguarded, and every
+		// one of them consumes transitions that must reach the priority set.
+		t.Fatalf("statusWorkerCycle calls syncHookStatuses %d times; this guard checks one "+
+			"binding (%q). Extend it to cover each call before adding another.", bindings, bound)
+	}
 
-	// 2. Binding it is not enough: it has to reach the priority set. Without this arm
-	// a log-only use (or `_ = hookChanged`) would satisfy the check above while the
-	// changed sessions still starved on the round-robin.
-	fed := false
+	// 2. Binding it is not enough — it must *assign into* priorityIDs, and do so
+	// before anything reads that map. Asserting a mere mention would accept a
+	// read-only body (`if priorityIDs[id] { … }`), and asserting no position would
+	// accept the merge sitting below the loop that consumes priorityIDs — both
+	// leave the map missing this cycle's hook changes and restore the ≈26s lag
+	// with a green suite.
+	isPriorityIndex := func(e ast.Expr) bool {
+		ix, ok := e.(*ast.IndexExpr)
+		if !ok {
+			return false
+		}
+		id, ok := ix.X.(*ast.Ident)
+		return ok && id.Name == "priorityIDs"
+	}
+
+	// Every `priorityIDs[k] = v` in the function, so reads can be told from writes.
+	writes := map[token.Pos]bool{}
+	ast.Inspect(fn, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for _, lhs := range as.Lhs {
+			if isPriorityIndex(lhs) {
+				writes[lhs.Pos()] = true
+			}
+		}
+		return true
+	})
+
+	// The merge: a write to priorityIDs inside a `range <bound>` loop.
+	mergePos := token.NoPos
 	ast.Inspect(fn, func(n ast.Node) bool {
 		rng, ok := n.(*ast.RangeStmt)
 		if !ok {
@@ -435,15 +471,43 @@ func TestStatusWorkerFeedsHookChangesIntoPriority(t *testing.T) {
 			return true
 		}
 		ast.Inspect(rng.Body, func(b ast.Node) bool {
-			if id, ok := b.(*ast.Ident); ok && id.Name == "priorityIDs" {
-				fed = true
+			if as, ok := b.(*ast.AssignStmt); ok {
+				for _, lhs := range as.Lhs {
+					if isPriorityIndex(lhs) && (mergePos == token.NoPos || lhs.Pos() < mergePos) {
+						mergePos = lhs.Pos()
+					}
+				}
 			}
 			return true
 		})
 		return true
 	})
-	if !fed {
-		t.Errorf("statusWorkerCycle binds syncHookStatuses' result to %q but never merges it "+
-			"into priorityIDs — the sessions it consumed still wait for the round-robin", bound)
+	if mergePos == token.NoPos {
+		t.Fatalf("statusWorkerCycle binds syncHookStatuses' result to %q but never assigns it "+
+			"into priorityIDs — the sessions it consumed still wait for the round-robin. "+
+			"(If the merge was refactored into a helper or maps.Copy, keep the invariant and "+
+			"update this guard: every id must land in priorityIDs before that map is read.)", bound)
+	}
+
+	// The consume: the first read of priorityIDs — an index that is not a write.
+	firstRead := token.NoPos
+	ast.Inspect(fn, func(n ast.Node) bool {
+		ix, ok := n.(*ast.IndexExpr)
+		if !ok || !isPriorityIndex(ix) || writes[ix.Pos()] {
+			return true
+		}
+		if firstRead == token.NoPos || ix.Pos() < firstRead {
+			firstRead = ix.Pos()
+		}
+		return true
+	})
+	if firstRead == token.NoPos {
+		t.Fatal("nothing reads priorityIDs in statusWorkerCycle — the priority set is built " +
+			"and never consumed, so no session is updated ahead of the round-robin")
+	}
+	if mergePos > firstRead {
+		t.Errorf("statusWorkerCycle merges %q into priorityIDs at offset %d, after the map is "+
+			"first read at offset %d — the sessions this cycle's sync consumed are missing from "+
+			"that read and fall back to the round-robin", bound, mergePos, firstRead)
 	}
 }


### PR DESCRIPTION
Diagnosed from a `D` snapshot: every signal said the session was running — hook `running`, pane detected `running`, Claude's own status file `busy` with a live pid, transcript advanced 12s past the hook — while the sidebar showed `idle`.

## Root cause

`syncHookStatuses` returns the sessions whose hook changed, but it computes that list by diffing against the session's **in-memory** hook state and then overwrites it. A transition is therefore **consume-once**: whichever caller syncs first eats it.

| Caller | Result |
|---|---|
| `hookChangedMsg` (UI) | → `enqueuePriorityUpdates` ✅ |
| `statusUpdateMsg`, post-detach (UI) | → `enqueuePriorityUpdates` ✅ |
| `statusWorkerCycle`, every ~500ms | **discarded** ❌ |

During an attach `tea.Exec` suspends the Update loop, so `hookChangedMsg` never runs and the worker is the sole observer — it consumed every hook transition and dropped it. `statusUpdateMsg`'s post-detach catch-up sync, which exists precisely to cover the attach window, then found nothing changed and enqueued nothing. Idle sessions aren't in the fast pass (`fastPassSessions` covers Running/Waiting/Starting only), so the session fell back to the round-robin: `ceil(N/statusRoundRobin) * tickInterval` ≈ **26s at 65 sessions**.

## Measured

Same session, same pipeline, 50 seconds apart:

```
17:44:44.145  hook-handler writes status=running     (attached)
17:45:08.457  status changed idle→running   hookAge=24.446s   ← 24.3s
17:45:33.454  hook-handler writes status=waiting     (detached)
17:45:33.564  status changed running→waiting hookAge=564ms    ← 110ms
```

The only differentiator is whether the Update loop was suspended.

## Regression from #214

Before c13286f the worker wedged in `refreshAllGitAndPR` for the duration of an attach, so it never got to consume the change and the detach-time sync caught it. Keeping the worker alive across attaches is right, but it turned that safety net into a guaranteed no-op.

## Fix

Bind the result and merge it into `priorityIDs`, which is built later in the same cycle — no added latency. Merged directly rather than pushed through `priorityStatusUpdates` because that channel drops on full, and a send-then-drain round trip through our own queue buys nothing.

## Test

AST-based, matching the guards #214 added. The damage needs a real attach (Tea suspended, worker still cycling), and `UpdateStatus` needs a live tmux pane to reach `Running` at all — neither is reachable from a `ui` unit test, since `Session.paneCapturer` is package-private to `internal/session`.

Both arms mutation-verified:
- restoring the bare `h.syncHookStatuses(sessions, true)` → red on the discard check
- `_ = hookChanged` → red on the merge check

`go test -race ./internal/ui/ ./internal/session/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fv8jX7xW1iMZ51dJUWrVtc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status rows now update much faster after detaching—typically within about 100 ms instead of up to 25 seconds.
  * Hook status changes are prioritized immediately, reducing delays caused by normal update scheduling.

* **Tests**
  * Added coverage to verify hook status changes are correctly prioritized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->