### PR TITLE
fix(ui): close the report dialog once the issue is filed

### DIFF
--- a/changelog/unreleased/report-dialog-closes-on-submit.md
+++ b/changelog/unreleased/report-dialog-closes-on-submit.md
@@ -1,4 +1,4 @@
 ---
 type: fixed
 ---
-**Reports close themselves.** Filing a bug or feature request left the form frozen on `Creating issue...` until you pressed `esc` — the issue was already filed. It now closes on submit and confirms with the issue URL.
+**Reports close themselves.** Filing a report left the form frozen on `Creating issue...` until you pressed `esc` — the issue was already filed. It now closes on submit and confirms with the issue URL.

--- a/changelog/unreleased/report-dialog-closes-on-submit.md
+++ b/changelog/unreleased/report-dialog-closes-on-submit.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+**Reports close themselves.** Filing a bug or feature request left the form frozen on `Creating issue...` until you pressed `esc` — the issue was already filed. It now closes on submit and confirms with the issue URL.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1106,6 +1106,16 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, h.ensureWhatsNewShimmer()
 
 	case bugReportClosedMsg:
+		// Closing here covers the submit path too: it files the issue from inside
+		// a tea.Cmd, which cannot reach the dialog, so without this the form sat
+		// on "Creating issue..." forever and had to be dismissed by hand (#233).
+		h.bugReport.Hide()
+		if msg.url != "" {
+			// The submit path also opens the URL in a browser, but that is only a
+			// logged warning when it fails — this line is the confirmation the
+			// user is guaranteed to get.
+			h.setInfo("Issue created: " + msg.url)
+		}
 		return h, nil
 
 	case bugReportOpenErrMsg:

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1109,7 +1109,15 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Closing here covers the submit path too: it files the issue from inside
 		// a tea.Cmd, which cannot reach the dialog, so without this the form sat
 		// on "Creating issue..." forever and had to be dismissed by hand (#233).
-		h.bugReport.Hide()
+		//
+		// Gated on submitting because the message carries no identity: esc during
+		// a submit hides the form and emits one, so pressing `!` again lands a
+		// fresh form that the still-pending gh result would otherwise close —
+		// taking the description typed into it. A form that isn't mid-submit is
+		// never the one this result belongs to.
+		if h.bugReport.submitting {
+			h.bugReport.Hide()
+		}
 		if msg.url != "" {
 			// The submit path also opens the URL in a browser, but that is only a
 			// logged warning when it fails — this line is the confirmation the

--- a/internal/ui/bugreport.go
+++ b/internal/ui/bugreport.go
@@ -16,8 +16,11 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// bugReportClosedMsg is sent when the bug report dialog closes.
-type bugReportClosedMsg struct{}
+// bugReportClosedMsg asks app.go to close the report dialog. The esc paths have
+// already hidden themselves by the time they emit it, but the submit path runs
+// inside a tea.Cmd and cannot touch dialog state, so the handler — not the
+// emitter — is what actually closes it. url is set only on a successful file.
+type bugReportClosedMsg struct{ url string }
 
 // bugReportOpenErrMsg is sent when opening the GitHub issue fails.
 type bugReportOpenErrMsg struct{ err error }
@@ -378,7 +381,7 @@ func (d *BugReportDialog) createGitHubIssue(title, body, label string) tea.Cmd {
 				debuglog.Logger.Warn("bug report: failed to open issue URL", "url", issueURL, "err", err)
 			}
 		}
-		return bugReportClosedMsg{}
+		return bugReportClosedMsg{url: issueURL}
 	}
 }
 

--- a/internal/ui/bugreport_test.go
+++ b/internal/ui/bugreport_test.go
@@ -97,6 +97,24 @@ func TestReportTitlesAndFeatureBodySanitizeHome(t *testing.T) {
 	}
 }
 
+// The submit path files the issue from inside a tea.Cmd, so it cannot hide the
+// dialog itself — only the handler can. Asserting on the *dialog* would pass
+// with the bug present (esc had already hidden it), so this drives the real
+// Update to prove a submitted report closes without a keypress.
+func TestBugReportClosedMsg_HidesDialogAndConfirms(t *testing.T) {
+	h := &Home{bugReport: bugFormDialog(), toasts: NewToastStack()}
+	h.bugReport.submitting = true
+
+	h.Update(bugReportClosedMsg{url: "https://github.com/brizzai/fleet/issues/1"})
+
+	if h.bugReport.IsVisible() {
+		t.Fatal("expected the report dialog to close once the issue was filed")
+	}
+	if !strings.Contains(h.infoMsg, "issues/1") {
+		t.Fatalf("expected the issue URL confirmed on screen, got %q", h.infoMsg)
+	}
+}
+
 func TestBugReportDialog_Esc_Hides(t *testing.T) {
 	d := bugFormDialog()
 	d.submitting = true

--- a/internal/ui/bugreport_test.go
+++ b/internal/ui/bugreport_test.go
@@ -115,6 +115,38 @@ func TestBugReportClosedMsg_HidesDialogAndConfirms(t *testing.T) {
 	}
 }
 
