### PR TITLE
fix(status): decide conversation ownership by reporting process

### DIFF
--- a/changelog/unreleased/fork-stale-conversation.md
+++ b/changelog/unreleased/fork-stale-conversation.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+**Forks resume the live conversation.** Forking a session that had rotated to a fresh conversation (a `/clear`, typically) could copy the one it left behind, so the fork opened work you finished an hour ago. It now follows the conversation the session is actually in.

--- a/changelog/unreleased/fork-stale-conversation.md
+++ b/changelog/unreleased/fork-stale-conversation.md
@@ -1,4 +1,4 @@
 ---
 type: fixed
 ---
-**Forks resume the live conversation.** Forking a session that had rotated to a fresh conversation (a `/clear`, typically) could copy the one it left behind, so the fork opened work you finished an hour ago. It now follows the conversation the session is actually in.
+**Forks follow the conversation.** Forking a session that had started a fresh conversation (after `/clear`, typically) could copy the one it left behind, so you got back work you finished an hour ago. You now fork whatever the session is actually in.

--- a/changelog/unreleased/frozen-conversation-id.md
+++ b/changelog/unreleased/frozen-conversation-id.md
@@ -1,4 +1,4 @@
 ---
 type: fixed
 ---
-**Stuck sessions unstick themselves.** A session could pin itself to a conversation that had already ended and then ignore every status update for the rest of its life — a frozen dot, and `r` reopening the wrong conversation. It now notices the old one has gone quiet and moves on.
+**Stuck sessions recover.** A session could pin itself to a conversation that had already ended and then ignore every status update for the rest of its life, so you got a frozen dot and an `r` that reopened the wrong conversation. Both come back the moment the old conversation's process is gone.

--- a/changelog/unreleased/frozen-conversation-id.md
+++ b/changelog/unreleased/frozen-conversation-id.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+**Stuck sessions unstick themselves.** A session could pin itself to a conversation that had already ended and then ignore every status update for the rest of its life — a frozen dot, and `r` reopening the wrong conversation. It now notices the old one has gone quiet and moves on.

--- a/cmd/fleet/hook_handler.go
+++ b/cmd/fleet/hook_handler.go
@@ -177,6 +177,10 @@ func handleHookHandler() {
 		UserPrompt:  userPrompt,
 		PromptCount: promptCount,
 		Reason:      payload.Reason,
+		// The agent runs the hook command directly, so our parent IS the agent
+		// process whose conversation this status describes. Recording it lets the
+		// TUI later ask whether that conversation is still alive.
+		AgentPID: os.Getppid(),
 	}
 
 	if err := hooks.WriteStatusFile(hooksDir, instanceID, sf); err != nil {

--- a/internal/hooks/hook_watcher.go
+++ b/internal/hooks/hook_watcher.go
@@ -23,6 +23,9 @@ type HookStatus struct {
 	UpdatedAt   time.Time
 	UserPrompt  string
 	PromptCount int
+	// AgentPID is the agent process that fired the hook, or 0 when the status file
+	// predates the field. See StatusFile.AgentPID.
+	AgentPID int
 }
 
 // HookWatcher watches ~/.config/fleet/hooks/ for status file changes
@@ -210,6 +213,7 @@ func (w *HookWatcher) processFile(filePath string) {
 		UpdatedAt:   time.Unix(sf.Timestamp, 0),
 		UserPrompt:  sf.UserPrompt,
 		PromptCount: sf.PromptCount,
+		AgentPID:    sf.AgentPID,
 	}
 
 	w.mu.Lock()

--- a/internal/hooks/status_file.go
+++ b/internal/hooks/status_file.go
@@ -18,6 +18,15 @@ type StatusFile struct {
 	// ("clear", "logout", "prompt_input_exit", "other"). "other" combined with
 	// no exit info typically means the process was killed externally.
 	Reason string `json:"reason,omitempty"`
+	// AgentPID is the process that fired this hook — the agent itself, since a
+	// hook command runs as its direct child (verified: a hook's getppid() is the
+	// `claude` process). It is what lets the status pipeline ask whether the
+	// conversation that owns a session is still running, which separates a
+	// session-id rotation (owner gone) from a nested agent that inherited
+	// FLEET_INSTANCE_ID (owner alive) — a distinction no amount of transcript
+	// reading can make. Omitted by handlers older than this field; readers must
+	// treat 0 as "unknown", not "dead".
+	AgentPID int `json:"agent_pid,omitempty"`
 }
 
 // WriteStatusFile atomically writes a status file to the hooks directory.

--- a/internal/session/agent_process.go
+++ b/internal/session/agent_process.go
@@ -1,0 +1,45 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// agentProcessAlive reports whether the agent process that fired a hook is still
+// running. pid 0 means the status file predates StatusFile.AgentPID, which is not
+// evidence of death — callers must treat false-with-unknown-pid separately.
+//
+// This is the signal a nested agent cannot produce. A `claude` spawned inside a
+// tool call inherits FLEET_INSTANCE_ID and fires hooks under its own conversation
+// id, which is indistinguishable from a session-id rotation by every transcript
+// signal we have: both leave one conversation writing and another silent. The
+// difference is that a rotation happens *inside* the owner process — the old
+// conversation's process is gone — while a nested agent runs *alongside* an owner
+// that is very much alive.
+//
+// Signal 0 checks for existence and permission without delivering anything. It
+// answers for zombies too (a not-yet-reaped child is still a process), which is the
+// answer we want: the agent has not been replaced.
+//
+// Fails closed. A pid can be recycled onto an unrelated process, which reads as
+// "owner alive" and leaves the session frozen — exactly what happens today without
+// this check, so a wrong answer here costs nothing that was not already lost, while
+// the opposite bias would hand a session's status and resume id to a scratch
+// conversation.
+func agentProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	// On Unix FindProcess never fails; the signal is what reports.
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = p.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	// EPERM means it exists and belongs to someone else — alive for our purposes.
+	return errors.Is(err, syscall.EPERM)
+}

--- a/internal/session/agent_process.go
+++ b/internal/session/agent_process.go
@@ -6,17 +6,38 @@ import (
 	"syscall"
 )
 
-// agentProcessAlive reports whether the agent process that fired a hook is still
-// running. pid 0 means the status file predates StatusFile.AgentPID, which is not
-// evidence of death — callers must treat false-with-unknown-pid separately.
+// conversationSucceeds reports whether a hook arriving from newPID, under a session
+// id we don't own, is the owner conversation continued rather than a nested agent
+// running beside it. known=false means one side has no pid (a status file older
+// than StatusFile.AgentPID) and the caller must fall back to transcripts.
 //
-// This is the signal a nested agent cannot produce. A `claude` spawned inside a
-// tool call inherits FLEET_INSTANCE_ID and fires hooks under its own conversation
-// id, which is indistinguishable from a session-id rotation by every transcript
-// signal we have: both leave one conversation writing and another silent. The
-// difference is that a rotation happens *inside* the owner process — the old
-// conversation's process is gone — while a nested agent runs *alongside* an owner
-// that is very much alive.
+// This is the signal a nested agent cannot produce, and it is about identity, not
+// just liveness:
+//
+//   - Same process, new session id. Claude rotates its id in place — `/clear`
+//     starts a fresh conversation inside the running process — so the report is
+//     the owner itself, under a new name. A rotation, unambiguously.
+//   - Different process, owner gone. The conversation that held this session
+//     ended; whatever is reporting now succeeded it.
+//   - Different process, owner alive. Two agents at once: a `claude` spawned
+//     inside a tool call inherited FLEET_INSTANCE_ID and is firing hooks under
+//     its own id while its parent waits. Adopting it would hand the session's
+//     status and resume id to a scratch conversation.
+//
+// Liveness alone cannot make that call. It gets the third case right and the first
+// one exactly wrong — an in-process `/clear` leaves the owner's pid very much
+// alive, which is the shape issue #226 was reported in.
+func conversationSucceeds(ownerPID, newPID int) (succeeds, known bool) {
+	if ownerPID <= 0 || newPID <= 0 {
+		return false, false
+	}
+	if ownerPID == newPID {
+		return true, true // in-process rotation
+	}
+	return !agentProcessAlive(ownerPID), true
+}
+
+// agentProcessAlive reports whether a process is still running.
 //
 // Signal 0 checks for existence and permission without delivering anything. It
 // answers for zombies too (a not-yet-reaped child is still a process), which is the

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -270,36 +270,36 @@ func sessionRotationVerdict(projectPath, ownerSessionID, newSessionID string) ro
 	return rotationNo
 }
 
-// deadOwnerSupersedeMargin is how far a rejected session's transcript must have
-// advanced past the owner's last entry before ownerConversationSuperseded accepts
-// that the owner conversation is dead.
+// deadOwnerSilenceWindow is how long the owner conversation must have been silent
+// before ownerConversationAbandoned accepts, on transcript evidence alone, that it
+// is gone.
 //
-// The margin has to clear the one benign way a foreign id outlives the owner's
-// last write: a nested child claude spawned from a tool call, during which the
-// parent writes nothing until the child returns. Fifteen minutes is far longer
-// than such a call runs, and far shorter than the "forever" a wrongly rejected
-// rotation otherwise lasts.
-const deadOwnerSupersedeMargin = 15 * time.Minute
+// Only the fallback path uses it — when the owner's pid is known, liveness answers
+// the question outright. It exists because the case the neg-cache guards against
+// (a nested agent that inherited FLEET_INSTANCE_ID) leaves the same trace as a
+// rotation: an owner that stopped writing. A parent blocked on a child inside a
+// tool call is silent for as long as the call runs, so the window has to clear
+// that, and fifteen minutes does — while staying far shorter than the "forever" a
+// wrongly rejected rotation otherwise lasts.
+const deadOwnerSilenceWindow = 15 * time.Minute
 
-// ownerConversationSuperseded reports whether newSessionID's transcript has
-// demonstrably taken over from ownerSessionID's: the owner stopped writing at
-// least deadOwnerSupersedeMargin before the new session's latest entry, and that
-// entry is itself recent — we only ever heal toward a conversation that is alive
-// now, never toward one that merely outlived the owner at some point in the past.
+// ownerConversationAbandoned reports whether the owner conversation looks dead from
+// its transcript alone: silent for at least deadOwnerSilenceWindow while the new
+// session has written since.
 //
-// This is the recovery path for a rotation sessionRotationVerdict could not prove
-// — a /clear whose handoff timestamps were unreadable, or a pair that stayed
-// undecidable past the retry cap. Those get neg-cached, and a neg-cached owner is
-// released by nothing: an in-process rotation fires no SessionEnd for the id it
-// leaves behind, so the session's status and its resume/fork id stay pinned to a
-// conversation nobody is in (issue #226).
+// This is the FALLBACK. The question it approximates — "has the conversation that
+// owns this session ended?" — is answered exactly by agentProcessAlive when the
+// owner's pid is known, and this is what remains when it isn't: a status file
+// written by a handler older than StatusFile.AgentPID. That is a one-launch
+// transient, since the next hook from the current handler records a pid.
 //
