### PR TITLE
fix(ci): give every changelog fragment paragraph its own list marker

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -188,7 +188,12 @@ jobs:
               # awk's paragraph mode (RS="") splits on blank lines, so a wrapped
               # single paragraph still becomes ONE bullet — which the naive fix
               # of prefixing every line would have broken instead.
+              # sed first: RS="" splits on EMPTY lines, and a line holding a
+              # stray space or tab is not empty — so a fragment with invisible
+              # whitespace between paragraphs would collapse back into one
+              # bullet, which is the exact bug being fixed here.
               BODY=$(awk 'BEGIN{skip=1} /^---$/{if(skip){skip=0; next} else {found=1; next}} found{print}' "$f" \
+                | sed -E 's/^[[:space:]]+$//' \
                 | awk 'BEGIN{RS=""} {gsub(/\n/, " "); print "- " $0}')
               if [ -n "$TYPE" ] && [ -n "$BODY" ]; then
                 ENTRIES[$TYPE]+="${BODY}"$'\n'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -176,11 +176,24 @@ jobs:
             for f in "${FRAGMENTS[@]}"; do
               TYPE=$(awk '/^type:/{print $2; exit}' "$f")
               HL=$(awk '/^highlight:/{print $2; exit}' "$f")
-              BODY=$(awk 'BEGIN{skip=1} /^---$/{if(skip){skip=0; next} else {found=1; next}} found{print}' "$f" | sed '/^$/d')
+              # One BULLET PER PARAGRAPH, not one bullet per file.
+              #
+              # This used to be `sed '/^$/d'` with a single "- " prefixed to the
+              # whole body, so a fragment holding several items — which is what
+              # CLAUDE.md asks for, one idea per bullet — collapsed into one
+              # bullet followed by unmarked continuation lines. It was corrected
+              # by hand in v2.29.0 (c5e87b7, "restore the list markers the
+              # roll-up dropped") and would have shipped wrong again in v2.30.0.
+              #
+              # awk's paragraph mode (RS="") splits on blank lines, so a wrapped
+              # single paragraph still becomes ONE bullet — which the naive fix
+              # of prefixing every line would have broken instead.
+              BODY=$(awk 'BEGIN{skip=1} /^---$/{if(skip){skip=0; next} else {found=1; next}} found{print}' "$f" \
+                | awk 'BEGIN{RS=""} {gsub(/\n/, " "); print "- " $0}')
               if [ -n "$TYPE" ] && [ -n "$BODY" ]; then
-                ENTRIES[$TYPE]+="- ${BODY}"$'\n'
+                ENTRIES[$TYPE]+="${BODY}"$'\n'
                 if [ "$HL" = "true" ]; then
-                  HIGHLIGHTS+="- ${BODY}"$'\n'
+                  HIGHLIGHTS+="${BODY}"$'\n'
                 fi
               fi
             done


### PR DESCRIPTION
## The bug

A changelog fragment carrying several items — which is what `CLAUDE.md` asks for, *"one idea per bullet"* — renders as **one bullet followed by unmarked continuation lines**, in both the `### Highlights` block and its type section:

```markdown
### Highlights

- **Tickets become worktrees** — Type `BRZ-3182` in the `w` dialog…
**Agent starts briefed** — The session opens already told to read…
**Your tickets on `t`** — Each row shows whether it already has a…
```

The roller strips blank lines with `sed '/^$/d'` and then prefixes a single `- ` to the whole body, so only the first line gets a marker.

## Why now

**This is the second occurrence.** v2.29.0 shipped it and was corrected by hand in `c5e87b7` — *"restore the list markers the roll-up dropped"*. v2.30.0 reproduced it exactly and needed the same patch again (#256). Fixing the source so there isn't a third.

## The fix

awk's paragraph mode (`RS=""`) splits on blank lines, so each item becomes its own bullet — **and a single paragraph that merely wraps across source lines still becomes one bullet**, which the obvious fix of prefixing every line would have broken instead.

Verified against both shapes:

```
-- multi-item fragment --
- **Tickets become worktrees** — Type `BRZ-3182` in the `w` dialog…
- **Agent starts briefed** — The session opens already told to read…
- **Your tickets on `t`** — Each row shows whether it already has a…
- **Two ways to connect** — `Ctrl+K` → "Connect Linear" signs you in…

-- wrapped single paragraph (must stay ONE bullet) --
- A single paragraph that happens to wrap across two source lines.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBQUYTfR7kzUjgozd58mr6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved release note formatting by converting each non-empty changelog paragraph into its own bullet point.
  * Wrapped lines within paragraphs are now combined for clearer, more consistent entries.
  * The improved formatting is applied consistently to both type entries and highlights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->