### PR TITLE
fix(status): hand the agent pid to the ownership gate

### DIFF
--- a/changelog/unreleased/agentpid-reaches-ownership.md
+++ b/changelog/unreleased/agentpid-reaches-ownership.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Stuck sessions recover.** The v2.24.0 fix for this never took effect — the check that decides whether a session's old conversation has ended was never handed the process id it needs, so a frozen dot stayed frozen. Now wired through.

--- a/changelog/unreleased/status-report-hook-divergence.md
+++ b/changelog/unreleased/status-report-hook-divergence.md
@@ -1,0 +1,5 @@
+---
+type: improved
+---
+
+**Wrong-status reports explain themselves.** A report filed with `!` now shows the hook status fleet applied beside the one sitting on disk, which conversation id it latched onto, and whether the two agree — so a stuck session can be diagnosed from the issue instead of a round trip asking for more.

--- a/internal/hooks/status_file.go
+++ b/internal/hooks/status_file.go
@@ -26,6 +26,17 @@ type StatusFile struct {
 	// FLEET_INSTANCE_ID (owner alive) — a distinction no amount of transcript
 	// reading can make. Omitted by handlers older than this field; readers must
 	// treat 0 as "unknown", not "dead".
+	//
+	// getppid() only names the agent because the installed hook command is a
+	// SINGLE SIMPLE COMMAND: Claude and Codex run GetHookCommand()'s
+	// `'<path>' hook-handler --fleet-hook` through a shell, which execs rather
+	// than forks, and OpenCode spawns the binary directly with no shell at all.
+	// A compound command (`;`, `&&`, `|`, a redirection) makes the shell fork,
+	// and getppid() would then record that shell — a process that exits
+	// immediately, which conversationSucceeds reads as "the owner is gone" for
+	// every foreign session id it is ever asked about. Only reachable by hand-
+	// editing settings.json today, but keep the installed command simple: the
+	// failure is a silently inverted ownership gate, not a missing signal.
 	AgentPID int `json:"agent_pid,omitempty"`
 }
 