-// Deliberately a different question from sessionRotationVerdict's. That one asks
-// "is this the same conversation continued?" and answers from lineage. This one
-// asks only "is the owner still being written to?", because by the time it runs
-// the lineage answer has already come back no and been wrong. Liveness is the one
-// signal a dead owner cannot fake.
-func ownerConversationSuperseded(projectPath, ownerSessionID, newSessionID string) bool {
+// It asks how long the owner has been silent, NOT how far the new session has run
+// past it. The difference matters: a /clear followed by six minutes of work and
+// then a pause never advances a "new session ran N past the owner" measure beyond
+// six minutes, so the session would stay frozen for the rest of its life — and a
+// short piece of work after a /clear is the common shape, since /clear is usually
+// how new work starts.
+func ownerConversationAbandoned(projectPath, ownerSessionID, newSessionID string) bool {
 	if projectPath == "" || ownerSessionID == "" || newSessionID == "" {
 		return false
 	}
@@ -309,10 +309,12 @@ func ownerConversationSuperseded(projectPath, ownerSessionID, newSessionID strin
 	if ownerLast.IsZero() || newLast.IsZero() {
 		return false
 	}
-	if time.Since(newLast) > deadOwnerSupersedeMargin {
+	// The new conversation must have outlived the owner, not merely coexisted with
+	// it: a child that finished before the owner's last write is no successor.
+	if !newLast.After(ownerLast) {
 		return false
 	}
-	return newLast.Sub(ownerLast) >= deadOwnerSupersedeMargin
+	return time.Since(ownerLast) >= deadOwnerSilenceWindow
 }
 
 // transcriptParentLink returns the logicalParentUuid of the first

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -270,6 +270,51 @@ func sessionRotationVerdict(projectPath, ownerSessionID, newSessionID string) ro
 	return rotationNo
 }
 
+// deadOwnerSupersedeMargin is how far a rejected session's transcript must have
+// advanced past the owner's last entry before ownerConversationSuperseded accepts
+// that the owner conversation is dead.
+//
+// The margin has to clear the one benign way a foreign id outlives the owner's
+// last write: a nested child claude spawned from a tool call, during which the
+// parent writes nothing until the child returns. Fifteen minutes is far longer
+// than such a call runs, and far shorter than the "forever" a wrongly rejected
+// rotation otherwise lasts.
+const deadOwnerSupersedeMargin = 15 * time.Minute
+
+// ownerConversationSuperseded reports whether newSessionID's transcript has
+// demonstrably taken over from ownerSessionID's: the owner stopped writing at
+// least deadOwnerSupersedeMargin before the new session's latest entry, and that
+// entry is itself recent — we only ever heal toward a conversation that is alive
+// now, never toward one that merely outlived the owner at some point in the past.
+//
+// This is the recovery path for a rotation sessionRotationVerdict could not prove
+// — a /clear whose handoff timestamps were unreadable, or a pair that stayed
+// undecidable past the retry cap. Those get neg-cached, and a neg-cached owner is
+// released by nothing: an in-process rotation fires no SessionEnd for the id it
+// leaves behind, so the session's status and its resume/fork id stay pinned to a
+// conversation nobody is in (issue #226).
+//
+// Deliberately a different question from sessionRotationVerdict's. That one asks
+// "is this the same conversation continued?" and answers from lineage. This one
+// asks only "is the owner still being written to?", because by the time it runs
+// the lineage answer has already come back no and been wrong. Liveness is the one
+// signal a dead owner cannot fake.
+func ownerConversationSuperseded(projectPath, ownerSessionID, newSessionID string) bool {
+	if projectPath == "" || ownerSessionID == "" || newSessionID == "" {
+		return false
+	}
+	ownerLast := lastTranscriptTimestamp(ClaudeTranscriptPath(ownerSessionID, projectPath))
+	newLast := lastTranscriptTimestamp(ClaudeTranscriptPath(newSessionID, projectPath))
+	// An unreadable transcript on either side is not evidence of anything.
+	if ownerLast.IsZero() || newLast.IsZero() {
+		return false
+	}
+	if time.Since(newLast) > deadOwnerSupersedeMargin {
+		return false
+	}
+	return newLast.Sub(ownerLast) >= deadOwnerSupersedeMargin
+}
+
 // transcriptParentLink returns the logicalParentUuid of the first
 // compact_boundary/summary entry in the transcript at path — the link a
 // continue/resume/fork rotation records to its parent session's tail uuid — or

--- a/internal/session/ownership_test.go
+++ b/internal/session/ownership_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -253,14 +254,14 @@ func TestUpdateHookStatusCapsUndecidedRotation(t *testing.T) {
 	// The first rotationUndecidedRetryCap cycles defer without neg-caching.
 	for i := 0; i < rotationUndecidedRetryCap; i++ {
 		s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "foreign-bbb", UpdatedAt: time.Now()}, true)
-		if s.rotRejectForeign == "foreign-bbb" {
+		if s.rotRejects["foreign-bbb"] != nil {
 			t.Fatalf("neg-cached too early at cycle %d (cap=%d)", i+1, rotationUndecidedRetryCap)
 		}
 	}
 	// One more undecided cycle exceeds the cap → neg-cache.
 	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "foreign-bbb", UpdatedAt: time.Now()}, true)
-	if s.rotRejectForeign != "foreign-bbb" {
-		t.Errorf("undecided pair past the retry cap should be neg-cached, got rotRejectForeign=%q", s.rotRejectForeign)
+	if s.rotRejects["foreign-bbb"] == nil {
+		t.Errorf("undecided pair past the retry cap should be neg-cached, got rotRejects=%v", s.rotRejects)
 	}
 	// The owner id is never clobbered by the undecidable foreign session.
 	if s.ClaudeSessionID != "owner-aaa" {
@@ -268,11 +269,24 @@ func TestUpdateHookStatusCapsUndecidedRotation(t *testing.T) {
 	}
 }
 
-// negCachedSession returns a session whose (owner-aaa, live-bbb) pair has been
-// rejected and neg-cached — the frozen state issue #226 was reported in — with the
+// reapedPID returns the pid of a process that has run and been waited on, so it is
+// reliably gone. Stands in for an agent whose conversation ended.
+func reapedPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("/usr/bin/true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("spawn throwaway process: %v", err)
+	}
+	return cmd.Process.Pid
+}
+
+// negCachedSession returns a session whose live-bbb hook has been rejected against
+// owner-aaa and neg-cached — the frozen state issue #226 was reported in — with the
 // recovery clock wound back so the next worker-path hook rechecks immediately.
-// ownerLast/liveLast set where each conversation last wrote.
-func negCachedSession(t *testing.T, ownerLast, liveLast time.Time) (*Session, string) {
+// ownerPID is the agent process recorded for the owner (0 = a status file older
+// than the field, which forces the transcript fallback); ownerLast/liveLast set
+// where each conversation last wrote.
+func negCachedSession(t *testing.T, ownerPID int, ownerLast, liveLast time.Time) (*Session, string) {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
 	proj := t.TempDir()
@@ -284,62 +298,110 @@ func negCachedSession(t *testing.T, ownerLast, liveLast time.Time) (*Session, st
 	writeTranscript(t, proj, "live-bbb", ownerLast.Add(-2*time.Hour), liveLast)
 
 	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
-	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-aaa", UpdatedAt: time.Now()}, true)
+	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-aaa", UpdatedAt: time.Now(), AgentPID: ownerPID}, true)
 	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true)
-	if s.rotRejectForeign != "live-bbb" {
-		t.Fatalf("setup: pair not neg-cached (rotRejectForeign=%q)", s.rotRejectForeign)
+	if s.rotRejects["live-bbb"] == nil {
+		t.Fatalf("setup: foreign id not neg-cached (rotRejects=%v)", s.rotRejects)
 	}
 	// negCacheRotation stamps the recovery clock; rewind it so the next hook is due.
 	s.mu.Lock()
-	s.rotRejectCheckedAt = time.Time{}
+	s.rotRejects["live-bbb"].checkedAt = time.Time{}
 	s.mu.Unlock()
 	return s, proj
 }
 
-// TestUpdateHookStatusRecoversFromDeadOwner covers issue #226: a rotation we could
-// not prove gets neg-cached, and nothing ever releases the owner — an in-process
-// rotation fires no SessionEnd for the id it abandons. Every hook from the live
-// conversation is then dropped, freezing the status and the id that fork/restart
-// resume. Once the owner has gone silent while the live session keeps writing, the
-// rejection must give way.
-func TestUpdateHookStatusRecoversFromDeadOwner(t *testing.T) {
+// TestUpdateHookStatusRecoversWhenOwnerProcessGone covers issue #226: a rotation we
+// could not prove gets neg-cached, and nothing ever releases the owner — an
+// in-process rotation fires no SessionEnd for the id it abandons. Every hook from
+// the live conversation is then dropped, freezing the status and the id that
+// fork/restart resume. A dead owner process ends the argument.
+func TestUpdateHookStatusRecoversWhenOwnerProcessGone(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, reapedPID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
 	changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true)
 	if !changed {
-		t.Errorf("superseded owner: hook should register as changed")
+		t.Errorf("dead owner process: hook should register as changed")
 	}
 	if got := s.GetHookStatus(); got != "waiting" {
-		t.Errorf("superseded owner: hook not adopted: %q, want waiting", got)
+		t.Errorf("dead owner process: hook not adopted: %q, want waiting", got)
 	}
 	if s.ClaudeSessionID != "live-bbb" {
-		t.Errorf("superseded owner: resume id still stale: %q, want live-bbb", s.ClaudeSessionID)
+		t.Errorf("dead owner process: resume id still stale: %q, want live-bbb", s.ClaudeSessionID)
 	}
 }
 
-// TestUpdateHookStatusKeepsOwnerWhileStillWriting is the other side: an owner
-// blocked on a nested child claude (an eval harness inside a tool call) writes
-// nothing while the child does, which looks like a dead owner in miniature. Inside
-// deadOwnerSupersedeMargin the rejection must hold.
-func TestUpdateHookStatusKeepsOwnerWhileStillWriting(t *testing.T) {
+// TestUpdateHookStatusKeepsOwnerWhileProcessAlive is the case transcripts cannot
+// decide and this one can: a nested agent that inherited FLEET_INSTANCE_ID writes
+// for hours while its parent, blocked on the tool call that spawned it, writes
+// nothing. Transcript-wise that is indistinguishable from a dead owner — the owner
+// here has been silent for two hours. The owner's process being alive is what says
+// otherwise, and the rejection must hold.
+func TestUpdateHookStatusKeepsOwnerWhileProcessAlive(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, now.Add(-2*time.Minute), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, os.Getpid(), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
 	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); changed {
-		t.Errorf("owner still writing: nested child hook should stay rejected")
+		t.Errorf("owner process alive: nested agent hook should stay rejected")
 	}
 	if s.ClaudeSessionID != "owner-aaa" {
-		t.Errorf("owner still writing: resume id clobbered: %q, want owner-aaa", s.ClaudeSessionID)
+		t.Errorf("owner process alive: resume id clobbered: %q, want owner-aaa", s.ClaudeSessionID)
 	}
 }
 
-// TestUpdateHookStatusDeadOwnerRecoveryStaysOffUIPath keeps the transcript I/O off
-// the Bubble Tea Update loop: the UI path passes resolveRotation=false and must
-// defer to the worker rather than scan.
+// TestUpdateHookStatusFallsBackToTranscriptWithoutPID covers a status file written
+// by a handler older than StatusFile.AgentPID: with no pid there is nothing to ask,
+// so owner silence has to carry the decision.
+func TestUpdateHookStatusFallsBackToTranscriptWithoutPID(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := negCachedSession(t, 0, now.Add(-2*time.Hour), now.Add(-time.Minute))
+
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); !changed {
+		t.Errorf("no pid + owner silent 2h: fallback should adopt")
+	}
+	if s.ClaudeSessionID != "live-bbb" {
+		t.Errorf("no pid: resume id still stale: %q, want live-bbb", s.ClaudeSessionID)
+	}
+}
+
+// TestUpdateHookStatusFallbackHoldsForRecentOwner is the fallback's other side: an
+// owner that wrote moments ago is not abandoned, whatever else is reporting.
+func TestUpdateHookStatusFallbackHoldsForRecentOwner(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := negCachedSession(t, 0, now.Add(-2*time.Minute), now.Add(-time.Minute))
+
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); changed {
+		t.Errorf("owner wrote 2m ago: fallback should hold the rejection")
+	}
+	if s.ClaudeSessionID != "owner-aaa" {
+		t.Errorf("recent owner: resume id clobbered: %q, want owner-aaa", s.ClaudeSessionID)
+	}
+}
+
+// TestUpdateHookStatusRotationShortlyAfterClearRecovers is the shape the first
+// attempt at this got wrong: `/clear`, a few minutes of work, then a pause. A
+// predicate asking how far the NEW conversation ran past the owner tops out at
+// those few minutes and never grows, freezing the session for good — and a short
+// piece of work after a /clear is the common shape.
+func TestUpdateHookStatusRotationShortlyAfterClearRecovers(t *testing.T) {
+	now := time.Now().UTC()
+	// Owner cleared an hour ago; the new conversation ran six minutes and stopped.
+	s, _ := negCachedSession(t, 0, now.Add(-time.Hour), now.Add(-54*time.Minute))
+
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); !changed {
+		t.Errorf("short post-/clear session should still recover")
+	}
+	if s.ClaudeSessionID != "live-bbb" {
+		t.Errorf("short post-/clear session stayed frozen: %q, want live-bbb", s.ClaudeSessionID)
+	}
+}
+
+// TestUpdateHookStatusDeadOwnerRecoveryStaysOffUIPath keeps the recovery off the
+// Bubble Tea Update loop: the UI path passes resolveRotation=false and must defer
+// to the worker rather than touch the disk.
 func TestUpdateHookStatusDeadOwnerRecoveryStaysOffUIPath(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, reapedPID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
 	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, false); changed {
 		t.Errorf("UI path must not adopt (it must not read transcripts)")
@@ -353,50 +415,101 @@ func TestUpdateHookStatusDeadOwnerRecoveryStaysOffUIPath(t *testing.T) {
 	}
 }
 
