### PR TITLE
docs(changelog): note that one fragment is one bullet

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -13,6 +13,17 @@ type: added
 Description of the change for end users
 ```
 
+**One file is one bullet.** At release time the roller prefixes each *fragment*
+with `- ` — not each paragraph inside it. A fragment holding two paragraphs
+therefore emits a bullet followed by a bare line, which markdown treats as a lazy
+continuation of the bullet above: two ideas render glued into one, in both the
+GitHub Release and the in-app Release Notes view. This happened in v2.23.2 and
+had to be patched on the release branch.
+
+So when a change really is two ideas — which "one idea per bullet" below asks you
+to split — give each one **its own file**. Splitting inside a single fragment
+looks right in the source and comes out wrong.
+
 ## Keep it concise
 
 Aim for **1–2 sentences** that lead with the user-facing change. A reader


### PR DESCRIPTION
## Why

v2.23.2's release PR rolled a malformed changelog:

```
- **No more idle flicker.** … a steady status for the whole turn.
**Compaction reads as running.** … the pane detects it directly.     ← no "- "
- **Large transcripts read fully.** …
```

The middle line has no bullet marker and no blank line before it, so markdown treats it as a *lazy continuation* of the bullet above — three bullets render as two, with compaction glued onto the end of the idle-flicker entry. That affects both the GitHub Release and the in-app Release Notes view.

## Cause

The roller prefixes each **fragment** with `- `, not each paragraph inside it. `activity-line-detection.md` held two paragraphs because review (correctly) asked for compaction to be its own bullet per the guide's *"one idea per bullet"* rule — and the split was made inside the file instead of across two files.

The guide already said *one idea per bullet*; it didn't say how to get one. Splitting inside a fragment looks right in the source and comes out wrong, with nothing to catch it.

## What this adds

A short note under **Format**: one file is one bullet, what happens when a fragment holds two paragraphs, and that a genuinely two-idea change needs two files.

Docs only, no behaviour change. The v2.23.2 changelog itself was patched directly on `release/next` (PR #223), so the release is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)