### PR TITLE
fix(status): read past oversized lines in Claude transcripts

### DIFF
--- a/changelog/unreleased/transcript-oversized-line.md
+++ b/changelog/unreleased/transcript-oversized-line.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**Long transcripts stop lying.** A session whose conversation contained a very large entry — a pasted image, a big tool result — could show as finished while it was still working. fleet read the transcript only up to that entry; it now reads all of it.
+**Large transcripts read fully.** A conversation entry over 1MB — a pasted image, a big tool result — used to stop fleet mid-file, so a session that was still working showed as finished. You now get the right status whatever the entry size.

--- a/changelog/unreleased/transcript-oversized-line.md
+++ b/changelog/unreleased/transcript-oversized-line.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Long transcripts stop lying.** A session whose conversation contained a very large entry — a pasted image, a big tool result — could show as finished while it was still working. fleet read the transcript only up to that entry; it now reads all of it.

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/brizzai/fleet/internal/debuglog"
 )
 
 // claudeProjectDirReplacer mirrors Claude Code's per-cwd transcript dir naming.
@@ -75,7 +77,7 @@ func ReadClaudeSessionName(claudeSessionID, projectPath string) string {
 	jsonlPath := filepath.Join(projectDir, claudeSessionID+".jsonl")
 
 	var lastCustom, lastAI string
-	forEachTranscriptLine(jsonlPath, func(line string) bool {
+	_ = forEachTranscriptLine(jsonlPath, func(line string) bool {
 		// Quick check before JSON parsing. Matches both "custom-title" and
 		// "ai-title"; the Type check below filters any incidental hits.
 		if !strings.Contains(line, "-title") {
@@ -278,7 +280,7 @@ func transcriptParentLink(path string) string {
 		return ""
 	}
 	var link string
-	forEachTranscriptLine(path, func(line string) bool {
+	_ = forEachTranscriptLine(path, func(line string) bool {
 		if !strings.Contains(line, "logicalParentUuid") {
 			return true
 		}
@@ -319,9 +321,18 @@ const transcriptLineCap = 8 << 20 // 8MB
 // uuid reported absent — and every consumer treats them as authoritative. That
 // silently disabled the between-bursts tiebreaker in conversationActivePastHook and
 // biased sessionRotationVerdict toward rejecting genuine rotations.
+// Callers that only need a best-effort answer discard the returned error; the
+// helper has already logged anything beyond a routine missing file.
 func forEachTranscriptLine(path string, fn func(line string) bool) error {
 	f, err := os.Open(path)
 	if err != nil {
+		// A missing transcript is routine — the session may not have written one
+		// yet, or belongs to an agent that keeps none. Anything else (permissions,
+		// a bad path) leaves callers returning a zero value that reads exactly like
+		// "nothing happened", so it must not pass in silence.
+		if !errors.Is(err, os.ErrNotExist) {
+			debuglog.Logger.Warn("transcript: open failed", "path", path, "err", err)
+		}
 		return err
 	}
 	defer f.Close()
@@ -353,6 +364,11 @@ func forEachTranscriptLine(path string, fn func(line string) bool) error {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
+			// Partial walk. Whatever the caller returns is derived from a prefix of
+			// the file, which is precisely the failure this helper exists to end —
+			// so say so rather than letting a stale answer look authoritative.
+			debuglog.Logger.Warn("transcript: read failed, result is partial",
+				"path", path, "err", err)
 			return err
 		}
 	}
@@ -366,7 +382,7 @@ func transcriptContainsUUID(path, uuid string) bool {
 		return false
 	}
 	found := false
-	forEachTranscriptLine(path, func(line string) bool {
+	_ = forEachTranscriptLine(path, func(line string) bool {
 		if !strings.Contains(line, uuid) {
 			return true
 		}
@@ -414,7 +430,7 @@ func scanTranscriptTimestamp(path string, last bool, excludeSidechain bool) time
 		return time.Time{}
 	}
 	var result time.Time
-	forEachTranscriptLine(path, func(line string) bool {
+	_ = forEachTranscriptLine(path, func(line string) bool {
 		if !strings.Contains(line, `"timestamp"`) {
 			return true
 		}

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/brizzai/fleet/internal/debuglog"
@@ -301,6 +302,36 @@ func transcriptParentLink(path string) string {
 	return link
 }
 
+// transcriptWarnInterval throttles the warnings below. They sit on per-cycle paths
+// — ReadClaudeSessionName re-reads a transcript on every worker cycle while a
+// session is still unnamed (app.go sets recheck=0 inside agentNameFreshPollWindow),
+// then ~every 30s — and the conditions they report are sticky: EACCES does not clear
+// itself, and an over-cap entry is re-encountered on every scan. Unthrottled, one
+// broken transcript writes a line per session per cycle for the life of the process.
+// debug.log's last 100 lines are what the bug-report flow pastes into a public issue,
+// so that drip would evict the diagnostics these warnings exist to preserve. Same
+// shape and interval as rotRejectLogInterval.
+const transcriptWarnInterval = time.Minute
+
+// transcriptWarnedAt maps reason+path to the last time that pair was logged.
+var transcriptWarnedAt sync.Map
+
+// warnTranscript logs at Warn at most once per transcriptWarnInterval per
+// (reason, path).
+//
+// Warn rather than Debug on purpose: debuglog only enables Debug when FLEET_DEBUG is
+// set, so a Debug line would be absent from exactly the bug reports these warnings
+// are for. Throttling is what makes Warn affordable on a per-cycle path.
+func warnTranscript(reason, path string, args ...any) {
+	key := reason + "\x00" + path
+	now := time.Now()
+	if prev, ok := transcriptWarnedAt.Load(key); ok && now.Sub(prev.(time.Time)) < transcriptWarnInterval {
+		return
+	}
+	transcriptWarnedAt.Store(key, now)
+	debuglog.Logger.Warn(reason, append([]any{"path", path}, args...)...)
+}
+
 // transcriptLineCap bounds how much of one JSONL line is held in memory. Past it
 // the remainder of that line is discarded and the walk continues with the next —
 // losing one entry is recoverable (its neighbours are usually seconds away),
@@ -331,7 +362,7 @@ func forEachTranscriptLine(path string, fn func(line string) bool) error {
 		// a bad path) leaves callers returning a zero value that reads exactly like
 		// "nothing happened", so it must not pass in silence.
 		if !errors.Is(err, os.ErrNotExist) {
-			debuglog.Logger.Warn("transcript: open failed", "path", path, "err", err)
+			warnTranscript("transcript: open failed", path, "err", err)
 		}
 		return err
 	}
@@ -347,6 +378,13 @@ func forEachTranscriptLine(path string, fn func(line string) bool) error {
 			if !overCap {
 				if len(buf)+len(chunk) > transcriptLineCap {
 					overCap, buf = true, nil
+					// Say so. A skipped entry leaves a complete-looking walk that is
+					// missing one line, and if that line was the last, the callers here
+					// return the entry before it — stale, and indistinguishable from a
+					// real answer. That is the failure this helper replaced, at a
+					// smaller scale, so it must not be the one it reintroduces.
+					warnTranscript("transcript: entry over cap, skipped", path,
+						"cap_bytes", transcriptLineCap)
 				} else {
 					buf = append(buf, chunk...)
 				}
@@ -367,8 +405,7 @@ func forEachTranscriptLine(path string, fn func(line string) bool) error {
 			// Partial walk. Whatever the caller returns is derived from a prefix of
 			// the file, which is precisely the failure this helper exists to end —
 			// so say so rather than letting a stale answer look authoritative.
-			debuglog.Logger.Warn("transcript: read failed, result is partial",
-				"path", path, "err", err)
+			warnTranscript("transcript: read failed, result is partial", path, "err", err)
 			return err
 		}
 	}

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -74,22 +74,12 @@ func ReadClaudeSessionName(claudeSessionID, projectPath string) string {
 	}
 	jsonlPath := filepath.Join(projectDir, claudeSessionID+".jsonl")
 
-	f, err := os.Open(jsonlPath)
-	if err != nil {
-		return ""
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max buffer
-
 	var lastCustom, lastAI string
-	for scanner.Scan() {
-		line := scanner.Text()
+	forEachTranscriptLine(jsonlPath, func(line string) bool {
 		// Quick check before JSON parsing. Matches both "custom-title" and
 		// "ai-title"; the Type check below filters any incidental hits.
 		if !strings.Contains(line, "-title") {
-			continue
+			return true
 		}
 
 		var entry struct {
@@ -98,7 +88,7 @@ func ReadClaudeSessionName(claudeSessionID, projectPath string) string {
 			AITitle     string `json:"aiTitle"`
 		}
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
-			continue
+			return true
 		}
 		switch entry.Type {
 		case "custom-title":
@@ -110,7 +100,8 @@ func ReadClaudeSessionName(claudeSessionID, projectPath string) string {
 				lastAI = entry.AITitle
 			}
 		}
-	}
+		return true
+	})
 
 	if lastCustom != "" {
 		return lastCustom
@@ -286,18 +277,10 @@ func transcriptParentLink(path string) string {
 	if path == "" {
 		return ""
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		return ""
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
+	var link string
+	forEachTranscriptLine(path, func(line string) bool {
 		if !strings.Contains(line, "logicalParentUuid") {
-			continue
+			return true
 		}
 		var entry struct {
 			Type              string `json:"type"`
@@ -305,13 +288,74 @@ func transcriptParentLink(path string) string {
 			LogicalParentUUID string `json:"logicalParentUuid"`
 		}
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
-			continue
+			return true
 		}
 		if entry.LogicalParentUUID != "" && (entry.Subtype == "compact_boundary" || entry.Type == "summary") {
-			return entry.LogicalParentUUID
+			link = entry.LogicalParentUUID
+			return false
+		}
+		return true
+	})
+	return link
+}
+
+// transcriptLineCap bounds how much of one JSONL line is held in memory. Past it
+// the remainder of that line is discarded and the walk continues with the next —
+// losing one entry is recoverable (its neighbours are usually seconds away),
+// whereas abandoning the walk silently turns the entire rest of the file into
+// "doesn't exist", which is the failure this helper exists to prevent.
+const transcriptLineCap = 8 << 20 // 8MB
+
+// forEachTranscriptLine calls fn for each non-empty line of the JSONL transcript
+// at path, stopping early when fn returns false.
+//
+// Deliberately not bufio.Scanner. A Scanner has a maximum token size and reports
+// an over-long line by ending the loop with ErrTooLong — which reads exactly like
+// a clean EOF unless the caller checks scanner.Err(), and none of the callers here
+// did. Transcript lines routinely get large: an entry carrying a pasted image or a
+// big tool result is one JSON line, and 4 of 554 local transcripts held a line over
+// 1MB, the worst of them 2% of the way into the file. The answers that came back
+// were not visibly broken, just stale — a timestamp from sixteen days earlier, a
+// uuid reported absent — and every consumer treats them as authoritative. That
+// silently disabled the between-bursts tiebreaker in conversationActivePastHook and
+// biased sessionRotationVerdict toward rejecting genuine rotations.
+func forEachTranscriptLine(path string, fn func(line string) bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	r := bufio.NewReaderSize(f, 64*1024)
+	var buf []byte
+	overCap := false
+	for {
+		chunk, err := r.ReadSlice('\n')
+		if errors.Is(err, bufio.ErrBufferFull) {
+			// Mid-line: accumulate until the cap, then drop the rest of this line.
+			if !overCap {
+				if len(buf)+len(chunk) > transcriptLineCap {
+					overCap, buf = true, nil
+				} else {
+					buf = append(buf, chunk...)
+				}
+			}
+			continue
+		}
+		if !overCap {
+			buf = append(buf, chunk...)
+			if line := strings.TrimRight(string(buf), "\r\n"); line != "" && !fn(line) {
+				return nil
+			}
+		}
+		buf, overCap = buf[:0], false
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
 		}
 	}
-	return ""
 }
 
 // transcriptContainsUUID reports whether any entry in the transcript at path
@@ -321,27 +365,21 @@ func transcriptContainsUUID(path, uuid string) bool {
 	if path == "" || uuid == "" {
 		return false
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
+	found := false
+	forEachTranscriptLine(path, func(line string) bool {
 		if !strings.Contains(line, uuid) {
-			continue
+			return true
 		}
 		var entry struct {
 			UUID string `json:"uuid"`
 		}
 		if err := json.Unmarshal([]byte(line), &entry); err == nil && entry.UUID == uuid {
-			return true
+			found = true
+			return false
 		}
-	}
-	return false
+		return true
+	})
+	return found
 }
 
 // firstTranscriptTimestamp returns the timestamp of the earliest timestamped JSONL
@@ -375,41 +413,29 @@ func scanTranscriptTimestamp(path string, last bool, excludeSidechain bool) time
 	if path == "" {
 		return time.Time{}
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		return time.Time{}
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max line
-
 	var result time.Time
-	for scanner.Scan() {
-		line := scanner.Text()
+	forEachTranscriptLine(path, func(line string) bool {
 		if !strings.Contains(line, `"timestamp"`) {
-			continue
+			return true
 		}
 		var entry struct {
 			Timestamp   string `json:"timestamp"`
 			IsSidechain bool   `json:"isSidechain"`
 		}
 		if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Timestamp == "" {
-			continue
+			return true
 		}
 		if excludeSidechain && entry.IsSidechain {
-			continue
+			return true
 		}
 		// RFC3339Nano: Claude transcripts stamp millisecond precision (e.g.
 		// "...:04.226Z"). The layout also parses entries with no fractional part.
 		ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp)
 		if err != nil {
-			continue
-		}
-		if !last {
-			return ts
+			return true
 		}
 		result = ts
-	}
+		return last // first match wins when we only want the earliest entry
+	})
 	return result
 }

--- a/internal/session/claude_name_test.go
+++ b/internal/session/claude_name_test.go
@@ -1,12 +1,16 @@
 package session
 
 import (
+	"bytes"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/brizzai/fleet/internal/debuglog"
 )
 
 func TestClaudeProjectDirName(t *testing.T) {
@@ -532,5 +536,41 @@ func TestForEachTranscriptLineReportsReadErrors(t *testing.T) {
 	}
 	if len(got) != 2 || got[1] != `{"b":2}` {
 		t.Errorf("lines = %q, want both entries including the unterminated last one", got)
+	}
+}
+
+// TestWarnTranscriptThrottles guards the property that makes these warnings
+// affordable. They sit on per-cycle paths — ReadClaudeSessionName re-reads a
+// transcript on every worker cycle while a session is unnamed — and report sticky
+// conditions (EACCES does not clear itself; an over-cap entry recurs on every
+// scan). Unthrottled they write a line per session per cycle forever, and since
+// debug.log's last 100 lines are what the bug-report flow publishes, that drip
+// evicts the diagnostics the warnings exist to preserve.
+func TestWarnTranscriptThrottles(t *testing.T) {
+	var buf bytes.Buffer
+	prev := debuglog.Logger
+	debuglog.Logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	t.Cleanup(func() { debuglog.Logger = prev })
+
+	const reason = "transcript: test reason"
+	warnTranscript(reason, "/tmp/a.jsonl")
+	warnTranscript(reason, "/tmp/a.jsonl") // same pair — suppressed
+	warnTranscript(reason, "/tmp/a.jsonl") // still suppressed
+
+	if got := strings.Count(buf.String(), reason); got != 1 {
+		t.Errorf("same (reason, path) logged %d times, want 1", got)
+	}
+
+	// A different path is a different condition and must still be reported —
+	// throttling per-pair rather than globally keeps one noisy transcript from
+	// masking a second one.
+	warnTranscript(reason, "/tmp/b.jsonl")
+	if got := strings.Count(buf.String(), reason); got != 2 {
+		t.Errorf("second path logged %d total, want 2 (a distinct path must not be throttled)", got)
+	}
+
+	// The path is always attached, so a report names the transcript at fault.
+	if !strings.Contains(buf.String(), "/tmp/b.jsonl") {
+		t.Error("warning omitted the transcript path")
 	}
 }

--- a/internal/session/claude_name_test.go
+++ b/internal/session/claude_name_test.go
@@ -442,3 +442,95 @@ func TestLastLeadTranscriptTimestamp(t *testing.T) {
 		}
 	})
 }
+
+// TestTranscriptScanSurvivesOversizedLine covers the bug where a single JSONL line
+// larger than the reader's buffer silently ended every transcript walk.
+//
+// bufio.Scanner reports an over-long line by returning false from Scan() and
+// setting ErrTooLong — indistinguishable from a clean EOF unless Err() is checked,
+// which none of these callers did. The scan therefore answered from whatever it had
+// read *before* the long line, and answered confidently: on a real 12,826-line
+// transcript whose first oversized entry sat at line 4,341, lastLeadTranscriptTimestamp
+// returned a timestamp sixteen days stale. That silently disabled the
+// conversationActivePastHook tiebreaker, so one between-bursts frame flipped a
+// mid-turn session to finished.
+//
+// An entry carrying a pasted image or a large tool result is a single JSON line, so
+// this is ordinary transcript content, not corruption.
+func TestTranscriptScanSurvivesOversizedLine(t *testing.T) {
+	early := time.Date(2026, 7, 12, 14, 26, 47, 0, time.UTC)
+	late := time.Date(2026, 7, 28, 12, 31, 53, 0, time.UTC)
+	lateUUID := "11111111-2222-3333-4444-555555555555"
+
+	entry := func(ts time.Time, pad int, uuid string) string {
+		var b strings.Builder
+		b.WriteString(`{"type":"user","uuid":"` + uuid + `","timestamp":"`)
+		b.WriteString(ts.UTC().Format(time.RFC3339Nano))
+		b.WriteString(`","data":"` + strings.Repeat("x", pad) + `"}` + "\n")
+		return b.String()
+	}
+
+	// Oversized but under transcriptLineCap: its own timestamp must still be read.
+	// Ordering matters — everything the bug hid lives after the long line.
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	body := entry(early, 10, "aaaaaaaa-0000-0000-0000-000000000000") +
+		entry(early.Add(time.Minute), 2<<20, "bbbbbbbb-0000-0000-0000-000000000000") +
+		entry(late, 10, lateUUID)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := lastLeadTranscriptTimestamp(path); !got.Equal(late) {
+		t.Errorf("lastLeadTranscriptTimestamp = %v, want %v (scan stopped at the oversized line)", got, late)
+	}
+	if got := lastTranscriptTimestamp(path); !got.Equal(late) {
+		t.Errorf("lastTranscriptTimestamp = %v, want %v", got, late)
+	}
+	// sessionRotationVerdict's parent-link signal reads the owner transcript this
+	// way; a uuid past the long line must not read as absent.
+	if !transcriptContainsUUID(path, lateUUID) {
+		t.Error("transcriptContainsUUID missed a uuid located after the oversized line")
+	}
+
+	// Past the cap the line itself is dropped, but the walk must continue: the entry
+	// after it is still found. Losing one entry is recoverable; losing the tail is not.
+	huge := filepath.Join(t.TempDir(), "huge.jsonl")
+	body = entry(early, 10, "aaaaaaaa-0000-0000-0000-000000000000") +
+		entry(early.Add(time.Minute), transcriptLineCap+1, "bbbbbbbb-0000-0000-0000-000000000000") +
+		entry(late, 10, lateUUID)
+	if err := os.WriteFile(huge, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := lastLeadTranscriptTimestamp(huge); !got.Equal(late) {
+		t.Errorf("over-cap line aborted the walk: got %v, want %v", got, late)
+	}
+	if !transcriptContainsUUID(huge, lateUUID) {
+		t.Error("over-cap line aborted the walk before a later uuid")
+	}
+}
+
+// TestForEachTranscriptLineReportsReadErrors guards the property whose absence caused
+// the bug: a truncated walk must be distinguishable from a complete one.
+func TestForEachTranscriptLineReportsReadErrors(t *testing.T) {
+	if err := forEachTranscriptLine(filepath.Join(t.TempDir(), "missing.jsonl"), func(string) bool {
+		return true
+	}); err == nil {
+		t.Error("expected an error for a missing transcript, got nil")
+	}
+
+	// A final line with no trailing newline must still be delivered.
+	path := filepath.Join(t.TempDir(), "noeol.jsonl")
+	if err := os.WriteFile(path, []byte("{\"a\":1}\n{\"b\":2}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	if err := forEachTranscriptLine(path, func(line string) bool {
+		got = append(got, line)
+		return true
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[1] != `{"b":2}` {
+		t.Errorf("lines = %q, want both entries including the unterminated last one", got)
+	}
+}


### PR DESCRIPTION
## What

Every transcript walk used a `bufio.Scanner` capped at 1MB per line. A Scanner reports an over-long line by returning `false` from `Scan()` and setting `ErrTooLong` — **indistinguishable from a clean EOF unless `Err()` is checked, and none of the four callers checked it.** Each therefore answered from whatever it had read *before* the long line, and answered confidently.

An entry carrying a pasted image or a large tool result is a single JSON line, so this is ordinary transcript content, not corruption. **4 of 554 local transcripts hold a line over 1MB**, the worst 2% of the way into the file.

## How it surfaced

A `D` snapshot showed a session as `finished` while every other signal said running: pane showing `✢ Topsy-turvying… (3m 59s · ↓ 12.5k tokens)`, transcript growing every 1–3s, Claude's own status file `busy`.

That transcript is 12,826 lines with its first oversized entry at line 4,341:

```
lastLeadTranscriptTimestamp() → 2026-07-12 14:26:47   ← 16 days stale
true last lead entry          → 2026-07-28 12:31:53
```

Both `conversationActivePastHook` conditions fail on that stale value, so the tiebreaker for the between-bursts frame — where a working agent's activity line is momentarily absent and the persistent `❯` box reads as a finished idle prompt — silently answered `false`. One such frame flipped a mid-turn session to finished:

```
15:32:04.867  ✻ Topsy-turvying… (3m 42s · … · thought for 8s)   ← thinking block ends
15:32:05.417  matched prompt ❯ linesFromBottom=3                 ← one frame, no activity line
15:32:05.510  hook says waiting but pane shows idle prompt, overriding to finished
```

Recovery was slow for a second reason: `fastPassSessions` carries only Running/Waiting/Starting, so on flipping to Finished the session dropped from the 500ms pass to the 2s round-robin — 14s of silence in the log before the capture.

## Blast radius

The same scanners back `sessionRotationVerdict`, where truncation biases every signal the same direction — a timestamp that looks un-advanced, a parent link that looks absent, a uuid that looks missing, all reading as *"not a rotation"*.

## The fix

One `forEachTranscriptLine` helper on `bufio.Reader`, which has no line limit, replacing all four scanner sites. Lines past an explicit 8MB cap are **skipped and the walk continues** — losing one entry is recoverable (its neighbours are usually seconds away), whereas abandoning the walk turns the entire rest of the file into "doesn't exist". Read errors are returned **and logged**: a missing transcript stays quiet (routine — a session may not have written one yet), while permission errors and mid-read I/O failures log at Warn with the path, so a partial walk is visible instead of returning a stale answer that reads as authoritative.

## Tests

Two cases that place the interesting entries **after** an oversized line and assert each reader still finds them — timestamps and `transcriptContainsUUID` (the rotation path) — plus the over-cap skip and an unterminated final line.

Run against a reverted implementation they fail, reproducing the real-world symptom exactly:

```
lastLeadTranscriptTimestamp = 2026-07-12 14:26:47, want 2026-07-28 12:31:53
transcriptContainsUUID missed a uuid located after the oversized line
```

Full suite green with `-race`; `vet`, `gofmt`, build clean.

## Deliberately not included

- **The fast-pass change.** Keeping a session on the 500ms pass briefly after a Running→Finished flip would cut the recovery lag, but that's an amplifier rather than the cause, and it has its own CPU cost — worth deciding on its own.
- **Any claim this closes the parked-job rotation bug.** Those transcripts have no line over 93KB, so that diagnosis stands independently and remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transcript processing for long/large sessions so oversized transcript entries no longer stop processing early.
  * Improved reliability when transcripts contain very large lines, including proper handling of the final entry even without a trailing newline.
* **Tests**
  * Added coverage ensuring transcript scanning continues after oversized lines.
  * Added coverage for missing transcript and error reporting when the final JSONL line is unterminated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->