-// TestDeadOwnerRecheckThrottled pins the throttle: the neg-cache exists to keep a
-// full transcript scan off every ~500ms worker cycle, so the recovery check must
-// not reopen that cost on every hook.
+// TestNegCacheKeyedByForeignID pins the eviction fix: an eval harness produces a
+// stream of foreign ids, and a single-slot cache let each new one evict the last —
+// so the rotated id fell out of the cache, paid a full transcript verdict on every
+// cycle, and had its recovery clock reset before it could ever fire.
+func TestNegCacheKeyedByForeignID(t *testing.T) {
+	now := time.Now().UTC()
+	s, proj := negCachedSession(t, os.Getpid(), now.Add(-2*time.Hour), now.Add(-time.Minute))
+
+	// A second foreign id reports and is rejected in its turn.
+	writeTranscript(t, proj, "child-ccc", now.Add(-3*time.Hour), now.Add(-2*time.Hour))
+	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "child-ccc", UpdatedAt: time.Now()}, true)
+
+	if s.rotRejects["live-bbb"] == nil {
+		t.Error("second foreign id evicted the first rejection")
+	}
+	if s.rotRejects["child-ccc"] == nil {
+		t.Error("second foreign id was not cached")
+	}
+}
+
+// TestDeadOwnerRecheckThrottled pins the throttle: the fallback walks two
+// transcripts, so the recovery check must not run on every ~500ms worker cycle.
 func TestDeadOwnerRecheckThrottled(t *testing.T) {
-	s := &Session{ID: "x"}
-	if !s.dueForDeadOwnerRecheck() {
+	s := &Session{ID: "x", rotRejects: map[string]*rotReject{"f": {owner: "o"}}}
+	if !s.dueForDeadOwnerRecheck("f") {
 		t.Fatal("first check should be due")
 	}
-	if s.dueForDeadOwnerRecheck() {
+	if s.dueForDeadOwnerRecheck("f") {
 		t.Error("second check within the interval should be throttled")
 	}
+	if s.dueForDeadOwnerRecheck("unknown-id") {
+		t.Error("an id with no rejection recorded is never due")
+	}
 	s.mu.Lock()
-	s.rotRejectCheckedAt = time.Now().Add(-deadOwnerRecheckInterval - time.Second)
+	s.rotRejects["f"].checkedAt = time.Now().Add(-deadOwnerRecheckInterval - time.Second)
 	s.mu.Unlock()
-	if !s.dueForDeadOwnerRecheck() {
+	if !s.dueForDeadOwnerRecheck("f") {
 		t.Error("check should be due again after the interval")
 	}
 }
 
-// TestResolveForkParentHealsFrozenID covers the fork half of #226. The worker's
-// recovery only runs when a hook arrives, and a session that rotated and then went
-// quiet fires none — so the fork itself must not copy a conversation nobody is in.
-func TestResolveForkParentHealsFrozenID(t *testing.T) {
+// TestResolveLaunchIDHealsFrozenID covers the launch half of #226. The worker's
+// recovery runs on a one-minute clock, so a key pressed inside that window would
+// otherwise fork or restart into a conversation nobody is in.
+func TestResolveLaunchIDHealsFrozenID(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, reapedPID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
-	parent, stale := s.ResolveForkParent()
-	if parent != "live-bbb" || stale != "owner-aaa" {
-		t.Errorf("ResolveForkParent() = (%q, %q), want (live-bbb, owner-aaa)", parent, stale)
+	launchID, stale := s.ResolveLaunchID()
+	if launchID != "live-bbb" || stale != "owner-aaa" {
+		t.Errorf("ResolveLaunchID() = (%q, %q), want (live-bbb, owner-aaa)", launchID, stale)
 	}
 }
 
-// TestResolveForkParentKeepsHealthyID guards the common path: with no standing
-// rejection the fork parent is simply the stored id, and nothing is reported as
-// healed.
-func TestResolveForkParentKeepsHealthyID(t *testing.T) {
+// TestResolveLaunchIDKeepsOwnerWhileProcessAlive: a live owner means the rejected id
+// is a nested agent, and launching must not follow it.
+func TestResolveLaunchIDKeepsOwnerWhileProcessAlive(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := negCachedSession(t, os.Getpid(), now.Add(-2*time.Hour), now.Add(-time.Minute))
+
+	launchID, stale := s.ResolveLaunchID()
+	if launchID != "owner-aaa" || stale != "" {
+		t.Errorf("ResolveLaunchID() = (%q, %q), want (owner-aaa, \"\")", launchID, stale)
+	}
+}
+
+// TestResolveLaunchIDKeepsHealthyID guards the common path: with no standing
+// rejection the launch id is simply the stored one, and nothing is reported healed.
+func TestResolveLaunchIDKeepsHealthyID(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	proj := t.TempDir()
 	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
 	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-aaa", UpdatedAt: time.Now()}, true)
 
-	parent, stale := s.ResolveForkParent()
-	if parent != "owner-aaa" || stale != "" {
-		t.Errorf("ResolveForkParent() = (%q, %q), want (owner-aaa, \"\")", parent, stale)
+	launchID, stale := s.ResolveLaunchID()
+	if launchID != "owner-aaa" || stale != "" {
+		t.Errorf("ResolveLaunchID() = (%q, %q), want (owner-aaa, \"\")", launchID, stale)
+	}
+}
+
+// TestAdoptResolvedLaunchIDBeforeClear is the ordering restart depends on:
+// clearHookState() drops the rejection state the heal is derived from, so a
+// restart that cleared first would resume the frozen id every time.
+func TestAdoptResolvedLaunchIDBeforeClear(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := negCachedSession(t, reapedPID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
+
+	s.adoptResolvedLaunchID("test")
+	if s.ClaudeSessionID != "live-bbb" {
+		t.Fatalf("resume id not healed before clear: %q, want live-bbb", s.ClaudeSessionID)
+	}
+	// After clearing there is nothing left to heal from — the evidence is gone.
+	s.clearHookState()
+	if s.rotRejects != nil {
+		t.Errorf("clearHookState left rejections behind: %v", s.rotRejects)
 	}
 }
 
@@ -468,10 +581,20 @@ func TestUpdateHookStatusIgnoresNestedChildWithCompaction(t *testing.T) {
 	)
 
 	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
-	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-x", UpdatedAt: time.Now()}, true)
+	// The owner's process is alive, which is what keeps this rejected on the second
+	// delivery too: its transcript has been silent for four hours, so silence alone
+	// would eventually read as abandonment.
+	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-x", UpdatedAt: time.Now(), AgentPID: os.Getpid()}, true)
 
 	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "child-x", UpdatedAt: time.Now()}, true); changed {
 		t.Errorf("nested child with foreign compaction link should be ignored")
+	}
+	// Again, now through the neg-cached branch where the recovery check lives.
+	s.mu.Lock()
+	s.rotRejects["child-x"].checkedAt = time.Time{}
+	s.mu.Unlock()
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "child-x", UpdatedAt: time.Now()}, true); changed {
+		t.Errorf("nested child should stay ignored while the owner process is alive")
 	}
 	if s.GetHookStatus() != "running" || s.ClaudeSessionID != "owner-x" {
 		t.Errorf("owner clobbered: hook=%q resumeID=%q", s.GetHookStatus(), s.ClaudeSessionID)

--- a/internal/session/ownership_test.go
+++ b/internal/session/ownership_test.go
@@ -268,6 +268,138 @@ func TestUpdateHookStatusCapsUndecidedRotation(t *testing.T) {
 	}
 }
 
+// negCachedSession returns a session whose (owner-aaa, live-bbb) pair has been
+// rejected and neg-cached — the frozen state issue #226 was reported in — with the
+// recovery clock wound back so the next worker-path hook rechecks immediately.
+// ownerLast/liveLast set where each conversation last wrote.
+func negCachedSession(t *testing.T, ownerLast, liveLast time.Time) (*Session, string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	proj := t.TempDir()
+
+	// No parent link, and the live session's FIRST entry sits hours before the
+	// owner's last — a handoff gap way past rotationHandoffWindow — so
+	// sessionRotationVerdict rejects the pair however close their last writes are.
+	writeTranscript(t, proj, "owner-aaa", ownerLast.Add(-3*time.Hour), ownerLast)
+	writeTranscript(t, proj, "live-bbb", ownerLast.Add(-2*time.Hour), liveLast)
+
+	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
+	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-aaa", UpdatedAt: time.Now()}, true)
+	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true)
+	if s.rotRejectForeign != "live-bbb" {
+		t.Fatalf("setup: pair not neg-cached (rotRejectForeign=%q)", s.rotRejectForeign)
+	}
+	// negCacheRotation stamps the recovery clock; rewind it so the next hook is due.
+	s.mu.Lock()
+	s.rotRejectCheckedAt = time.Time{}
+	s.mu.Unlock()
+	return s, proj
+}
+
+// TestUpdateHookStatusRecoversFromDeadOwner covers issue #226: a rotation we could
+// not prove gets neg-cached, and nothing ever releases the owner — an in-process
+// rotation fires no SessionEnd for the id it abandons. Every hook from the live
+// conversation is then dropped, freezing the status and the id that fork/restart
+// resume. Once the owner has gone silent while the live session keeps writing, the
+// rejection must give way.
+func TestUpdateHookStatusRecoversFromDeadOwner(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := negCachedSession(t, now.Add(-2*time.Hour), now.Add(-time.Minute))
+
+	changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true)
+	if !changed {
+		t.Errorf("superseded owner: hook should register as changed")
+	}
+	if got := s.GetHookStatus(); got != "waiting" {
+		t.Errorf("superseded owner: hook not adopted: %q, want waiting", got)
+	}
+	if s.ClaudeSessionID != "live-bbb" {
+		t.Errorf("superseded owner: resume id still stale: %q, want live-bbb", s.ClaudeSessionID)
+	}
+}
+
+// TestUpdateHookStatusKeepsOwnerWhileStillWriting is the other side: an owner
+// blocked on a nested child claude (an eval harness inside a tool call) writes
+// nothing while the child does, which looks like a dead owner in miniature. Inside
+// deadOwnerSupersedeMargin the rejection must hold.
+func TestUpdateHookStatusKeepsOwnerWhileStillWriting(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := negCachedSession(t, now.Add(-2*time.Minute), now.Add(-time.Minute))
+
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); changed {
+		t.Errorf("owner still writing: nested child hook should stay rejected")
+	}
+	if s.ClaudeSessionID != "owner-aaa" {
+		t.Errorf("owner still writing: resume id clobbered: %q, want owner-aaa", s.ClaudeSessionID)
+	}
+}
+
+// TestUpdateHookStatusDeadOwnerRecoveryStaysOffUIPath keeps the transcript I/O off
+// the Bubble Tea Update loop: the UI path passes resolveRotation=false and must
+// defer to the worker rather than scan.
+func TestUpdateHookStatusDeadOwnerRecoveryStaysOffUIPath(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := negCachedSession(t, now.Add(-2*time.Hour), now.Add(-time.Minute))
+
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, false); changed {
+		t.Errorf("UI path must not adopt (it must not read transcripts)")
+	}
+	if s.ClaudeSessionID != "owner-aaa" {
+		t.Errorf("UI path adopted anyway: %q, want owner-aaa", s.ClaudeSessionID)
+	}
+	// The worker path, same instant, recovers — proving the UI path only deferred.
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); !changed {
+		t.Errorf("worker path should recover after the UI path deferred")
+	}
+}
+
+// TestDeadOwnerRecheckThrottled pins the throttle: the neg-cache exists to keep a
+// full transcript scan off every ~500ms worker cycle, so the recovery check must
+// not reopen that cost on every hook.
+func TestDeadOwnerRecheckThrottled(t *testing.T) {
+	s := &Session{ID: "x"}
+	if !s.dueForDeadOwnerRecheck() {
+		t.Fatal("first check should be due")
+	}
+	if s.dueForDeadOwnerRecheck() {
+		t.Error("second check within the interval should be throttled")
+	}
+	s.mu.Lock()
+	s.rotRejectCheckedAt = time.Now().Add(-deadOwnerRecheckInterval - time.Second)
+	s.mu.Unlock()
+	if !s.dueForDeadOwnerRecheck() {
+		t.Error("check should be due again after the interval")
+	}
+}
+
+// TestResolveForkParentHealsFrozenID covers the fork half of #226. The worker's
+// recovery only runs when a hook arrives, and a session that rotated and then went
+// quiet fires none — so the fork itself must not copy a conversation nobody is in.
+func TestResolveForkParentHealsFrozenID(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := negCachedSession(t, now.Add(-2*time.Hour), now.Add(-time.Minute))
+
+	parent, stale := s.ResolveForkParent()
+	if parent != "live-bbb" || stale != "owner-aaa" {
+		t.Errorf("ResolveForkParent() = (%q, %q), want (live-bbb, owner-aaa)", parent, stale)
+	}
+}
+
+// TestResolveForkParentKeepsHealthyID guards the common path: with no standing
+// rejection the fork parent is simply the stored id, and nothing is reported as
+// healed.
+func TestResolveForkParentKeepsHealthyID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	proj := t.TempDir()
+	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
+	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-aaa", UpdatedAt: time.Now()}, true)
+
+	parent, stale := s.ResolveForkParent()
+	if parent != "owner-aaa" || stale != "" {
+		t.Errorf("ResolveForkParent() = (%q, %q), want (owner-aaa, \"\")", parent, stale)
+	}
+}
+
 // writeTranscriptRaw writes arbitrary JSONL lines for a session under the
 // HOME-rooted projects dir, for tests that need uuid / compact_boundary entries.
 func writeTranscriptRaw(t *testing.T, projectPath, sessionID string, lines ...string) {

--- a/internal/session/ownership_test.go
+++ b/internal/session/ownership_test.go
@@ -269,6 +269,21 @@ func TestUpdateHookStatusCapsUndecidedRotation(t *testing.T) {
 	}
 }
 
