### PR TITLE
fix(github): stop a superseded run's failure from reddening the badge

### DIFF
--- a/changelog/unreleased/stale-ci-failure.md
+++ b/changelog/unreleased/stale-ci-failure.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**Red PR badge means act now** — a check that failed in an earlier run no longer shows red while the same workflow is running again, so a gate that goes red before its suites are triggered reads as pending until the real verdict lands.
+**Stale CI failures** — A PR badge no longer goes red for a failure a later run of the same workflow is already recomputing; you see pending until the new verdict lands.

--- a/changelog/unreleased/stale-ci-failure.md
+++ b/changelog/unreleased/stale-ci-failure.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Red PR badge means act now** — a check that failed in an earlier run no longer shows red while the same workflow is running again, so a gate that goes red before its suites are triggered reads as pending until the real verdict lands.

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os/exec"
 	"path"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -106,6 +108,7 @@ type statusCheckEntry struct {
 	Conclusion   string `json:"conclusion"`
 	StartedAt    string `json:"startedAt"`    // RFC3339; used to pick the latest run when a check has several
 	WorkflowName string `json:"workflowName"` // empty for status contexts; called workflows report their caller
+	DetailsURL   string `json:"detailsUrl"`   // .../actions/runs/<run>/job/<job> for check runs; carries run identity
 }
 
 // GetPRForBranch returns the PR associated with the current branch, or nil if none.
@@ -280,17 +283,42 @@ func isInFlightCheck(c statusCheckEntry) bool {
 	return c.Conclusion == ""
 }
 