+// bugReportClosedMsg carries no identity, so a submit that is still in flight
+// when the user escapes out and opens a fresh report would close the new form
+// and take the description typed into it — Show() blanks descInput on the next
+// open, making it unrecoverable. Only a form that is itself mid-submit can be
+// the one a result belongs to.
+func TestBugReportClosedMsg_LeavesANewerFormAlone(t *testing.T) {
+	h := &Home{bugReport: bugFormDialog(), toasts: NewToastStack()}
+	h.bugReport.submitting = true
+
+	// esc while submitting: hides the form, emits a bare closed msg, and leaves
+	// the gh call still running.
+	h.bugReport.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	// `!` again — a fresh report, part-way through being typed.
+	h.bugReport.Show("v0.0.0-test", 0, NewErrorHistory(50), NewActionLog(100), 100, 40, nil, 0, nil)
+	h.bugReport.stage = stageForm
+	h.bugReport.descInput.SetValue("half-written second report")
+
+	// The first submission finally returns.
+	h.Update(bugReportClosedMsg{url: "https://github.com/brizzai/fleet/issues/1"})
+
+	if !h.bugReport.IsVisible() {
+		t.Fatal("a stale submit result closed the report the user was typing into")
+	}
+	if got := h.bugReport.descInput.Value(); got != "half-written second report" {
+		t.Fatalf("description lost to the stale result, got %q", got)
+	}
+	if !strings.Contains(h.infoMsg, "issues/1") {
+		t.Fatalf("the filed issue must still be confirmed, got %q", h.infoMsg)
+	}
+}
+
 func TestBugReportDialog_Esc_Hides(t *testing.T) {
 	d := bugFormDialog()
 	d.submitting = true


### PR DESCRIPTION
Fixes #233.

## The bug

Submitting a report — bug, feature request, or wrong-status alike — left the form frozen on `Creating issue...`. The issue was already filed and already opened in a browser; you came back to the terminal and had to dismiss a modal that still claimed it was mid-flight. `esc` worked, but the `submitting` footer replaces the whole controls line, so even that hint isn't on screen.

## Root cause

`createGitHubIssue` returns `bugReportClosedMsg{}` on success — a message *named* as if it closes the dialog. But it runs inside a `tea.Cmd`, which can't mutate dialog state, and the handler was a no-op:

```go
case bugReportClosedMsg:
    return h, nil          // never called h.bugReport.Hide()
```

It went unnoticed because the only *other* emitters are the two `esc` paths, which call `d.Hide()` themselves before emitting. To the handler, the message had always meant "already closed."

Not a regression — present since `bded48b`, the original TUI commit. The error path (`bugReportOpenErrMsg`) was always correct: it clears `submitting` and keeps the dialog open to retry.

## The fix

The handler hides the dialog, and `bugReportClosedMsg` now carries the issue URL so the close is confirmed on screen. The toast isn't decoration: `openURL` failure is only a `debuglog.Warn`, so without it a machine that can't launch a browser gets a modal vanishing and no other feedback at all.

The regression test drives the real `Home.Update` rather than the dialog — asserting on the dialog alone would have passed with the bug present, since `esc` had already hidden it. The whole defect lives in the handler.

## Not fixed here

The `submitting` footer (`bugreport.go:500`) prints only `Creating issue...` and drops the `esc` hint, so a genuinely *hung* `gh issue create` still has no advertised escape. Auto-close makes that far less likely to bite; flagging rather than widening the diff.

## Test plan

- `make test` (`-race`) green across the repo; `make build` passes.
- New `TestBugReportClosedMsg_HidesDialogAndConfirms` fails on `master` (dialog stays visible), passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gDK9k4hwvtAmV8YUskztZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bug-report dialogs now close after a successful submission instead of becoming unresponsive.
  * A confirmation notification displays the URL of the newly created issue.
* **Documentation**
  * Added an unreleased changelog entry documenting the improved bug-report submission experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->