+// otherLivePID returns the pid of a live process that is not the test's own.
+// Stands in for a nested agent running beside the owner.
+func otherLivePID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", "sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn long-lived process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd.Process.Pid
+}
+
 // reapedPID returns the pid of a process that has run and been waited on, so it is
 // reliably gone. Stands in for an agent whose conversation ended.
 func reapedPID(t *testing.T) int {
@@ -283,10 +298,11 @@ func reapedPID(t *testing.T) int {
 // negCachedSession returns a session whose live-bbb hook has been rejected against
 // owner-aaa and neg-cached — the frozen state issue #226 was reported in — with the
 // recovery clock wound back so the next worker-path hook rechecks immediately.
-// ownerPID is the agent process recorded for the owner (0 = a status file older
-// than the field, which forces the transcript fallback); ownerLast/liveLast set
-// where each conversation last wrote.
-func negCachedSession(t *testing.T, ownerPID int, ownerLast, liveLast time.Time) (*Session, string) {
+// ownerPID/livePID are the agent processes recorded for each conversation (0 = a
+// status file older than the field, which forces the transcript fallback); equal
+// pids are an in-process rotation. ownerLast/liveLast set where each conversation
+// last wrote.
+func negCachedSession(t *testing.T, ownerPID, livePID int, ownerLast, liveLast time.Time) (*Session, string) {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
 	proj := t.TempDir()
@@ -299,7 +315,7 @@ func negCachedSession(t *testing.T, ownerPID int, ownerLast, liveLast time.Time)
 
 	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
 	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-aaa", UpdatedAt: time.Now(), AgentPID: ownerPID}, true)
-	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true)
+	s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now(), AgentPID: livePID}, true)
 	if s.rotRejects["live-bbb"] == nil {
 		t.Fatalf("setup: foreign id not neg-cached (rotRejects=%v)", s.rotRejects)
 	}
@@ -317,9 +333,9 @@ func negCachedSession(t *testing.T, ownerPID int, ownerLast, liveLast time.Time)
 // fork/restart resume. A dead owner process ends the argument.
 func TestUpdateHookStatusRecoversWhenOwnerProcessGone(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, reapedPID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, reapedPID(t), os.Getpid(), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
-	changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true)
+	changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now(), AgentPID: os.Getpid()}, true)
 	if !changed {
 		t.Errorf("dead owner process: hook should register as changed")
 	}
@@ -331,6 +347,39 @@ func TestUpdateHookStatusRecoversWhenOwnerProcessGone(t *testing.T) {
 	}
 }
 
+// TestUpdateHookStatusRecoversInProcessRotation is the shape issue #226 was
+// actually reported in, and the one a pure liveness check gets exactly wrong:
+// `/clear` starts a fresh conversation INSIDE the running agent, so the owner's
+// process is still very much alive. What identifies it is that the new id is
+// reported by that same process.
+func TestUpdateHookStatusRecoversInProcessRotation(t *testing.T) {
+	now := time.Now().UTC()
+	agent := otherLivePID(t)
+	// Same pid on both sides: one process, two conversation ids.
+	s, _ := negCachedSession(t, agent, agent, now.Add(-time.Hour), now.Add(-time.Minute))
+
+	changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now(), AgentPID: agent}, true)
+	if !changed {
+		t.Errorf("in-process rotation: hook should register as changed")
+	}
+	if s.ClaudeSessionID != "live-bbb" {
+		t.Errorf("in-process rotation stayed frozen: %q, want live-bbb", s.ClaudeSessionID)
+	}
+}
+
+// TestResolveLaunchIDHealsInProcessRotation is the same case on the launch path —
+// the one that decides what `f`, `F` and `r` actually open.
+func TestResolveLaunchIDHealsInProcessRotation(t *testing.T) {
+	now := time.Now().UTC()
+	agent := otherLivePID(t)
+	s, _ := negCachedSession(t, agent, agent, now.Add(-time.Hour), now.Add(-time.Minute))
+
+	launchID, stale := s.ResolveLaunchID()
+	if launchID != "live-bbb" || stale != "owner-aaa" {
+		t.Errorf("ResolveLaunchID() = (%q, %q), want (live-bbb, owner-aaa)", launchID, stale)
+	}
+}
+
 // TestUpdateHookStatusKeepsOwnerWhileProcessAlive is the case transcripts cannot
 // decide and this one can: a nested agent that inherited FLEET_INSTANCE_ID writes
 // for hours while its parent, blocked on the tool call that spawned it, writes