-// newestInFlightPerWorkflow returns, per workflow, the StartedAt of the most
-// recently started check still running. Status contexts (no workflow) are
-// excluded: they'd all share the "" key and suppress each other unrelated.
-func newestInFlightPerWorkflow(checks []statusCheckEntry) map[string]string {
-	newest := make(map[string]string)
+var runIDPattern = regexp.MustCompile(`/actions/runs/(\d+)`)
+
+// runID extracts the workflow run id from a check run's details URL
+// (`.../actions/runs/<run_id>/job/<job_id>`), or 0 when there is none —
+// status contexts point wherever their publisher likes.
+//
+// Run identity has to come from here because the rollup's own timestamps are
+// per *job*: jobs of one run start seconds to minutes apart (`needs:` chains,
+// runner acquisition), so comparing StartedAt cannot tell a later run from a
+// later-starting sibling of the same run.
+func runID(c statusCheckEntry) int64 {
+	m := runIDPattern.FindStringSubmatch(c.DetailsURL)
+	if m == nil {
+		return 0
+	}
+	id, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0 // absurdly long digit string; treat as unidentified
+	}
+	return id
+}
+
+// newestInFlightRunPerWorkflow returns, per workflow, the highest run id that
+// still has a check running. Run ids ascend over time within a repo, so a
+// greater id is a later run.
+//
+// Status contexts (no workflow) are excluded: they'd all share the "" key and
+// suppress each other unrelated.
+func newestInFlightRunPerWorkflow(checks []statusCheckEntry) map[string]int64 {
+	newest := make(map[string]int64)
 	for _, c := range checks {
 		if c.WorkflowName == "" || !isInFlightCheck(c) {
 			continue
 		}
-		if c.StartedAt > newest[c.WorkflowName] {
-			newest[c.WorkflowName] = c.StartedAt
+		if id := runID(c); id > newest[c.WorkflowName] {
+			newest[c.WorkflowName] = id
 		}
 	}
 	return newest
@@ -302,9 +330,14 @@ func newestInFlightPerWorkflow(checks []statusCheckEntry) map[string]string {
 // FAILURE is reserved for failures worth acting on. A workflow that re-runs
 // under a different job name — a gate that publishes a verdict before its
 // suites are triggered, say — leaves a red job behind from the earlier run,
-// and latestRunPerCheck can't collapse it because the names differ. Once that
-// same workflow is running again, its old verdict is being recomputed, so it
-// reports PENDING (wait) rather than FAILURE (go look).
+// and latestRunPerCheck can't collapse it because the names differ. Once a
+// *later run* of that same workflow is going, the old verdict is being
+// recomputed, so it reports PENDING (wait) rather than FAILURE (go look).
+//
+// "Later run" is a strictly greater run id, never a later timestamp: a failure
+// must still go red while its own run's other jobs finish. A failure whose run
+// id doesn't parse is never suppressed — an unrecognized URL shape should cost
+// a false red, not a missed one.
 func deriveCIStatus(checks []statusCheckEntry, ignorePatterns []string) string {
 	if len(checks) == 0 {
 		return ""
@@ -317,7 +350,7 @@ func deriveCIStatus(checks []statusCheckEntry, ignorePatterns []string) string {
 		}
 		considered = append(considered, c)
 	}
-	inFlight := newestInFlightPerWorkflow(considered)
+	inFlightRun := newestInFlightRunPerWorkflow(considered)
 
 	hasFailure := false
 	hasPending := false
@@ -325,8 +358,8 @@ func deriveCIStatus(checks []statusCheckEntry, ignorePatterns []string) string {
 	for _, check := range considered {
 		switch {
 		case isFailedCheck(check):
-			if since, ok := inFlight[check.WorkflowName]; ok && check.StartedAt < since {
-				continue // superseded by a newer run of the same workflow
+			if id := runID(check); id != 0 && inFlightRun[check.WorkflowName] > id {
+				continue // superseded by a later run of the same workflow
 			}
 			hasFailure = true
 		case isInFlightCheck(check):

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -101,10 +101,11 @@ type ghPRResponse struct {
 }
 
 type statusCheckEntry struct {
-	Name       string `json:"name"`
-	Status     string `json:"status"`
-	Conclusion string `json:"conclusion"`
-	StartedAt  string `json:"startedAt"` // RFC3339; used to pick the latest run when a check has several
+	Name         string `json:"name"`
+	Status       string `json:"status"`
+	Conclusion   string `json:"conclusion"`
+	StartedAt    string `json:"startedAt"`    // RFC3339; used to pick the latest run when a check has several
+	WorkflowName string `json:"workflowName"` // empty for status contexts; called workflows report their caller
 }
 
 // GetPRForBranch returns the PR associated with the current branch, or nil if none.
@@ -263,26 +264,72 @@ func latestRunPerCheck(checks []statusCheckEntry) []statusCheckEntry {
 	return out
 }
 
+func isFailedCheck(c statusCheckEntry) bool {
+	switch strings.ToUpper(c.Conclusion) {
+	case "FAILURE", "ERROR", "TIMED_OUT":
+		return true
+	}
+	return false
+}
+
+func isInFlightCheck(c statusCheckEntry) bool {
+	switch strings.ToUpper(c.Status) {
+	case "IN_PROGRESS", "QUEUED", "PENDING":
+		return true
+	}
+	return c.Conclusion == ""
+}
+
+// newestInFlightPerWorkflow returns, per workflow, the StartedAt of the most
+// recently started check still running. Status contexts (no workflow) are
+// excluded: they'd all share the "" key and suppress each other unrelated.
+func newestInFlightPerWorkflow(checks []statusCheckEntry) map[string]string {
+	newest := make(map[string]string)
+	for _, c := range checks {
+		if c.WorkflowName == "" || !isInFlightCheck(c) {
+			continue
+		}
+		if c.StartedAt > newest[c.WorkflowName] {
+			newest[c.WorkflowName] = c.StartedAt
+		}
+	}
+	return newest
+}
+
 // deriveCIStatus determines overall CI status from status check rollup.
 // Checks whose name matches any ignorePatterns glob are dropped before rollup.
+//
+// FAILURE is reserved for failures worth acting on. A workflow that re-runs
+// under a different job name — a gate that publishes a verdict before its
+// suites are triggered, say — leaves a red job behind from the earlier run,
+// and latestRunPerCheck can't collapse it because the names differ. Once that
+// same workflow is running again, its old verdict is being recomputed, so it
+// reports PENDING (wait) rather than FAILURE (go look).
 func deriveCIStatus(checks []statusCheckEntry, ignorePatterns []string) string {
 	if len(checks) == 0 {
 		return ""
 	}
 
+	considered := make([]statusCheckEntry, 0, len(checks))
+	for _, c := range latestRunPerCheck(checks) {
+		if matchesAnyPattern(c.Name, ignorePatterns) {
+			continue
+		}
+		considered = append(considered, c)
+	}
+	inFlight := newestInFlightPerWorkflow(considered)
+
 	hasFailure := false
 	hasPending := false
 
-	for _, check := range latestRunPerCheck(checks) {
-		if matchesAnyPattern(check.Name, ignorePatterns) {
-			continue
-		}
-		conclusion := strings.ToUpper(check.Conclusion)
-		status := strings.ToUpper(check.Status)
-
-		if conclusion == "FAILURE" || conclusion == "ERROR" || conclusion == "TIMED_OUT" {
+	for _, check := range considered {
+		switch {
+		case isFailedCheck(check):
+			if since, ok := inFlight[check.WorkflowName]; ok && check.StartedAt < since {
+				continue // superseded by a newer run of the same workflow
+			}
 			hasFailure = true
-		} else if status == "IN_PROGRESS" || status == "QUEUED" || status == "PENDING" || conclusion == "" {
+		case isInFlightCheck(check):
 			hasPending = true
 		}
 	}

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -207,10 +207,26 @@ func TestDeriveCIStatus(t *testing.T) {
 	}
 }
 
+// jobURL is the details URL shape GitHub gives a check run. Run identity comes
+// from here, so every fixture below must carry one to mean anything.
+func jobURL(run, job string) string {
+	return "https://github.com/brizzai/fleet/actions/runs/" + run + "/job/" + job
+}
+
+// Run ids of the two real runs this was found on: a push run whose gate went red
+// before the suites were triggered, then the run a /e2e comment started.
+const (
+	pushRun    = "30754985996"
+	labeledRun = "30755192426"
+)
+
 // A gate job that publishes its verdict before the suites it gates are
 // triggered goes red, then goes green in a later run of the same workflow.
 // Between the two, the stale red must not read as "this needs you" — the
 // workflow is already recomputing it.
+//
+// The timestamps below are deliberately arranged so that comparing StartedAt
+// instead of run id would give the wrong answer in both directions.
 func TestDeriveCIStatusSupersededFailure(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -219,23 +235,43 @@ func TestDeriveCIStatusSupersededFailure(t *testing.T) {
 		want   string
 	}{
 		{
-			"stale gate failure while its workflow re-runs",
+			"stale gate failure while a later run of its workflow is going",
 			[]statusCheckEntry{
 				{Name: "heavy_gate", Status: "COMPLETED", Conclusion: "FAILURE",
-					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests"},
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: jobURL(pushRun, "91515571601")},
 				{Name: "E2E / E2E Tests", Status: "IN_PROGRESS",
-					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests"},
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: jobURL(labeledRun, "91516663251")},
 			},
 			nil,
 			"PENDING",
 		},
 		{
-			"failure newer than the in-flight check still counts",
+			// The regression the run id exists for: one run, jobs staggered by
+			// `needs:` chains and runner acquisition. A finished failure here is
+			// final and actionable no matter what its siblings are still doing.
+			"a later-starting sibling of the same run never suppresses",
+			[]statusCheckEntry{
+				{Name: "golangci-lint", Status: "COMPLETED", Conclusion: "FAILURE",
+					StartedAt: "2026-08-02T15:44:27Z", WorkflowName: "CI - Merge Gatekeeper",
+					DetailsURL: jobURL("30754985868", "91515665758")},
+				{Name: "Core Tests", Status: "IN_PROGRESS",
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Merge Gatekeeper",
+					DetailsURL: jobURL("30754985868", "91515868760")},
+			},
+			nil,
+			"FAILURE",
+		},
+		{
+			"a failure in the newer run outranks an in-flight job of the older one",
 			[]statusCheckEntry{
 				{Name: "E2E / E2E Tests", Status: "COMPLETED", Conclusion: "FAILURE",
-					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests"},
-				{Name: "E2E / Cleanup", Status: "IN_PROGRESS",
-					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests"},
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: jobURL(labeledRun, "91516663251")},
+				{Name: "E2E / Preflight", Status: "IN_PROGRESS",
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: jobURL(pushRun, "91515571784")},
 			},
 			nil,
 			"FAILURE",
@@ -244,20 +280,38 @@ func TestDeriveCIStatusSupersededFailure(t *testing.T) {
 			"another workflow running does not excuse this one's failure",
 			[]statusCheckEntry{
 				{Name: "heavy_gate", Status: "COMPLETED", Conclusion: "FAILURE",
-					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests"},
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: jobURL(pushRun, "91515571601")},
 				{Name: "Core Tests", Status: "IN_PROGRESS",
-					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Merge Gatekeeper"},
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Merge Gatekeeper",
+					DetailsURL: jobURL("30754985868", "91515868760")},
 			},
 			nil,
 			"FAILURE",
 		},
 		{
+			// Status contexts carry no workflow and an arbitrary URL, so neither
+			// half of the key exists. They must never suppress anything.
 			"status contexts share no workflow, so they never suppress",
 			[]statusCheckEntry{
 				{Name: "validate", Status: "COMPLETED", Conclusion: "FAILURE",
 					StartedAt: "2026-08-02T15:45:07Z"},
 				{Name: "gitStream.cm", Status: "IN_PROGRESS",
-					StartedAt: "2026-08-02T15:49:12Z"},
+					StartedAt: "2026-08-02T15:49:12Z", DetailsURL: "https://docs.gitstream.cm/examples/"},
+			},
+			nil,
+			"FAILURE",
+		},
+		{
+			// An unrecognized URL shape costs a false red, never a missed one.
+			"a failure with no parseable run id is never suppressed",
+			[]statusCheckEntry{
+				{Name: "heavy_gate", Status: "COMPLETED", Conclusion: "FAILURE",
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: "https://ci.example.com/build/7"},
+				{Name: "E2E / E2E Tests", Status: "IN_PROGRESS",
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: jobURL(labeledRun, "91516663251")},
 			},
 			nil,
 			"FAILURE",
@@ -266,11 +320,14 @@ func TestDeriveCIStatusSupersededFailure(t *testing.T) {
 			"suppressed failure does not mask a live one elsewhere",
 			[]statusCheckEntry{
 				{Name: "heavy_gate", Status: "COMPLETED", Conclusion: "FAILURE",
-					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests"},
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: jobURL(pushRun, "91515571601")},
 				{Name: "E2E / E2E Tests", Status: "IN_PROGRESS",
-					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests"},
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: jobURL(labeledRun, "91516663251")},
 				{Name: "Core Tests", Status: "COMPLETED", Conclusion: "FAILURE",
-					StartedAt: "2026-08-02T15:44:00Z", WorkflowName: "CI - Merge Gatekeeper"},
+					StartedAt: "2026-08-02T15:44:00Z", WorkflowName: "CI - Merge Gatekeeper",
+					DetailsURL: jobURL("30754985868", "91515868760")},
 			},
 			nil,
 			"FAILURE",
@@ -279,9 +336,11 @@ func TestDeriveCIStatusSupersededFailure(t *testing.T) {
 			"an ignored in-flight check cannot suppress a failure",
 			[]statusCheckEntry{
 				{Name: "heavy_gate", Status: "COMPLETED", Conclusion: "FAILURE",
-					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests"},
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: jobURL(pushRun, "91515571601")},
 				{Name: "E2E / Flaky", Status: "IN_PROGRESS",
-					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests"},
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests",
+					DetailsURL: jobURL(labeledRun, "91516663252")},
 			},
 			[]string{"E2E / Flaky"},
 			"FAILURE",

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -206,3 +206,93 @@ func TestDeriveCIStatus(t *testing.T) {
 		})
 	}
 }
+
+// A gate job that publishes its verdict before the suites it gates are
+// triggered goes red, then goes green in a later run of the same workflow.
+// Between the two, the stale red must not read as "this needs you" — the
+// workflow is already recomputing it.
+func TestDeriveCIStatusSupersededFailure(t *testing.T) {
+	tests := []struct {
+		name   string
+		checks []statusCheckEntry
+		ignore []string
+		want   string
+	}{
+		{
+			"stale gate failure while its workflow re-runs",
+			[]statusCheckEntry{
+				{Name: "heavy_gate", Status: "COMPLETED", Conclusion: "FAILURE",
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests"},
+				{Name: "E2E / E2E Tests", Status: "IN_PROGRESS",
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests"},
+			},
+			nil,
+			"PENDING",
+		},
+		{
+			"failure newer than the in-flight check still counts",
+			[]statusCheckEntry{
+				{Name: "E2E / E2E Tests", Status: "COMPLETED", Conclusion: "FAILURE",
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests"},
+				{Name: "E2E / Cleanup", Status: "IN_PROGRESS",
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests"},
+			},
+			nil,
+			"FAILURE",
+		},
+		{
+			"another workflow running does not excuse this one's failure",
+			[]statusCheckEntry{
+				{Name: "heavy_gate", Status: "COMPLETED", Conclusion: "FAILURE",
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests"},
+				{Name: "Core Tests", Status: "IN_PROGRESS",
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Merge Gatekeeper"},
+			},
+			nil,
+			"FAILURE",
+		},
+		{
+			"status contexts share no workflow, so they never suppress",
+			[]statusCheckEntry{
+				{Name: "validate", Status: "COMPLETED", Conclusion: "FAILURE",
+					StartedAt: "2026-08-02T15:45:07Z"},
+				{Name: "gitStream.cm", Status: "IN_PROGRESS",
+					StartedAt: "2026-08-02T15:49:12Z"},
+			},
+			nil,
+			"FAILURE",
+		},
+		{
+			"suppressed failure does not mask a live one elsewhere",
+			[]statusCheckEntry{
+				{Name: "heavy_gate", Status: "COMPLETED", Conclusion: "FAILURE",
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests"},
+				{Name: "E2E / E2E Tests", Status: "IN_PROGRESS",
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests"},
+				{Name: "Core Tests", Status: "COMPLETED", Conclusion: "FAILURE",
+					StartedAt: "2026-08-02T15:44:00Z", WorkflowName: "CI - Merge Gatekeeper"},
+			},
+			nil,
+			"FAILURE",
+		},
+		{
+			"an ignored in-flight check cannot suppress a failure",
+			[]statusCheckEntry{
+				{Name: "heavy_gate", Status: "COMPLETED", Conclusion: "FAILURE",
+					StartedAt: "2026-08-02T15:45:07Z", WorkflowName: "CI - Heavy Tests"},
+				{Name: "E2E / Flaky", Status: "IN_PROGRESS",
+					StartedAt: "2026-08-02T15:49:12Z", WorkflowName: "CI - Heavy Tests"},
+			},
+			[]string{"E2E / Flaky"},
+			"FAILURE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveCIStatus(tt.checks, tt.ignore); got != tt.want {
+				t.Errorf("deriveCIStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A red PR badge is supposed to mean *go look at this*. On a repo whose heavy tests are gated behind a `/e2e` comment, it didn't.

The gate job publishes its verdict on push — before the suites it gates have been triggered — so it goes red. Commenting `/e2e` starts a second run of the same workflow, which re-publishes the verdict green at the end. In between, `latestRunPerCheck` can't collapse the two: they're different job names (`heavy_gate` vs `E2E / E2E Tests`), so the stale red survived and the badge stayed FAILURE for the entire E2E run — pointing at a failure the workflow was already recomputing.

## Fix

Skip a failure when a **newer check of the same workflow is still running**. The badge reports PENDING (wait) instead of FAILURE (go look).

Observed shape:

| check | workflow | started | state |
|---|---|---|---|
| `heavy_gate` | CI - Heavy Tests | 15:45:07 | FAILURE |
| `E2E / E2E Tests` | CI - Heavy Tests | 15:49:12 | IN_PROGRESS |

Scoping is per workflow, so:
- a failure from a workflow that isn't re-running still goes red immediately
- another workflow running never excuses this one's failure
- status contexts (empty `workflowName`) are excluded — they'd share one key and suppress each other unrelated
- an ignored (`pr_checks.ignore`) in-flight check can't suppress anything, since the filter runs first

Requires `workflowName` from the rollup, which `gh pr view` already returns.

## Test

`TestDeriveCIStatusSupersededFailure` covers all six cases above. `go test -race ./internal/github/` and `make build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpQT3wMAS2wRGt4RoE83Ss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated failed checks from keeping a pull request blocked when a newer run for the same workflow is in progress.
  * Preserved accurate reporting for active failures, pending checks, ignored checks, and unrelated workflow failures.

* **Documentation**
  * Added an unreleased changelog entry describing the stale CI failure fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->