--- a/internal/session/agent_process.go
+++ b/internal/session/agent_process.go
@@ -27,6 +27,13 @@ import (
 // Liveness alone cannot make that call. It gets the third case right and the first
 // one exactly wrong — an in-process `/clear` leaves the owner's pid very much
 // alive, which is the shape issue #226 was reported in.
+//
+// It trusts both pids to be agent processes, which is StatusFile.AgentPID's
+// contract, not something checked here. Note how this fails if that contract
+// breaks: a pid belonging to something short-lived is never alive, so the third
+// case collapses into the second and EVERY foreign session id is adopted — the
+// gate inverts rather than degrades. See StatusFile.AgentPID for what the
+// contract rests on.
 func conversationSucceeds(ownerPID, newPID int) (succeeds, known bool) {
 	if ownerPID <= 0 || newPID <= 0 {
 		return false, false

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1589,6 +1589,14 @@ type StatusSnapshot struct {
 	HookUpdatedAt    time.Time
 	HookOverriddenAt time.Time
 
+	// OwnerSessionID/OwnerPID are the conversation the ownership gate has latched
+	// onto. A hook whose session_id differs from OwnerSessionID is dropped, and
+	// the in-memory hook then sits frozen while the status file on disk moves on —
+	// a divergence that reads, from the outside, as a status stuck forever. These
+	// are captured so a report can show it instead of leaving it to be inferred.
+	OwnerSessionID string
+	OwnerPID       int
+
 	LastContentHash     string
 	LastContentChangeAt time.Time
 
@@ -1611,6 +1619,8 @@ func (s *Session) SnapshotData(rawPane string) StatusSnapshot {
 		HookStatus:          s.hookStatus,
 		HookUpdatedAt:       s.hookUpdatedAt,
 		HookOverriddenAt:    s.hookOverriddenAt,
+		OwnerSessionID:      s.ownerSessionID,
+		OwnerPID:            s.ownerPID,
 		LastContentHash:     s.lastContentHash,
 		LastContentChangeAt: s.lastContentChangeAt,
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -5222,9 +5222,18 @@ func (h *Home) syncHookStatuses(sessions []*session.Session, resolveRotation boo
 			oldFirstPrompt := s.FirstPrompt
 			oldPromptCount := s.PromptCount
 			if s.UpdateHookStatus(&session.HookStatus{
-				Status:      hs.Status,
-				SessionID:   hs.SessionID,
-				UpdatedAt:   hs.UpdatedAt,
+				Status:    hs.Status,
+				SessionID: hs.SessionID,
+				UpdatedAt: hs.UpdatedAt,
+				// AgentPID is what lets ownership ask "is the conversation that owns
+				// this session still running?" — the only question that releases a
+				// neg-cached rotation. Dropping it here (this is the sole production
+				// caller of UpdateHookStatus) leaves both sides of that comparison at
+				// 0, so conversationSucceeds answers "unknown" forever and the
+				// process-based recovery never fires. The ownership tests inject
+				// AgentPID straight into UpdateHookStatus, so they stay green while
+				// production runs blind — hence TestSyncHookStatusesPropagatesAgentPID.
+				AgentPID:    hs.AgentPID,
 				UserPrompt:  hs.UserPrompt,
 				PromptCount: hs.PromptCount,
 			}, resolveRotation) {

--- a/internal/ui/hookstatus_sync_test.go
+++ b/internal/ui/hookstatus_sync_test.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/brizzai/fleet/internal/hooks"
+	"github.com/brizzai/fleet/internal/session"
+)
+
+// TestSyncHookStatusesPropagatesAgentPID guards the seam between the hook watcher
+// and the ownership gate.
+//
+// syncHookStatuses is the ONLY production caller of UpdateHookStatus, and it
+// rebuilds the HookStatus field by field. Every ownership test injects AgentPID
+// straight into UpdateHookStatus, so dropping it here stayed green everywhere
+// while production ran with both sides of the comparison at 0 —
+// conversationSucceeds answers "unknown", the neg-cached rotation is never
+// released, and the session's hook sits frozen while the file on disk moves on.
+// Asserting on the reconstructed struct is the point: this test must fail if a
+// field is dropped in transit, not if the gate's logic changes.
+func TestSyncHookStatusesPropagatesAgentPID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const instanceID = "inst-agentpid"
+	const conversationID = "sess-aaa"
+	agentPID := os.Getpid()
+
+	// Land the file before the watcher exists so loadExisting picks it up on
+	// Start, rather than racing an fsnotify delivery.
+	if err := hooks.WriteStatusFile(hooks.GetHooksDir(), instanceID, &hooks.StatusFile{
+		Status:    "running",
+		SessionID: conversationID,
+		Event:     "UserPromptSubmit",
+		Timestamp: time.Now().Unix(),
+		AgentPID:  agentPID,
+	}); err != nil {
+		t.Fatalf("write status file: %v", err)
+	}
+
+	w, err := hooks.NewHookWatcher()
+	if err != nil {
+		t.Fatalf("new hook watcher: %v", err)
+	}
+	go w.Start()
+	t.Cleanup(w.Stop)
+
+	var hs *hooks.HookStatus
+	for range 200 {
+		if hs = w.GetStatus(instanceID); hs != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if hs == nil {
+		t.Fatal("hook watcher never loaded the status file")
+	}
+	if hs.AgentPID != agentPID {
+		t.Fatalf("watcher lost AgentPID: got %d, want %d", hs.AgentPID, agentPID)
+	}
+
+	db, err := session.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open state db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	h := &Home{hookWatcher: w, storage: db}
+	s := &session.Session{ID: instanceID, ProjectPath: t.TempDir()}
+
+	h.syncHookStatuses([]*session.Session{s}, true)
+
+	snap := s.SnapshotData("")
+	if snap.OwnerSessionID != conversationID {
+		t.Fatalf("ownership not claimed: owner = %q, want %q", snap.OwnerSessionID, conversationID)
+	}
+	if snap.OwnerPID != agentPID {
+		t.Fatalf("syncHookStatuses dropped AgentPID: ownerPID = %d, want %d", snap.OwnerPID, agentPID)
+	}
+}

--- a/internal/ui/snapshot.go
+++ b/internal/ui/snapshot.go
@@ -218,20 +218,42 @@ func buildSnapshotJSON(snap session.StatusSnapshot, hookFileRaw []byte, hookFile
 	}
 	m["worker"] = worker
 
+	// `status` is what fleet APPLIED (in memory); `file_contents` is what the agent
+	// last WROTE. They are separate sources read at the same instant, and they can
+	// disagree: the ownership gate drops a hook whose session_id is not the owner,
+	// so memory stays frozen while the file moves on. owner_session_id/owner_pid are
+	// the gate's own state — without them that divergence can only be guessed at.
 	hookMap := map[string]any{
-		"status":        snap.HookStatus,
-		"updated_at":    snap.HookUpdatedAt.Format(time.RFC3339),
-		"age":           fmtSnapshotAge(snap.HookUpdatedAt, now),
-		"overridden_at": fmtSnapshotAge(snap.HookOverriddenAt, now),
+		"status":           snap.HookStatus,
+		"updated_at":       snap.HookUpdatedAt.Format(time.RFC3339),
+		"age":              fmtSnapshotAge(snap.HookUpdatedAt, now),
+		"overridden_at":    fmtSnapshotAge(snap.HookOverriddenAt, now),
+		"owner_session_id": snap.OwnerSessionID,
+		"owner_pid":        snap.OwnerPID,
 	}
 	if len(hookFileRaw) > 0 {
 		var parsed any
 		if json.Unmarshal(hookFileRaw, &parsed) == nil {
 			hookMap["file_contents"] = parsed
+			// Lift the two fields the divergence turns on out of file_contents, and
+			// state the comparison outright. file_contents is never published (it
+			// carries the reporter's verbatim prompt), so a report that only showed
+			// the applied status left "is fleet even reading this file?" to be
+			// re-derived by hand from the fact that the handler maps event→status.
+			if fc, ok := parsed.(map[string]any); ok {
+				fileStatus, _ := fc["status"].(string)
+				fileSession, _ := fc["session_id"].(string)
+				hookMap["file_status"] = fileStatus
+				hookMap["file_session_id"] = fileSession
+				if fileStatus != "" {
+					hookMap["applied_matches_file"] = fileStatus == snap.HookStatus
+				}
+			}
 		}
 	}
 	if hookFileInfo != nil {
 		hookMap["file_mod_time"] = hookFileInfo.ModTime().Format(time.RFC3339)
+		hookMap["file_age"] = fmtSnapshotAge(hookFileInfo.ModTime(), now)
 	}
 	m["hook"] = hookMap
 

--- a/internal/ui/snapshot.go
+++ b/internal/ui/snapshot.go
@@ -19,6 +19,17 @@ import (
 	"github.com/brizzai/fleet/internal/session"
 )
 
+// divergenceLagGrace is how far the hook file may sit ahead of the applied hook
+// before the gap stops being explainable as ordinary lag.
+//
+// Two sources feed it. The pipeline itself costs ~600ms (a 100ms fsnotify
+// debounce plus up to a 500ms fast worker cycle). The larger term is precision:
+// the applied timestamp comes from the status file's `ts`, which is Unix
+// SECONDS, while ModTime is sub-second — so re-reading the very same file yields
+// a skew anywhere in [0, 1s) with nothing wrong at all. 3s clears both with room
+// to spare, and the case this exists to catch is off by hours, not seconds.
+const divergenceLagGrace = 3 * time.Second
+
 type statusSnapshotMsg struct {
 	path string
 	err  error
@@ -254,6 +265,20 @@ func buildSnapshotJSON(snap session.StatusSnapshot, hookFileRaw []byte, hookFile
 	if hookFileInfo != nil {
 		hookMap["file_mod_time"] = hookFileInfo.ModTime().Format(time.RFC3339)
 		hookMap["file_age"] = fmtSnapshotAge(hookFileInfo.ModTime(), now)
+
+		// A false applied_matches_file has two very different causes, and they carry
+		// the same value. The applied side lags the file by design — fsnotify debounce
+		// plus a worker cycle — so a capture landing mid-write reads false benignly,
+		// identically to a hook fleet dropped and never applied. The skew separates
+		// them: benign lag is sub-cycle, a dropped hook leaves the applied side
+		// arbitrarily far behind (18h27m in #220). Report it rather than asking the
+		// reader to infer it from two age rows.
+		if !snap.HookUpdatedAt.IsZero() {
+			if skew := hookFileInfo.ModTime().Sub(snap.HookUpdatedAt); skew > 0 {
+				hookMap["file_newer_by"] = skew.Round(time.Millisecond).String()
+				hookMap["divergence_significant"] = skew > divergenceLagGrace
+			}
+		}
 	}
 	m["hook"] = hookMap
 

--- a/internal/ui/snapshot_divergence_test.go
+++ b/internal/ui/snapshot_divergence_test.go
@@ -1,0 +1,119 @@
+package ui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/brizzai/fleet/internal/session"
+)
+
+// hookFileInfoAt writes a status file and stamps its mtime, returning the FileInfo
+// buildSnapshotJSON takes.
+func hookFileInfoAt(t *testing.T, modTime time.Time) os.FileInfo {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "hook.json")
+	if err := os.WriteFile(path, []byte(`{"status":"finished"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info
+}
+
+// The producer side of the bold-vs-plain decision. The renderer tests drive it
+// from literal maps, so without this nothing pins how the flag is actually
+// computed — which is exactly the seam that let a dropped AgentPID ship green.
+func TestBuildSnapshotJSON_DivergenceSignificance(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name string
+		// how far the file on disk sits ahead of the hook fleet applied
+		skew        time.Duration
+		wantSignif  bool
+		wantPresent bool
+	}{
+		// #220's shape: applied hook hours behind the file.
+		{"dropped hook", 18*time.Hour + 27*time.Minute, true, true},
+		// Unix-second `ts` vs sub-second mtime means re-reading one file can show
+		// up to 1s of skew with nothing wrong.
+		{"second-granularity artifact", 900 * time.Millisecond, false, true},
+		// fsnotify debounce + a worker cycle.
+		{"pipeline lag", 2 * time.Second, false, true},
+		{"just past the grace", divergenceLagGrace + time.Second, true, true},
+		// File not newer than what we applied: nothing to explain.
+		{"file not newer", 0, false, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			applied := now.Add(-tc.skew)
+			snap := session.StatusSnapshot{
+				HookStatus:    "running",
+				HookUpdatedAt: applied,
+			}
+			m := buildSnapshotJSON(snap, []byte(`{"status":"finished","event":"Stop"}`),
+				hookFileInfoAt(t, now), now, nil, nil, workerHeartbeat{})
+
+			hook, ok := m["hook"].(map[string]any)
+			if !ok {
+				t.Fatal("snapshot has no hook block")
+			}
+			got, present := hook["divergence_significant"]
+			if present != tc.wantPresent {
+				t.Fatalf("divergence_significant present = %v, want %v (hook=%v)", present, tc.wantPresent, hook)
+			}
+			if tc.wantPresent && got != tc.wantSignif {
+				t.Errorf("divergence_significant = %v, want %v (skew %s)", got, tc.wantSignif, tc.skew)
+			}
+			// The comparison itself must still be reported regardless of significance:
+			// event Stop maps to finished, which is not the applied "running".
+			if am := hook["applied_matches_file"]; am != false {
+				t.Errorf("applied_matches_file = %v, want false", am)
+			}
+		})
+	}
+}
+
+// The whole hook block must survive a round trip through encoding/json, since a
+// Shift+D capture is read back off disk rather than out of memory.
+func TestBuildSnapshotJSON_HookBlockMarshals(t *testing.T) {
+	now := time.Now()
+	snap := session.StatusSnapshot{
+		HookStatus:     "running",
+		HookUpdatedAt:  now.Add(-time.Hour),
+		OwnerSessionID: "owner-aaa",
+		OwnerPID:       4242,
+	}
+	m := buildSnapshotJSON(snap, []byte(`{"status":"finished","event":"Stop","session_id":"new-bbb"}`),
+		hookFileInfoAt(t, now), now, nil, nil, workerHeartbeat{})
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("snapshot.json does not marshal: %v", err)
+	}
+	var back map[string]any
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("snapshot.json does not round trip: %v", err)
+	}
+	hook := back["hook"].(map[string]any)
+
+	// metaInt must survive the float64 that json.Unmarshal produces.
+	if got := metaInt(hook, "owner_pid"); got != 4242 {
+		t.Errorf("owner_pid after round trip = %d, want 4242", got)
+	}
+	if got := metaString(hook, "file_session_id"); got != "new-bbb" {
+		t.Errorf("file_session_id after round trip = %q, want new-bbb", got)
+	}
+	if got := metaString(hook, "owner_session_id"); got != "owner-aaa" {
+		t.Errorf("owner_session_id after round trip = %q, want owner-aaa", got)
+	}
+}

--- a/internal/ui/statusreport.go
+++ b/internal/ui/statusreport.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -371,7 +372,22 @@ func shortSessionID(id string) string {
 	return id
 }
 
-// metaString/metaBool/metaSub read named fields out of the snapshot.json map.
+// shortPID renders a recorded agent pid, or "-" when there is none.
+//
+// 0 is not a pid. It is what a status file written before StatusFile.AgentPID
+// existed leaves behind — every session already running across an upgrade — and
+// it is exactly the state in which conversationSucceeds returns known=false, so
+// the pid recovery cannot run at all. Printing "0" spells "the mechanism was
+// unavailable" as "here is the pid", which is the opposite of what this row is
+// for. "-" matches how shortSessionID spells an absent id.
+func shortPID(pid int) string {
+	if pid <= 0 {
+		return "-"
+	}
+	return strconv.Itoa(pid)
+}
+
+// metaString/metaInt/metaSub read named fields out of the snapshot.json map.
 //
 // Everything filed goes through these. The map is NOT marshalled wholesale —
 // it embeds hook.file_contents.user_prompt, the reporter's verbatim prompt
@@ -384,6 +400,23 @@ func metaSub(m map[string]any, key string) map[string]any {
 	}
 	sub, _ := m[key].(map[string]any)
 	return sub
+}
+
+// metaInt reads a numeric field. The map is built in-process (int), but a
+// snapshot.json round-tripped through encoding/json yields float64 — accept both
+// so a reader of a persisted capture gets the same answer as the live dialog.
+func metaInt(m map[string]any, key string) int {
+	if m == nil {
+		return 0
+	}
+	switch v := m[key].(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	default:
+		return 0
+	}
 }
 
 func metaString(m map[string]any, key string) string {
@@ -453,21 +486,37 @@ func buildStatusReportBody(desc string, expected session.Status, f *statusReport
 	if ev := metaString(metaSub(hook, "file_contents"), "event"); ev != "" {
 		fmt.Fprintf(&b, "| hook event (on disk) | `%s` |\n", ev)
 	}
+	// Only a divergence too large to be lag gets the bold. Applied lags disk by
+	// design, so a capture landing mid-write reads false benignly — bolding that
+	// trains people to quote the row without reading the ages that qualify it.
 	if am := metaString(hook, "applied_matches_file"); am != "" {
-		fmt.Fprintf(&b, "| **applied matches disk** | **%s** |\n", am)
+		switch {
+		case am != "false":
+			fmt.Fprintf(&b, "| applied matches disk | %s |\n", am)
+		case metaString(hook, "divergence_significant") == "true":
+			fmt.Fprintf(&b, "| **applied matches disk** | **false** (applied hook is %s old) |\n", metaString(hook, "age"))
+		case metaString(hook, "file_newer_by") != "":
+			fmt.Fprintf(&b, "| applied matches disk | false (file %s newer — in flight) |\n", metaString(hook, "file_newer_by"))
+		default:
+			fmt.Fprintf(&b, "| applied matches disk | false |\n")
+		}
 	}
 	fmt.Fprintf(&b, "| hook age (applied) | %s |\n", metaString(hook, "age"))
 	if fa := metaString(hook, "file_age"); fa != "" {
 		fmt.Fprintf(&b, "| hook file age (on disk) | %s |\n", fa)
 	}
-	// Ownership: a hook whose session_id is not the owner is dropped, and for a
-	// non-Claude agent it can never be adopted (the rotation check reads Claude
-	// transcripts), so it is dropped for the session's life. Short ids — enough to
-	// answer "same or different", which is the whole question.
+	// Ownership: a hook whose session_id is not the owner is dropped. For a
+	// non-Claude agent the transcript check that decides "rotation or nested child?"
+	// can never resolve — it reads Claude transcripts — so the pair is neg-cached
+	// and recovery falls entirely to comparing the two agent pids
+	// (conversationSucceeds, which has no agent gate). That is why the pid sits here
+	// beside the ids: without it there is no telling a gate that could not decide
+	// from one that decided against. Short ids — enough to answer "same or
+	// different", which is the whole question.
 	if hookSess, ownerSess := metaString(hook, "file_session_id"), metaString(hook, "owner_session_id"); hookSess != "" || ownerSess != "" {
 		fmt.Fprintf(&b, "| hook session (on disk) | `%s` |\n", shortSessionID(hookSess))
 		fmt.Fprintf(&b, "| owner session (latched) | `%s` |\n", shortSessionID(ownerSess))
-		fmt.Fprintf(&b, "| owner pid | %s |\n", metaString(hook, "owner_pid"))
+		fmt.Fprintf(&b, "| owner pid | %s |\n", shortPID(metaInt(hook, "owner_pid")))
 	}
 	if ov := metaString(hook, "overridden_at"); ov != "" {
 		fmt.Fprintf(&b, "| hook overridden | %s ago |\n", ov)

--- a/internal/ui/statusreport.go
+++ b/internal/ui/statusreport.go
@@ -356,6 +356,21 @@ func sanitizeHome(s string) string {
 	return strings.ReplaceAll(s, home, "~")
 }
 
+// shortSessionID trims an agent session id to its leading block for the issue
+// table. The only question asked of these ids is whether the one on disk is the
+// one fleet latched onto, and 8 hex chars settle that without pasting two full
+// UUIDs into a public issue. "-" reads as absent, where an empty cell would look
+// like a rendering bug.
+func shortSessionID(id string) string {
+	if id == "" {
+		return "-"
+	}
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
 // metaString/metaBool/metaSub read named fields out of the snapshot.json map.
 //
 // Everything filed goes through these. The map is NOT marshalled wholesale —
@@ -426,11 +441,34 @@ func buildStatusReportBody(desc string, expected session.Status, f *statusReport
 	b.WriteString("| Signal | Value |\n|--------|-------|\n")
 	fmt.Fprintf(&b, "| agent | `%s` |\n", f.agent)
 	fmt.Fprintf(&b, "| captured at | %s |\n", metaString(meta, "captured_at"))
-	fmt.Fprintf(&b, "| hook status | `%s` |\n", metaString(hook, "status"))
-	if ev := metaString(metaSub(hook, "file_contents"), "event"); ev != "" {
-		fmt.Fprintf(&b, "| hook event | `%s` |\n", ev)
+	// Applied vs on-disk are two different sources read at the same instant, so they
+	// are labelled as such. Reading one row as "the hook status" is what turns a
+	// dropped-hook report into a guess: the handler maps event→status
+	// deterministically, so `Stop` next to an applied `running` means fleet is not
+	// applying the file at all — a fact worth stating rather than re-deriving.
+	fmt.Fprintf(&b, "| hook status (applied) | `%s` |\n", metaString(hook, "status"))
+	if fs := metaString(hook, "file_status"); fs != "" {
+		fmt.Fprintf(&b, "| hook status (on disk) | `%s` |\n", fs)
 	}
-	fmt.Fprintf(&b, "| hook age | %s |\n", metaString(hook, "age"))
+	if ev := metaString(metaSub(hook, "file_contents"), "event"); ev != "" {
+		fmt.Fprintf(&b, "| hook event (on disk) | `%s` |\n", ev)
+	}
+	if am := metaString(hook, "applied_matches_file"); am != "" {
+		fmt.Fprintf(&b, "| **applied matches disk** | **%s** |\n", am)
+	}
+	fmt.Fprintf(&b, "| hook age (applied) | %s |\n", metaString(hook, "age"))
+	if fa := metaString(hook, "file_age"); fa != "" {
+		fmt.Fprintf(&b, "| hook file age (on disk) | %s |\n", fa)
+	}
+	// Ownership: a hook whose session_id is not the owner is dropped, and for a
+	// non-Claude agent it can never be adopted (the rotation check reads Claude
+	// transcripts), so it is dropped for the session's life. Short ids — enough to
+	// answer "same or different", which is the whole question.
+	if hookSess, ownerSess := metaString(hook, "file_session_id"), metaString(hook, "owner_session_id"); hookSess != "" || ownerSess != "" {
+		fmt.Fprintf(&b, "| hook session (on disk) | `%s` |\n", shortSessionID(hookSess))
+		fmt.Fprintf(&b, "| owner session (latched) | `%s` |\n", shortSessionID(ownerSess))
+		fmt.Fprintf(&b, "| owner pid | %s |\n", metaString(hook, "owner_pid"))
+	}
 	if ov := metaString(hook, "overridden_at"); ov != "" {
 		fmt.Fprintf(&b, "| hook overridden | %s ago |\n", ov)
 	}

--- a/internal/ui/statusreport_test.go
+++ b/internal/ui/statusreport_test.go
@@ -34,8 +34,11 @@ func statusFormFixture() *statusReportForm {
 				"file_session_id":      "61fd77f6-2b1a-4c0d-9e88-1122aabbccdd",
 				"file_age":             "1.2s",
 				"applied_matches_file": false,
-				"owner_session_id":     "0aa11bb2-3c4d-5e6f-8899-aabbccddeeff",
-				"owner_pid":            4242,
+				// Far enough behind that lag can't explain it — the dropped-hook shape.
+				"divergence_significant": true,
+				"file_newer_by":          "5m33s",
+				"owner_session_id":       "0aa11bb2-3c4d-5e6f-8899-aabbccddeeff",
+				"owner_pid":              4242,
 				"file_contents": map[string]any{
 					"event":       "PermissionRequest",
 					"user_prompt": secretPrompt,
@@ -134,6 +137,69 @@ func TestBuildStatusReportBody_CarriesAppliedVsDiskDivergence(t *testing.T) {
 	// pasting full conversation ids into a public issue.
 	if strings.Contains(body, "61fd77f6-2b1a-4c0d-9e88-1122aabbccdd") {
 		t.Fatal("issue body carried a full session id; want the shortened form")
+	}
+}
+
+// The applied hook lags disk by design (fsnotify debounce + a worker cycle), so a
+// capture landing mid-write reads `false` for the same reason a dropped hook does.
+// Only the gap tells them apart, so only the large gap gets the bold — otherwise
+// the loudest row in the table cries wolf on a healthy session.
+func TestBuildStatusReportBody_BoldsOnlySignificantDivergence(t *testing.T) {
+	r := &diagnostics.Report{Version: "v2.22.0", OS: "darwin", Arch: "arm64"}
+
+	significant := statusFormFixture()
+	significant.includeContent = false
+	body := buildStatusReportBody("desc", session.StatusIdle, significant, r)
+	if !strings.Contains(body, "| **applied matches disk** | **false** (applied hook is 5m34s old) |") {
+		t.Fatalf("a real divergence should be bolded and dated:\n%s", body)
+	}
+
+	// Same false, gap under divergenceLagGrace: a write still in flight.
+	inFlight := statusFormFixture()
+	inFlight.includeContent = false
+	hook := inFlight.snap.meta["hook"].(map[string]any)
+	hook["divergence_significant"] = false
+	hook["file_newer_by"] = "412ms"
+	body = buildStatusReportBody("desc", session.StatusIdle, inFlight, r)
+	if !strings.Contains(body, "| applied matches disk | false (file 412ms newer — in flight) |") {
+		t.Fatalf("an in-flight write should render unbolded and qualified:\n%s", body)
+	}
+	if strings.Contains(body, "**applied matches disk**") {
+		t.Fatalf("in-flight divergence must not be bolded:\n%s", body)
+	}
+}
+
+// 0 is not a pid — it is "no pid was recorded", which is exactly the state where
+// conversationSucceeds returns known=false and the recovery cannot run. Rendering
+// it as `0` disguises an unavailable mechanism as a reading.
+func TestBuildStatusReportBody_UnknownOwnerPIDRendersAsAbsent(t *testing.T) {
+	f := statusFormFixture()
+	f.includeContent = false
+	f.snap.meta["hook"].(map[string]any)["owner_pid"] = 0
+	r := &diagnostics.Report{Version: "v2.22.0", OS: "darwin", Arch: "arm64"}
+
+	body := buildStatusReportBody("desc", session.StatusIdle, f, r)
+
+	if !strings.Contains(body, "| owner pid | - |") {
+		t.Fatalf("unknown owner pid should render as `-`:\n%s", body)
+	}
+	if strings.Contains(body, "| owner pid | 0 |") {
+		t.Fatal("owner pid 0 rendered as a pid")
+	}
+}
+
+func TestShortPID(t *testing.T) {
+	for _, tc := range []struct {
+		pid  int
+		want string
+	}{
+		{0, "-"},
+		{-1, "-"},
+		{4242, "4242"},
+	} {
+		if got := shortPID(tc.pid); got != tc.want {
+			t.Errorf("shortPID(%d) = %q, want %q", tc.pid, got, tc.want)
+		}
 	}
 }
 

--- a/internal/ui/statusreport_test.go
+++ b/internal/ui/statusreport_test.go
@@ -28,12 +28,18 @@ func statusFormFixture() *statusReportForm {
 		meta: map[string]any{
 			"captured_at": "2026-07-22T14:00:00Z",
 			"hook": map[string]any{
-				"status": "waiting",
-				"age":    "5m34s",
+				"status":               "waiting",
+				"age":                  "5m34s",
+				"file_status":          "running",
+				"file_session_id":      "61fd77f6-2b1a-4c0d-9e88-1122aabbccdd",
+				"file_age":             "1.2s",
+				"applied_matches_file": false,
+				"owner_session_id":     "0aa11bb2-3c4d-5e6f-8899-aabbccddeeff",
+				"owner_pid":            4242,
 				"file_contents": map[string]any{
 					"event":       "PermissionRequest",
 					"user_prompt": secretPrompt,
-					"session_id":  "61fd77f6",
+					"session_id":  "61fd77f6-2b1a-4c0d-9e88-1122aabbccdd",
 				},
 			},
 			"detection": map[string]any{
@@ -93,6 +99,64 @@ func TestBuildStatusReportBody_AlwaysCarriesSignals(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Fatalf("signals block missing %q:\n%s", want, body)
 		}
+	}
+}
+
+// Issue #220 arrived showing `hook status: running` beside `hook event: Stop` —
+// two rows read from different sources (memory vs the file on disk) under labels
+// that implied one. Since the handler maps event→status deterministically, that
+// pair means fleet was not applying the file at all, but the report gave no way
+// to tell WHY: the session ids that decide it were captured and then dropped on
+// the way to the issue body. These rows are what makes the next one answerable
+// without a follow-up round trip.
+func TestBuildStatusReportBody_CarriesAppliedVsDiskDivergence(t *testing.T) {
+	f := statusFormFixture()
+	f.includeContent = false
+	r := &diagnostics.Report{Version: "v2.22.0", OS: "darwin", Arch: "arm64"}
+
+	body := buildStatusReportBody("stuck running forever", session.StatusIdle, f, r)
+
+	for _, want := range []string{
+		"hook status (applied) | `waiting`",
+		"hook status (on disk) | `running`",
+		"applied matches disk", "false",
+		"hook file age (on disk) | 1.2s",
+		"hook session (on disk) | `61fd77f6`",
+		"owner session (latched) | `0aa11bb2`",
+		"owner pid | 4242",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("divergence rows missing %q:\n%s", want, body)
+		}
+	}
+
+	// Short ids are the point: enough to answer "same or different" without
+	// pasting full conversation ids into a public issue.
+	if strings.Contains(body, "61fd77f6-2b1a-4c0d-9e88-1122aabbccdd") {
+		t.Fatal("issue body carried a full session id; want the shortened form")
+	}
+}
+
+// A session that has never had a hook has neither file nor owner. The rows must
+// drop out rather than render blank or "0" cells that read as real readings.
+func TestBuildStatusReportBody_OmitsDivergenceRowsWithoutHookFile(t *testing.T) {
+	f := statusFormFixture()
+	f.includeContent = false
+	hook := f.snap.meta["hook"].(map[string]any)
+	for _, k := range []string{"file_status", "file_session_id", "file_age", "applied_matches_file", "owner_session_id", "owner_pid", "file_contents"} {
+		delete(hook, k)
+	}
+	r := &diagnostics.Report{Version: "v2.22.0", OS: "darwin", Arch: "arm64"}
+
+	body := buildStatusReportBody("desc", session.StatusIdle, f, r)
+
+	for _, unwanted := range []string{"hook status (on disk)", "applied matches disk", "owner session (latched)"} {
+		if strings.Contains(body, unwanted) {
+			t.Fatalf("row %q rendered with no hook file:\n%s", unwanted, body)
+		}
+	}
+	if !strings.Contains(body, "hook status (applied)") {
+		t.Fatal("applied status must still render")
 	}
 }
 


### PR DESCRIPTION
## What

`syncHookStatuses` is the **only** production caller of `UpdateHookStatus`, and it rebuilds the `HookStatus` field by field. `AgentPID` was left out.

So both sides of `conversationSucceeds(ownerPID, hs.AgentPID)` were always `0` → it returns `known=false` → the neg-cached rotation is never released → a session pinned to a conversation that already ended stays pinned for its whole life. `ownerConversationAbandoned` is the only fallback, and it returns `false` on unreadable transcripts.

That is the **v2.24.0 "Stuck sessions recover" fix, shipped inert** (#229).

## Why it wasn't caught

Every test in `ownership_test.go` injects `AgentPID` straight into `UpdateHookStatus`:

```go
s.UpdateHookStatus(&HookStatus{Status: "waiting", SessionID: "live-bbb", AgentPID: livePID}, true)
```

The gate's logic is well covered. The **seam** carrying data into it was not, so the whole feature stayed green while production ran blind.

`TestSyncHookStatusesPropagatesAgentPID` closes that: it writes a real status file, lets the real watcher load it, calls `syncHookStatuses`, and asserts on the reconstructed struct — so a dropped field fails *there*, not in the gate. Verified it fails on the unfixed code with `ownerPID = 0, want 82501`.

## Also: make wrong-status reports self-diagnosing

Found while investigating #220, which arrived showing:

| hook status | hook event |
|---|---|
| `running` | `Stop` |

Those are two different sources under labels implying one — `hook status` is in-memory, `hook event` is read fresh off disk. `mapEventToStatus` maps `Stop`→`finished` deterministically, so no single file can hold that pair: fleet was 18h27m behind the file and not applying it. But the report couldn't say **why** — the conversation ids that decide it are captured at `!` and then dropped before the issue body is built.

The signals table now carries:

- `hook status (applied)` vs `hook status (on disk)`, and a computed **`applied matches disk`**
- `hook session (on disk)` vs `owner session (latched)` — shortened to 8 chars, enough to answer "same or different" without pasting full ids into a public issue
- `owner pid`, and the hook file's own age alongside the applied age

Governing rule is unchanged: allowlisted field reads only, never a marshal of the snapshot map (`hook.file_contents.user_prompt` is the reporter's verbatim prompt). `TestBuildStatusReportBody_NeverLeaksUserPrompt` still passes; the new rows add a full-id leak check of their own.

## Not fixed here

#220's root cause is **still unconfirmed** — it narrows to (a) the ownership gate rejecting the later hooks, or (b) a lost watcher entry, and the deciding field was discarded before the report was written. This PR may well fix it outright if (a); the new rows settle it if it recurs.

**Correction (was wrong in the original description).** I first wrote that a Codex session can never be adopted and stays rejected for its life. That was true *until this PR*. `conversationSucceeds` is pure pid math with no agent gate, and `UpdateHookStatus` has no agent check — so once `AgentPID` flows, a neg-cached Codex pair recovers on pids. `sessionRotationVerdict` still can't resolve a non-Claude rotation (it reads Claude transcripts), so such a pair always neg-caches first and recovery rests entirely on the pid path. Thanks @hayke102 for catching it.

## Test plan

- `go test -race ./...` green
- `TestSyncHookStatusesPropagatesAgentPID` fails on unfixed code, passes here
- `make build` clean

Refs #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJTDzXNbPxHRyzkrEP27Pj