@@ -339,9 +388,9 @@ func TestUpdateHookStatusRecoversWhenOwnerProcessGone(t *testing.T) {
 // otherwise, and the rejection must hold.
 func TestUpdateHookStatusKeepsOwnerWhileProcessAlive(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, os.Getpid(), now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, os.Getpid(), otherLivePID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
-	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); changed {
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now(), AgentPID: otherLivePID(t)}, true); changed {
 		t.Errorf("owner process alive: nested agent hook should stay rejected")
 	}
 	if s.ClaudeSessionID != "owner-aaa" {
@@ -354,7 +403,7 @@ func TestUpdateHookStatusKeepsOwnerWhileProcessAlive(t *testing.T) {
 // so owner silence has to carry the decision.
 func TestUpdateHookStatusFallsBackToTranscriptWithoutPID(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, 0, now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, 0, 0, now.Add(-2*time.Hour), now.Add(-time.Minute))
 
 	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); !changed {
 		t.Errorf("no pid + owner silent 2h: fallback should adopt")
@@ -368,7 +417,7 @@ func TestUpdateHookStatusFallsBackToTranscriptWithoutPID(t *testing.T) {
 // owner that wrote moments ago is not abandoned, whatever else is reporting.
 func TestUpdateHookStatusFallbackHoldsForRecentOwner(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, 0, now.Add(-2*time.Minute), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, 0, 0, now.Add(-2*time.Minute), now.Add(-time.Minute))
 
 	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); changed {
 		t.Errorf("owner wrote 2m ago: fallback should hold the rejection")
@@ -386,7 +435,7 @@ func TestUpdateHookStatusFallbackHoldsForRecentOwner(t *testing.T) {
 func TestUpdateHookStatusRotationShortlyAfterClearRecovers(t *testing.T) {
 	now := time.Now().UTC()
 	// Owner cleared an hour ago; the new conversation ran six minutes and stopped.
-	s, _ := negCachedSession(t, 0, now.Add(-time.Hour), now.Add(-54*time.Minute))
+	s, _ := negCachedSession(t, 0, 0, now.Add(-time.Hour), now.Add(-54*time.Minute))
 
 	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); !changed {
 		t.Errorf("short post-/clear session should still recover")
@@ -401,16 +450,16 @@ func TestUpdateHookStatusRotationShortlyAfterClearRecovers(t *testing.T) {
 // to the worker rather than touch the disk.
 func TestUpdateHookStatusDeadOwnerRecoveryStaysOffUIPath(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, reapedPID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, reapedPID(t), os.Getpid(), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
-	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, false); changed {
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now(), AgentPID: os.Getpid()}, false); changed {
 		t.Errorf("UI path must not adopt (it must not read transcripts)")
 	}
 	if s.ClaudeSessionID != "owner-aaa" {
 		t.Errorf("UI path adopted anyway: %q, want owner-aaa", s.ClaudeSessionID)
 	}
 	// The worker path, same instant, recovers — proving the UI path only deferred.
-	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now()}, true); !changed {
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", UpdatedAt: time.Now(), AgentPID: os.Getpid()}, true); !changed {
 		t.Errorf("worker path should recover after the UI path deferred")
 	}
 }
@@ -421,7 +470,7 @@ func TestUpdateHookStatusDeadOwnerRecoveryStaysOffUIPath(t *testing.T) {
 // cycle, and had its recovery clock reset before it could ever fire.
 func TestNegCacheKeyedByForeignID(t *testing.T) {
 	now := time.Now().UTC()
-	s, proj := negCachedSession(t, os.Getpid(), now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, proj := negCachedSession(t, os.Getpid(), otherLivePID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
 	// A second foreign id reports and is rejected in its turn.
 	writeTranscript(t, proj, "child-ccc", now.Add(-3*time.Hour), now.Add(-2*time.Hour))
@@ -461,7 +510,7 @@ func TestDeadOwnerRecheckThrottled(t *testing.T) {
 // otherwise fork or restart into a conversation nobody is in.
 func TestResolveLaunchIDHealsFrozenID(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, reapedPID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, reapedPID(t), os.Getpid(), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
 	launchID, stale := s.ResolveLaunchID()
 	if launchID != "live-bbb" || stale != "owner-aaa" {
@@ -473,7 +522,7 @@ func TestResolveLaunchIDHealsFrozenID(t *testing.T) {
 // is a nested agent, and launching must not follow it.
 func TestResolveLaunchIDKeepsOwnerWhileProcessAlive(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, os.Getpid(), now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, os.Getpid(), otherLivePID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
 	launchID, stale := s.ResolveLaunchID()
 	if launchID != "owner-aaa" || stale != "" {
@@ -500,7 +549,7 @@ func TestResolveLaunchIDKeepsHealthyID(t *testing.T) {
 // restart that cleared first would resume the frozen id every time.
 func TestAdoptResolvedLaunchIDBeforeClear(t *testing.T) {
 	now := time.Now().UTC()
-	s, _ := negCachedSession(t, reapedPID(t), now.Add(-2*time.Hour), now.Add(-time.Minute))
+	s, _ := negCachedSession(t, reapedPID(t), os.Getpid(), now.Add(-2*time.Hour), now.Add(-time.Minute))
 
 	s.adoptResolvedLaunchID("test")
 	if s.ClaudeSessionID != "live-bbb" {
@@ -581,19 +630,21 @@ func TestUpdateHookStatusIgnoresNestedChildWithCompaction(t *testing.T) {
 	)
 
 	s := &Session{ID: "x", ProjectPath: proj, Status: StatusRunning}
-	// The owner's process is alive, which is what keeps this rejected on the second
-	// delivery too: its transcript has been silent for four hours, so silence alone
-	// would eventually read as abandonment.
-	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-x", UpdatedAt: time.Now(), AgentPID: os.Getpid()}, true)
+	// Two live processes: the owner, and a child reporting under its own pid. That
+	// pairing is what keeps this rejected on the second delivery, where the recovery
+	// check lives — the owner's transcript has been silent for four hours, so silence
+	// alone would read as abandonment.
+	ownerPID, childPID := os.Getpid(), otherLivePID(t)
+	s.UpdateHookStatus(&HookStatus{Status: "running", SessionID: "owner-x", UpdatedAt: time.Now(), AgentPID: ownerPID}, true)
 
-	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "child-x", UpdatedAt: time.Now()}, true); changed {
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "child-x", UpdatedAt: time.Now(), AgentPID: childPID}, true); changed {
 		t.Errorf("nested child with foreign compaction link should be ignored")
 	}
 	// Again, now through the neg-cached branch where the recovery check lives.
 	s.mu.Lock()
 	s.rotRejects["child-x"].checkedAt = time.Time{}
 	s.mu.Unlock()
-	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "child-x", UpdatedAt: time.Now()}, true); changed {
+	if changed := s.UpdateHookStatus(&HookStatus{Status: "dead", SessionID: "child-x", UpdatedAt: time.Now(), AgentPID: childPID}, true); changed {
 		t.Errorf("nested child should stay ignored while the owner process is alive")
 	}
 	if s.GetHookStatus() != "running" || s.ClaudeSessionID != "owner-x" {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -78,26 +78,21 @@ type Session struct {
 	hookUpdatedAt    time.Time
 	hookOverriddenAt time.Time // timestamp of hook that was overridden by pane; prevents re-evaluation of same stale hook
 	ownerSessionID   string    // Claude session_id that owns this fleet session; hooks from other (nested) Claudes are ignored
+	ownerPID         int       // agent process behind ownerSessionID (0 = unknown: pre-AgentPID status file)
 	forkParentID     string    // parent's claude session id while this fork hasn't diverged yet; lets us adopt the fork's own id deterministically (cleared on divergence)
 
-	// Negative cache for the rotation check: the last (owner, foreign) pair that
-	// sessionRotationVerdict rejected. A persistent foreign id (a nested-child eval
-	// harness) would otherwise rescan transcripts every worker cycle; once
-	// rejected we short-circuit until the owner or the foreign id changes.
-	rotRejectOwner   string
-	rotRejectForeign string
-	// When we last logged that this pair is still being rejected. The rejection
-	// itself is logged once, on the cycle it is cached — but a neg-cached pair then
-	// drops every subsequent hook silently, so a session whose hook layer is dead
-	// looks identical in the log to one that is simply quiet. Re-announcing it on a
-	// throttle is what makes "the hook is frozen because we rejected its id"
-	// greppable instead of a whole-pipeline trace.
-	rotRejectLoggedAt time.Time
-	// When we last paid the transcript I/O to ask whether a rejected pair has become
-	// recoverable (ownerConversationSuperseded). The neg-cache exists precisely to
-	// keep that scan off the ~500ms worker cycle, so the recovery check rides a
-	// slower clock of its own rather than reopening the cost the cache saved.
-	rotRejectCheckedAt time.Time
+	// Negative cache for the rotation check, keyed by the FOREIGN session id that
+	// was rejected. A persistent foreign id (a nested agent) would otherwise rescan
+	// transcripts every worker cycle; once rejected we short-circuit until the owner
+	// changes.
+	//
+	// Keyed rather than a single (owner, foreign) slot: an eval harness spawning
+	// sub-agents produces a stream of foreign ids, and one slot meant each new id
+	// evicted the last. Two ids alternating then paid a full sessionRotationVerdict
+	// — two transcript walks — on every ~500ms cycle, the exact cost this cache
+	// exists to avoid, and the recovery clock below was reset by every eviction so
+	// it never accumulated.
+	rotRejects map[string]*rotReject
 
 	// Bounded retry tracking for an undecidable (owner, foreign) pair — one
 	// sessionRotationVerdict can't yet classify because a transcript hasn't flushed a
@@ -134,6 +129,16 @@ type Session struct {
 	paneCapturer PaneCapturer // optional override for testing; if nil, uses tmuxSession
 	convActiveFn func() bool  // optional override for testing; if nil, reads the real transcript
 	mu           sync.RWMutex
+}
+
+// rotReject is one rejected foreign session id: which owner it was rejected
+// against, and the two clocks that keep the rejection from going silent (logging)
+// or permanent (recovery). Per foreign id, so one noisy nested agent can neither
+// evict another id's rejection nor reset its clocks.
+type rotReject struct {
+	owner     string
+	loggedAt  time.Time // last "still rejected" line; a dropped hook must never be silent
+	checkedAt time.Time // last recovery check; throttles the fallback's transcript I/O
 }
 
 // NewSession creates a new session for the given project path.
@@ -398,6 +403,10 @@ type HookStatus struct {
 	UpdatedAt   time.Time
 	UserPrompt  string
 	PromptCount int
+	// AgentPID is the agent process that fired the hook, or 0 when unknown (a
+	// status file written before the field existed). Ownership uses it to ask
+	// whether the conversation currently owning this session is still running.
+	AgentPID int
 }
 
 // UpdateHookStatus updates the session's hook-based status.
@@ -434,15 +443,18 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 	//   - A nested child `claude` (an eval harness spawning sub-Claudes)
 	//     inherited FLEET_INSTANCE_ID. Adopting it would clobber our status and
 	//     resume id, so it must be ignored.
-	// sessionRotationVerdict distinguishes them; a persistent rejection is cached so
-	// a nested child doesn't rescan transcripts every cycle.
+	// sessionRotationVerdict distinguishes them from the transcripts; a persistent
+	// rejection is cached so a nested child doesn't rescan them every cycle. When
+	// that verdict is wrong, ownerStillRunning is what unsticks it — see the
+	// negCached branch.
 	var owner string
 	if hs.SessionID != "" {
 		s.mu.RLock()
 		owner = s.ownerSessionID
+		ownerPID := s.ownerPID
 		forkParent := s.forkParentID
 		projectPath := s.ProjectPath
-		negCached := owner != "" && s.rotRejectOwner == owner && s.rotRejectForeign == hs.SessionID
+		negCached := owner != "" && s.rotRejects[hs.SessionID] != nil && s.rotRejects[hs.SessionID].owner == owner
 		frozenHook, frozenHookAt := s.hookStatus, s.hookUpdatedAt
 		s.mu.RUnlock()
 		if owner != "" && hs.SessionID != owner {
@@ -465,17 +477,28 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 				debuglog.Logger.Info("adopting forked claude session",
 					"id", s.ID, "parent", owner, "new", hs.SessionID)
 			case negCached:
-				// Normally this pair stays rejected for the session's whole life — right
-				// for a nested child, wrong for a rotation we simply could not prove.
+				// Normally this id stays rejected for the session's whole life — right
+				// for a nested agent, wrong for a rotation we simply could not prove.
 				// Nothing else releases the owner (an in-process rotation fires no
-				// SessionEnd for the id it abandons), so recheck on a slow clock whether
-				// the owner conversation has gone silent while this one keeps writing.
-				if resolveRotation && s.dueForDeadOwnerRecheck() &&
-					ownerConversationSuperseded(projectPath, owner, hs.SessionID) {
-					debuglog.Logger.Info("adopting superseded claude session",
-						"id", s.ID, "old", owner, "new", hs.SessionID,
-						"frozenHookAge", time.Since(frozenHookAt).Truncate(time.Second))
-					break // recovered — fall through to the adoption block below
+				// SessionEnd for the id it abandons), so ask the one question the
+				// transcripts cannot answer: is the owner's process still running?
+				if resolveRotation && s.dueForDeadOwnerRecheck(hs.SessionID) {
+					if alive, known := s.ownerStillRunning(ownerPID); known && !alive {
+						debuglog.Logger.Info("adopting claude session: owner process gone",
+							"id", s.ID, "old", owner, "ownerPID", ownerPID, "new", hs.SessionID,
+							"frozenHookAge", time.Since(frozenHookAt).Truncate(time.Second))
+						break // recovered — fall through to the adoption block below
+					} else if !known && ownerConversationAbandoned(projectPath, owner, hs.SessionID) {
+						// No pid recorded (status file from an older handler). Fall back to
+						// transcript silence, which cannot separate a dead owner from one
+						// blocked on this very child — accepted only because the alternative
+						// is staying frozen forever, and because it self-clears: the next
+						// hook from the current handler records a pid.
+						debuglog.Logger.Info("adopting claude session: owner transcript abandoned",
+							"id", s.ID, "old", owner, "new", hs.SessionID,
+							"frozenHookAge", time.Since(frozenHookAt).Truncate(time.Second))
+						break // recovered — fall through to the adoption block below
+					}
 				}
 				// Re-announce the rejection on a throttle: this branch is the steady
 				// state of a session whose hook layer has gone dead, and dropping every
@@ -487,8 +510,8 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 				now := time.Now()
 				shouldLog := false
 				s.mu.Lock()
-				if now.Sub(s.rotRejectLoggedAt) >= rotRejectLogInterval {
-					s.rotRejectLoggedAt = now
+				if r := s.rotRejects[hs.SessionID]; r != nil && now.Sub(r.loggedAt) >= rotRejectLogInterval {
+					r.loggedAt = now
 					shouldLog = true
 				}
 				s.mu.Unlock()
@@ -555,6 +578,15 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 			return false
 		}
 		s.ownerSessionID = hs.SessionID
+		// Track the process behind the owning conversation. Every hook re-stamps it,
+		// so a resume that reuses the same session id under a new process is followed
+		// too. 0 (a status file older than the field) is recorded as-is: "unknown"
+		// must not read as "dead", and it self-clears on the next hook.
+		s.ownerPID = hs.AgentPID
+		// A newly owned id is no longer a rejected one. Without this, an id adopted
+		// through the recovery path above would still be in the reject map, so the
+		// negCached branch would fire against the wrong owner if it ever came back.
+		delete(s.rotRejects, hs.SessionID)
 		// Once we own an id other than the fork parent, the fork has diverged to its
 		// own session — drop the parent link so it can't influence later hooks.
 		if s.forkParentID != "" && hs.SessionID != s.forkParentID {
@@ -630,46 +662,59 @@ func (s *Session) bumpUndecidedRotation(owner, foreign string) bool {
 	return s.rotUndecidedCount <= rotationUndecidedRetryCap
 }
 
-// deadOwnerRecheckInterval throttles the ownerConversationSuperseded scan for a
-// neg-cached pair. The state it recovers from has already lasted minutes by the
-// time it is reachable at all (deadOwnerSupersedeMargin), so checking once a
-// minute costs nothing and loses nothing.
+// deadOwnerRecheckInterval throttles the recovery check for a rejected foreign id.
+// The liveness half is a signal 0 and could run every cycle, but the fallback half
+// walks two transcripts — and the state being recovered from has already lasted
+// minutes by the time it is reachable at all, so a one-minute clock costs nothing
+// and keeps the expensive path off the ~500ms pass.
 const deadOwnerRecheckInterval = time.Minute
 
-// dueForDeadOwnerRecheck reports whether enough time has passed to re-examine a
-// neg-cached rejection, stamping the clock when it does. Check and stamp under ONE
+// dueForDeadOwnerRecheck reports whether enough time has passed to re-examine the
+// rejection of foreign, stamping its clock when it does. Check and stamp under ONE
 // lock: the worker calls this on every fast cycle, and a snapshot-then-write split
 // would let two cycles both pass and pay the scan twice.
-func (s *Session) dueForDeadOwnerRecheck() bool {
+func (s *Session) dueForDeadOwnerRecheck(foreign string) bool {
 	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if now.Sub(s.rotRejectCheckedAt) < deadOwnerRecheckInterval {
+	r := s.rotRejects[foreign]
+	if r == nil || now.Sub(r.checkedAt) < deadOwnerRecheckInterval {
 		return false
 	}
-	s.rotRejectCheckedAt = now
+	r.checkedAt = now
 	return true
 }
 
-// negCacheRotation records the (owner, foreign) pair as a confirmed non-rotation so
+// ownerStillRunning reports whether the agent process behind the current owner is
+// alive, and whether we know at all. known=false means no pid was recorded (a
+// status file written before StatusFile.AgentPID), which callers must not read as
+// death — it is the one case that still needs the transcript fallback.
+func (s *Session) ownerStillRunning(ownerPID int) (alive, known bool) {
+	if ownerPID <= 0 {
+		return false, false
+	}
+	return agentProcessAlive(ownerPID), true
+}
+
+// negCacheRotation records foreign as a confirmed non-rotation against owner, so
 // future hooks for it short-circuit without rescanning transcripts, and clears any
 // undecided-retry tracking for it.
 func (s *Session) negCacheRotation(owner, foreign string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.rotRejectOwner = owner
-	s.rotRejectForeign = foreign
-	// Stamp the throttle for the NEW pair. The caller logs "ignoring foreign claude
+	if s.rotRejects == nil {
+		s.rotRejects = make(map[string]*rotReject, 1)
+	}
+	now := time.Now()
+	// Stamp both clocks for the NEW entry. The caller logs "ignoring foreign claude
 	// session" on this same cycle, so the first negCached hit that follows would only
 	// repeat it; starting the interval here makes the throttled line a pure
-	// still-happening heartbeat. Stamping per pair also stops a pair rejected moments
-	// after another from inheriting the previous pair's spent interval — that silence
-	// would land squarely in the window where a user hits `!` and files a report.
-	s.rotRejectLoggedAt = time.Now()
-	// Same for the recovery clock: a pair rejected this instant cannot yet show a
-	// superseded owner (the margin is minutes wide), so start its interval here
-	// rather than letting the very next cycle spend a transcript scan proving it.
-	s.rotRejectCheckedAt = time.Now()
+	// still-happening heartbeat. Per entry rather than per session, so an id rejected
+	// moments after another can't inherit the previous one's spent interval — that
+	// silence would land squarely in the window where a user hits `!` and files a
+	// report. The recovery clock starts here for the same reason plus one of its own:
+	// an id rejected this instant cannot yet show an abandoned owner.
+	s.rotRejects[foreign] = &rotReject{owner: owner, loggedAt: now, checkedAt: now}
 	s.rotUndecidedOwner = ""
 	s.rotUndecidedForeign = ""
 	s.rotUndecidedCount = 0
@@ -678,6 +723,10 @@ func (s *Session) negCacheRotation(owner, foreign string) {
 // Restart kills and recreates the tmux session with the same config.
 func (s *Session) Restart() error {
 	debuglog.Logger.Info("session restart", "id", s.ID, "title", s.Title)
+	// Resolve the id to resume BEFORE clearHookState() wipes the rejection state it
+	// is derived from. Otherwise a session frozen on a dead conversation restarts
+	// straight back into it (issue #226).
+	s.adoptResolvedLaunchID("restart")
 	// Kill old tmux session if it still exists.
 	if s.tmuxSession.Exists() {
 		_ = s.tmuxSession.Kill()
@@ -715,10 +764,27 @@ func (s *Session) Restart() error {
 	return nil
 }
 
+// adoptResolvedLaunchID promotes a healed conversation id onto ClaudeSessionID so
+// the relaunch resumes it, logging when it changes anything. Must run before
+// clearHookState(), which drops the rejection state ResolveLaunchID reads.
+func (s *Session) adoptResolvedLaunchID(why string) {
+	launchID, stale := s.ResolveLaunchID()
+	if stale == "" {
+		return
+	}
+	s.mu.Lock()
+	s.ClaudeSessionID = launchID
+	s.mu.Unlock()
+	debuglog.Logger.Info("healed stale conversation id before relaunch",
+		"id", s.ID, "title", s.Title, "why", why, "stale", stale, "resuming", launchID)
+}
+
 // RespawnClaude restarts the claude process in an existing tmux session.
 func (s *Session) RespawnClaude() error {
 	resuming := s.ClaudeSessionID != ""
 	debuglog.Logger.Info("session respawn", "id", s.ID, "title", s.Title, "resuming", resuming)
+	// Same ordering constraint as Restart: resolve before the state is cleared.
+	s.adoptResolvedLaunchID("respawn")
 	s.clearHookState()
 	s.mu.Lock()
 	s.Status = StatusStarting
@@ -778,31 +844,53 @@ func (s *Session) GetClaudeSessionID() string {
 	return s.ClaudeSessionID
 }
 
-// ResolveForkParent returns the conversation id a fork of this session should
-// resume, plus the stale id it replaced when one was healed ("" when nothing was
-// wrong). Read-only: the source session heals itself through UpdateHookStatus on
-// its next hook.
+// ResolveLaunchID returns the conversation id this session should resume — for a
+// fork, a restart, or a resume — plus the stale id it replaced when one was healed
+// ("" when nothing was wrong). Read-only: the session itself heals through
+// UpdateHookStatus.
 //
 // Normally the answer is just ClaudeSessionID. It is not when a foreign id is
-// neg-cached against the owner: the pane may be in that other conversation while
-// ClaudeSessionID still names the one we froze on, and a fork of a dead id silently
-// copies a conversation the user stopped working in an hour ago (issue #226). The
-// worker's own recovery can't be relied on here — it only reruns when a hook
-// arrives, and a session that rotated and then went quiet fires none.
+// rejected against the current owner: the pane may be in that other conversation
+// while ClaudeSessionID still names the one we froze on, and relaunching a dead id
+// silently reopens a conversation the user stopped working in an hour ago (issue
+// #226).
 //
-// Does transcript I/O. Call it off the Bubble Tea Update loop.
-func (s *Session) ResolveForkParent() (parentID, healedFrom string) {
+// This duplicates the rule in UpdateHookStatus's negCached branch on purpose, and
+// not for the reason it might look like — the worker does re-evaluate on its own,
+// since syncHookStatuses re-offers the last cached hook every cycle whether or not
+// a new one fired. What it buys is the gap: the recovery runs on a one-minute clock,
+// and a key pressed inside that window would otherwise launch the stale id. Restart
+// has a second reason — clearHookState() wipes the rejection state, so by the time
+// buildAgentCmd runs the evidence is gone. Both callers must resolve BEFORE that.
+//
+// May do transcript I/O (the no-pid fallback). Call it off the Bubble Tea Update loop.
+func (s *Session) ResolveLaunchID() (launchID, healedFrom string) {
 	s.mu.RLock()
-	stored, owner, rejected := s.ClaudeSessionID, s.ownerSessionID, s.rotRejectForeign
-	rejectedAgainst, projectPath := s.rotRejectOwner, s.ProjectPath
+	stored, owner, ownerPID := s.ClaudeSessionID, s.ownerSessionID, s.ownerPID
+	projectPath := s.ProjectPath
+	var rejected string
+	for foreign, r := range s.rotRejects {
+		if r.owner == owner {
+			rejected = foreign
+			break
+		}
+	}
 	s.mu.RUnlock()
 
-	// Only a rejection standing against the *current* owner says anything about the
-	// id we are about to fork.
-	if rejected == "" || rejected == stored || owner == "" || rejectedAgainst != owner || stored != owner {
+	// Only a rejection standing against the id we are about to launch says anything.
+	// (`stored != owner` also covers owner == "": a rejection implies a non-empty
+	// owner, and negCacheRotation is only ever reached with foreign != owner, so
+	// `rejected == stored` cannot happen here.)
+	if rejected == "" || stored != owner {
 		return stored, ""
 	}
-	if !ownerConversationSuperseded(projectPath, owner, rejected) {
+	if alive, known := s.ownerStillRunning(ownerPID); known {
+		if alive {
+			return stored, "" // owner is running — the rejected id is a nested agent
+		}
+		return rejected, stored
+	}
+	if !ownerConversationAbandoned(projectPath, owner, rejected) {
 		return stored, ""
 	}
 	return rejected, stored
@@ -819,12 +907,12 @@ func (s *Session) clearHookState() {
 	s.hookUpdatedAt = time.Time{}
 	s.hookOverriddenAt = time.Time{}
 	s.ownerSessionID = ""
-	s.rotRejectOwner = ""
-	s.rotRejectForeign = ""
-	// Zero the throttle with the pair it belongs to, so a restart re-arms the
-	// "hook dropped" line instead of inheriting a spent interval from the old pair.
-	s.rotRejectLoggedAt = time.Time{}
-	s.rotRejectCheckedAt = time.Time{}
+	s.ownerPID = 0
+	// Drop the rejections along with the owner they were judged against — and with
+	// them both clocks, so a restart re-arms the "hook dropped" line instead of
+	// inheriting a spent interval. Callers that need the rejection state must read it
+	// BEFORE calling this (see Restart/RespawnClaude → ResolveLaunchID).
+	s.rotRejects = nil
 	// Clear the fork parent link too. Restart()/RespawnClaude() call this without
 	// going through Start() (the only place forkParentID is set), so without this an
 	// un-diverged fork that resumes the parent id would re-claim owner==forkParent on

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -136,9 +136,10 @@ type Session struct {
 // or permanent (recovery). Per foreign id, so one noisy nested agent can neither
 // evict another id's rejection nor reset its clocks.
 type rotReject struct {
-	owner     string
-	loggedAt  time.Time // last "still rejected" line; a dropped hook must never be silent
-	checkedAt time.Time // last recovery check; throttles the fallback's transcript I/O
+	owner      string
+	foreignPID int       // process that reported the rejected id, so ResolveLaunchID can ask conversationSucceeds too
+	loggedAt   time.Time // last "still rejected" line; a dropped hook must never be silent
+	checkedAt  time.Time // last recovery check; throttles the fallback's transcript I/O
 }
 
 // NewSession creates a new session for the given project path.
@@ -445,7 +446,7 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 	//     resume id, so it must be ignored.
 	// sessionRotationVerdict distinguishes them from the transcripts; a persistent
 	// rejection is cached so a nested child doesn't rescan them every cycle. When
-	// that verdict is wrong, ownerStillRunning is what unsticks it — see the
+	// that verdict is wrong, conversationSucceeds is what unsticks it — see the
 	// negCached branch.
 	var owner string
 	if hs.SessionID != "" {
@@ -480,17 +481,18 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 				// Normally this id stays rejected for the session's whole life — right
 				// for a nested agent, wrong for a rotation we simply could not prove.
 				// Nothing else releases the owner (an in-process rotation fires no
-				// SessionEnd for the id it abandons), so ask the one question the
-				// transcripts cannot answer: is the owner's process still running?
+				// SessionEnd for the id it abandons), so ask the question the transcripts
+				// cannot answer: which PROCESS is reporting? See conversationSucceeds.
 				if resolveRotation && s.dueForDeadOwnerRecheck(hs.SessionID) {
-					if alive, known := s.ownerStillRunning(ownerPID); known && !alive {
-						debuglog.Logger.Info("adopting claude session: owner process gone",
-							"id", s.ID, "old", owner, "ownerPID", ownerPID, "new", hs.SessionID,
+					if verdict, known := conversationSucceeds(ownerPID, hs.AgentPID); known && verdict {
+						debuglog.Logger.Info("adopting claude session: process says rotation",
+							"id", s.ID, "old", owner, "ownerPID", ownerPID,
+							"new", hs.SessionID, "newPID", hs.AgentPID,
 							"frozenHookAge", time.Since(frozenHookAt).Truncate(time.Second))
 						break // recovered — fall through to the adoption block below
 					} else if !known && ownerConversationAbandoned(projectPath, owner, hs.SessionID) {
-						// No pid recorded (status file from an older handler). Fall back to
-						// transcript silence, which cannot separate a dead owner from one
+						// No pid on one side (a status file from an older handler). Fall back
+						// to transcript silence, which cannot separate a dead owner from one
 						// blocked on this very child — accepted only because the alternative
 						// is staying frozen forever, and because it self-clears: the next
 						// hook from the current handler records a pid.
@@ -550,7 +552,7 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 					// stayed undecidable past the retry cap (e.g. a permanently unreadable
 					// owner transcript). Neg-cache so a persistent foreign id doesn't rescan
 					// transcripts every cycle.
-					s.negCacheRotation(owner, hs.SessionID)
+					s.negCacheRotation(owner, hs.SessionID, hs.AgentPID)
 					debuglog.Logger.Info("ignoring foreign claude session",
 						"id", s.ID, "owner", owner, "foreign", hs.SessionID)
 					return false
@@ -685,21 +687,10 @@ func (s *Session) dueForDeadOwnerRecheck(foreign string) bool {
 	return true
 }
 
-// ownerStillRunning reports whether the agent process behind the current owner is
-// alive, and whether we know at all. known=false means no pid was recorded (a
-// status file written before StatusFile.AgentPID), which callers must not read as
-// death — it is the one case that still needs the transcript fallback.
-func (s *Session) ownerStillRunning(ownerPID int) (alive, known bool) {
-	if ownerPID <= 0 {
-		return false, false
-	}
-	return agentProcessAlive(ownerPID), true
-}
-
 // negCacheRotation records foreign as a confirmed non-rotation against owner, so
 // future hooks for it short-circuit without rescanning transcripts, and clears any
 // undecided-retry tracking for it.
-func (s *Session) negCacheRotation(owner, foreign string) {
+func (s *Session) negCacheRotation(owner, foreign string, foreignPID int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.rotRejects == nil {
@@ -714,7 +705,7 @@ func (s *Session) negCacheRotation(owner, foreign string) {
 	// silence would land squarely in the window where a user hits `!` and files a
 	// report. The recovery clock starts here for the same reason plus one of its own:
 	// an id rejected this instant cannot yet show an abandoned owner.
-	s.rotRejects[foreign] = &rotReject{owner: owner, loggedAt: now, checkedAt: now}
+	s.rotRejects[foreign] = &rotReject{owner: owner, foreignPID: foreignPID, loggedAt: now, checkedAt: now}
 	s.rotUndecidedOwner = ""
 	s.rotUndecidedForeign = ""
 	s.rotUndecidedCount = 0
@@ -868,11 +859,19 @@ func (s *Session) ResolveLaunchID() (launchID, healedFrom string) {
 	s.mu.RLock()
 	stored, owner, ownerPID := s.ClaudeSessionID, s.ownerSessionID, s.ownerPID
 	projectPath := s.ProjectPath
+	// Pick the rejection standing against the current owner. Several can, when an
+	// eval harness has been spawning sub-agents, so prefer one reported by the
+	// owner's own process — that is a rotation by identity, where the others are
+	// merely other processes. Map order is random, so without this tie-break the
+	// launch id would vary run to run.
 	var rejected string
+	var rejectedPID int
 	for foreign, r := range s.rotRejects {
-		if r.owner == owner {
-			rejected = foreign
-			break
+		if r.owner != owner {
+			continue
+		}
+		if rejected == "" || (r.foreignPID == ownerPID && ownerPID > 0) {
+			rejected, rejectedPID = foreign, r.foreignPID
 		}
 	}
 	s.mu.RUnlock()
@@ -884,9 +883,9 @@ func (s *Session) ResolveLaunchID() (launchID, healedFrom string) {
 	if rejected == "" || stored != owner {
 		return stored, ""
 	}
-	if alive, known := s.ownerStillRunning(ownerPID); known {
-		if alive {
-			return stored, "" // owner is running — the rejected id is a nested agent
+	if succeeds, known := conversationSucceeds(ownerPID, rejectedPID); known {
+		if !succeeds {
+			return stored, "" // another live process — a nested agent, not our successor
 		}
 		return rejected, stored
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -93,6 +93,11 @@ type Session struct {
 	// throttle is what makes "the hook is frozen because we rejected its id"
 	// greppable instead of a whole-pipeline trace.
 	rotRejectLoggedAt time.Time
+	// When we last paid the transcript I/O to ask whether a rejected pair has become
+	// recoverable (ownerConversationSuperseded). The neg-cache exists precisely to
+	// keep that scan off the ~500ms worker cycle, so the recovery check rides a
+	// slower clock of its own rather than reopening the cost the cache saved.
+	rotRejectCheckedAt time.Time
 
 	// Bounded retry tracking for an undecidable (owner, foreign) pair — one
 	// sessionRotationVerdict can't yet classify because a transcript hasn't flushed a
@@ -460,10 +465,22 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 				debuglog.Logger.Info("adopting forked claude session",
 					"id", s.ID, "parent", owner, "new", hs.SessionID)
 			case negCached:
-				// Already rejected this (owner, foreign) pair. Re-announce it on a
-				// throttle: this branch is the steady state of a session whose hook
-				// layer has gone dead, and dropping every hook in silence is what
-				// made that state cost a full pipeline trace to identify.
+				// Normally this pair stays rejected for the session's whole life — right
+				// for a nested child, wrong for a rotation we simply could not prove.
+				// Nothing else releases the owner (an in-process rotation fires no
+				// SessionEnd for the id it abandons), so recheck on a slow clock whether
+				// the owner conversation has gone silent while this one keeps writing.
+				if resolveRotation && s.dueForDeadOwnerRecheck() &&
+					ownerConversationSuperseded(projectPath, owner, hs.SessionID) {
+					debuglog.Logger.Info("adopting superseded claude session",
+						"id", s.ID, "old", owner, "new", hs.SessionID,
+						"frozenHookAge", time.Since(frozenHookAt).Truncate(time.Second))
+					break // recovered — fall through to the adoption block below
+				}
+				// Re-announce the rejection on a throttle: this branch is the steady
+				// state of a session whose hook layer has gone dead, and dropping every
+				// hook in silence is what made that state cost a full pipeline trace to
+				// identify.
 				// Check and stamp under ONE lock: the worker and the UI path both reach
 				// here (app.go calls syncHookStatuses from each), so a snapshot-then-write
 				// split lets both pass the interval check and log the same drop twice.
@@ -613,6 +630,27 @@ func (s *Session) bumpUndecidedRotation(owner, foreign string) bool {
 	return s.rotUndecidedCount <= rotationUndecidedRetryCap
 }
 
+// deadOwnerRecheckInterval throttles the ownerConversationSuperseded scan for a
+// neg-cached pair. The state it recovers from has already lasted minutes by the
+// time it is reachable at all (deadOwnerSupersedeMargin), so checking once a
+// minute costs nothing and loses nothing.
+const deadOwnerRecheckInterval = time.Minute
+
+// dueForDeadOwnerRecheck reports whether enough time has passed to re-examine a
+// neg-cached rejection, stamping the clock when it does. Check and stamp under ONE
+// lock: the worker calls this on every fast cycle, and a snapshot-then-write split
+// would let two cycles both pass and pay the scan twice.
+func (s *Session) dueForDeadOwnerRecheck() bool {
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if now.Sub(s.rotRejectCheckedAt) < deadOwnerRecheckInterval {
+		return false
+	}
+	s.rotRejectCheckedAt = now
+	return true
+}
+
 // negCacheRotation records the (owner, foreign) pair as a confirmed non-rotation so
 // future hooks for it short-circuit without rescanning transcripts, and clears any
 // undecided-retry tracking for it.
@@ -628,6 +666,10 @@ func (s *Session) negCacheRotation(owner, foreign string) {
 	// after another from inheriting the previous pair's spent interval — that silence
 	// would land squarely in the window where a user hits `!` and files a report.
 	s.rotRejectLoggedAt = time.Now()
+	// Same for the recovery clock: a pair rejected this instant cannot yet show a
+	// superseded owner (the margin is minutes wide), so start its interval here
+	// rather than letting the very next cycle spend a transcript scan proving it.
+	s.rotRejectCheckedAt = time.Now()
 	s.rotUndecidedOwner = ""
 	s.rotUndecidedForeign = ""
 	s.rotUndecidedCount = 0
@@ -736,6 +778,36 @@ func (s *Session) GetClaudeSessionID() string {
 	return s.ClaudeSessionID
 }
 
+// ResolveForkParent returns the conversation id a fork of this session should
+// resume, plus the stale id it replaced when one was healed ("" when nothing was
+// wrong). Read-only: the source session heals itself through UpdateHookStatus on
+// its next hook.
+//
+// Normally the answer is just ClaudeSessionID. It is not when a foreign id is
+// neg-cached against the owner: the pane may be in that other conversation while
+// ClaudeSessionID still names the one we froze on, and a fork of a dead id silently
+// copies a conversation the user stopped working in an hour ago (issue #226). The
+// worker's own recovery can't be relied on here — it only reruns when a hook
+// arrives, and a session that rotated and then went quiet fires none.
+//
+// Does transcript I/O. Call it off the Bubble Tea Update loop.
+func (s *Session) ResolveForkParent() (parentID, healedFrom string) {
+	s.mu.RLock()
+	stored, owner, rejected := s.ClaudeSessionID, s.ownerSessionID, s.rotRejectForeign
+	rejectedAgainst, projectPath := s.rotRejectOwner, s.ProjectPath
+	s.mu.RUnlock()
+
+	// Only a rejection standing against the *current* owner says anything about the
+	// id we are about to fork.
+	if rejected == "" || rejected == stored || owner == "" || rejectedAgainst != owner || stored != owner {
+		return stored, ""
+	}
+	if !ownerConversationSuperseded(projectPath, owner, rejected) {
+		return stored, ""
+	}
+	return rejected, stored
+}
+
 // clearHookState drops the previous Claude process's hook state — both the
 // in-memory cache and the on-disk status file at
 // ~/.config/fleet/hooks/<id>.json. Called before relaunching Claude so the
@@ -752,6 +824,7 @@ func (s *Session) clearHookState() {
 	// Zero the throttle with the pair it belongs to, so a restart re-arms the
 	// "hook dropped" line instead of inheriting a spent interval from the old pair.
 	s.rotRejectLoggedAt = time.Time{}
+	s.rotRejectCheckedAt = time.Time{}
 	// Clear the fork parent link too. Restart()/RespawnClaude() call this without
 	// going through Start() (the only place forkParentID is set), so without this an
 	// un-diverged fork that resumes the parent id would re-claim owner==forkParent on

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -818,14 +818,21 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// source session's ClaudeSessionID; if that id is stale (a missed
 		// rotation), the fork opens the wrong conversation (issue #142). Logging
 		// the source id + parent claude id here lets a bug report pin whether the
-		// parent we forked was the source's current conversation.
-		debuglog.Logger.Info("forking session",
+		// parent we forked was the source's current conversation. staleClaude is
+		// set only when ResolveForkParent caught a frozen id and forked past it
+		// (issue #226) — the one line that says the recovery fired.
+		forkLog := []any{
 			"newID", s.ID,
 			"newTitle", msg.title,
 			"sourceID", msg.sourceSessionID,
 			"sourceTitle", msg.sourceTitle,
 			"parentClaude", msg.parentClaudeSessionID,
-			"destPath", msg.path)
+			"destPath", msg.path,
+		}
+		if msg.staleClaudeSessionID != "" {
+			forkLog = append(forkLog, "staleClaude", msg.staleClaudeSessionID)
+		}
+		debuglog.Logger.Info("forking session", forkLog...)
 		parentSessionID := msg.parentClaudeSessionID
 		sourcePath := msg.sourcePath
 		destPath := msg.path
@@ -3827,20 +3834,23 @@ func (h *Home) forkSelected() tea.Cmd {
 		h.setError(fmt.Errorf("cannot fork: no session selected"))
 		return nil
 	}
-	if s.ClaudeSessionID == "" {
+	if s.GetClaudeSessionID() == "" {
 		h.setError(fmt.Errorf("cannot fork: session has no Claude conversation ID yet"))
 		return nil
 	}
+	h.actionLog.Add("fork session", s.Title, true)
 	title := s.Title + " (fork)"
-	claudeSessionID := s.ClaudeSessionID
 	sourceID := s.ID
 	sourceTitle := s.Title
 	path := s.ProjectPath
 	workspaceName := s.WorkspaceName
 	parentAgent := s.Agent
 	return func() tea.Msg {
+		// Off the Update loop: ResolveForkParent reads transcripts.
+		claudeSessionID, stale := s.ResolveForkParent()
 		return forkSessionMsg{
 			parentClaudeSessionID: claudeSessionID,
+			staleClaudeSessionID:  stale,
 			sourceSessionID:       sourceID,
 			sourceTitle:           sourceTitle,
 			sourcePath:            path,
@@ -3856,10 +3866,10 @@ func (h *Home) forkSelected() tea.Cmd {
 // worktree picker, so the deferred result handlers can build a forkSessionMsg
 // targeting the chosen destination.
 type forkContext struct {
-	parentClaudeSessionID string
-	parentSessionID       string // fleet id of the session being forked (for diagnostics)
-	parentProjectPath     string
-	parentTitle           string
+	parentSession     *session.Session
+	parentSessionID   string // fleet id of the session being forked (for diagnostics)
+	parentProjectPath string
+	parentTitle       string
 }
 
 // clearPendingFork resets fork-target picker state. Safe to call when nothing
@@ -3882,13 +3892,16 @@ func (h *Home) dispatchForkToWorktree(ctx *forkContext, destPath, destWorkspaceN
 	if destWorkspaceName != "" {
 		title = ctx.parentTitle + " (" + destWorkspaceName + ")"
 	}
-	parentClaudeSessionID := ctx.parentClaudeSessionID
+	parent := ctx.parentSession
 	sourceID := ctx.parentSessionID
 	sourceTitle := ctx.parentTitle
 	sourcePath := ctx.parentProjectPath
 	return func() tea.Msg {
+		// Off the Update loop: ResolveForkParent reads transcripts.
+		parentClaudeSessionID, stale := parent.ResolveForkParent()
 		return forkSessionMsg{
 			parentClaudeSessionID: parentClaudeSessionID,
+			staleClaudeSessionID:  stale,
 			sourceSessionID:       sourceID,
 			sourceTitle:           sourceTitle,
 			sourcePath:            sourcePath,
@@ -3916,7 +3929,7 @@ func (h *Home) forkToWorktreeSelected() tea.Cmd {
 		h.setError(fmt.Errorf("fork to worktree is Claude-only; use 'f' to fork this session in place"))
 		return nil
 	}
-	if s.ClaudeSessionID == "" {
+	if s.GetClaudeSessionID() == "" {
 		h.setError(fmt.Errorf("cannot fork to worktree: session has no Claude conversation ID yet"))
 		return nil
 	}
@@ -3925,11 +3938,12 @@ func (h *Home) forkToWorktreeSelected() tea.Cmd {
 		h.setError(fmt.Errorf("cannot fork to worktree: session is not inside a git repo"))
 		return nil
 	}
+	h.actionLog.Add("fork to worktree", s.Title, true)
 	h.pendingForkCtx = &forkContext{
-		parentClaudeSessionID: s.ClaudeSessionID,
-		parentSessionID:       s.ID,
-		parentProjectPath:     s.ProjectPath,
-		parentTitle:           s.Title,
+		parentSession:     s,
+		parentSessionID:   s.ID,
+		parentProjectPath: s.ProjectPath,
+		parentTitle:       s.Title,
 	}
 	h.worktreeDialog.ShowLoading()
 	return tea.Batch(h.fetchWorkspaceListForRepo(repoPath), spinnerTickCmd)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -819,7 +819,7 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// rotation), the fork opens the wrong conversation (issue #142). Logging
 		// the source id + parent claude id here lets a bug report pin whether the
 		// parent we forked was the source's current conversation. staleClaude is
-		// set only when ResolveForkParent caught a frozen id and forked past it
+		// set only when ResolveLaunchID caught a frozen id and forked past it
 		// (issue #226) — the one line that says the recovery fired.
 		forkLog := []any{
 			"newID", s.ID,
@@ -3846,8 +3846,8 @@ func (h *Home) forkSelected() tea.Cmd {
 	workspaceName := s.WorkspaceName
 	parentAgent := s.Agent
 	return func() tea.Msg {
-		// Off the Update loop: ResolveForkParent reads transcripts.
-		claudeSessionID, stale := s.ResolveForkParent()
+		// Off the Update loop: ResolveLaunchID may read transcripts.
+		claudeSessionID, stale := s.ResolveLaunchID()
 		return forkSessionMsg{
 			parentClaudeSessionID: claudeSessionID,
 			staleClaudeSessionID:  stale,
@@ -3897,8 +3897,8 @@ func (h *Home) dispatchForkToWorktree(ctx *forkContext, destPath, destWorkspaceN
 	sourceTitle := ctx.parentTitle
 	sourcePath := ctx.parentProjectPath
 	return func() tea.Msg {
-		// Off the Update loop: ResolveForkParent reads transcripts.
-		parentClaudeSessionID, stale := parent.ResolveForkParent()
+		// Off the Update loop: ResolveLaunchID may read transcripts.
+		parentClaudeSessionID, stale := parent.ResolveLaunchID()
 		return forkSessionMsg{
 			parentClaudeSessionID: parentClaudeSessionID,
 			staleClaudeSessionID:  stale,

--- a/internal/ui/dialogs.go
+++ b/internal/ui/dialogs.go
@@ -33,6 +33,7 @@ type sessionCreateMsg struct {
 // destination's Claude project dir before the new session launches.
 type forkSessionMsg struct {
 	parentClaudeSessionID string
+	staleClaudeSessionID  string // non-empty when parentClaudeSessionID replaced a frozen id (for diagnostics)
 	sourceSessionID       string // fleet id of the session being forked (for diagnostics)
 	sourceTitle           string // title of the session being forked (for diagnostics)
 	sourcePath            string


### PR DESCRIPTION
A session pins itself to the agent session_id that claimed it, and a hook from a
different id has to prove it continues that conversation before being adopted.
When the proof fails the id is neg-cached — and nothing undoes that. Ownership is
released on one condition only: a `dead` hook *for the owner id*. An in-process
rotation (`/clear`) never sends one, so a rotation we could not prove leaves the
session pinned to a conversation nobody is in, for the rest of its life.

Everything downstream reads that id. Status freezes (every hook from the live
conversation is dropped), `r` resumes the abandoned conversation, and `f`/`F`
fork it — which is how the state gets reported: three times now, as "the fork
doesn't work" (#142, #156, #226). #226 is the first report carrying the
fork-initiation logging from #151, and it is conclusive: the source session fires
UserPromptSubmit under `fb8a487e` at 17:00:09, and eight seconds later fleet
forks `c6e65cc4`.

The proof fails for reasons that have nothing to do with the conversation.
Before #222 a transcript entry over 1MB — a pasted image — ended the scan early
and biased every rotation signal toward "not a rotation"; a pair that stays
undecidable past the retry cap is neg-cached on a timeout rather than on
evidence.

## Ask the process, not the transcript

Transcript recency cannot separate the two cases it is being asked about. A
nested `claude` spawned inside a tool call inherits FLEET_INSTANCE_ID and fires
hooks under its own conversation id while its parent, blocked on that call,
writes nothing — the same trace a rotation leaves. No margin fixes that; it only
sets how long the wrong answer takes.

A hook command runs as a direct child of the agent that fired it, so the handler
records `os.Getppid()` in the status file. Ownership then asks which *process* is
reporting:

  - same pid, new session id -> the owner itself under a new name. `/clear`
    starts a fresh conversation inside the running process. A rotation.
  - different pid, owner gone -> the conversation that held this session ended;
    whatever reports now succeeded it.
  - different pid, owner alive -> two agents at once. Reject.

Note the first row, because it is the one the reported bug lives in and the one
a liveness check gets backwards: an in-process `/clear` leaves the owner's pid
very much alive.

Fails closed. A recycled pid reads as "owner alive" and leaves the session
frozen, which is today's behaviour — so a wrong answer costs nothing already
lost, where the opposite bias would hand a session's status and resume id to a
scratch conversation.

The transcript predicate survives as the fallback for status files written
before the field existed, corrected to measure how long the owner has been
silent rather than how far the new conversation ran past it. The difference is
load-bearing: six minutes of work after a `/clear` then a pause never advances a
"ran N past the owner" measure beyond six minutes, so that session stayed frozen
for good — and a short piece of work after `/clear` is the common shape. The
fallback self-clears on the next hook from the current handler.

## Also

  - The neg-cache is keyed by foreign id. One slot meant an eval harness's
    stream of sub-agent ids evicted the rotated pair, so it paid a full
    two-transcript verdict every ~500ms cycle — the cost the cache exists to
    avoid — and its recovery clock was reset before it could fire.
  - `r` heals, not just fork. Restart and respawn resolve the id before
    `clearHookState()` wipes the state it is derived from.
  - `f` and `F` reach the action log. #226's steps-to-reproduce lists eleven
    attaches and four deletes and not one of the five forks it is about.

## Verified against Claude 2.1.220

  - a hook's `getppid()` is the `claude` process (probed before building on it);
  - `--resume <unknown-id> --fork-session` exits without firing SessionStart, so
    the forks in #226 resumed a real conversation — just a dead one;
  - a fork reports its OWN id at SessionStart, where 2.1.191 reported the
    parent's. The `forkParentID` adoption branch is now dead code against
    current Claude; left in place as it remains correct for older CLIs.

Tests cover both directions and are mutation-checked: deleting the same-pid
branch fails the in-process rotation cases, forcing liveness to report "gone"
fails the three nested-agent guards, and restoring the old
"how far the new session ran" predicate fails the short-post-`/clear` case.
