### PR TITLE
docs(changelog): restore the list markers v2.0.0 and v2.5.0 shipped without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,16 +380,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Session titles now use Claude's own model-generated title. fleet reads Claude Code's `ai-title` from the conversation transcript — the same title that evolves as the work shifts — instead of guessing from your first prompt and re-running a heuristic every few prompts. An in-session `/rename` (`custom-title`) still takes precedence, and fleet's `R` rename always wins. When Claude writes no title (e.g. title generation disabled), the old prompt heuristic remains as a fallback. Claude's occasional kebab-case slug titles (e.g. `native-ai-title-integration`) are spaced out for readability (`native ai title integration`) with their casing preserved, so acronyms like `API` survive.
 - Sidebar redesigned around a calmer origin → checkout → session tree. Worktrees of the same GitHub repo collapse under one origin header (e.g. `brizzai/fleet`); no-remote repos get their own `local:<name>` group. `z` folds/unfolds idle sessions for a checkout; `u` is the new undo-delete (was `z`).
-Boot is now gated by a one-shot bootstrap that resolves every repo's origin + branch + PR status in parallel (8 workers, 6s deadline) — the sidebar paints once in its final shape instead of regrouping as data trickles in. While bootstrap runs, fleet shows a gradient FLEET wordmark splash with rotating ops-humor labels and a progress bar.
-Steady-state git/PR refresh now fans out across all session repos every 2s (bounded 4-worker pool) instead of round-robining one repo per tick, so branch/dirty/PR badges feel near-instant after any change.
+- Boot is now gated by a one-shot bootstrap that resolves every repo's origin + branch + PR status in parallel (8 workers, 6s deadline) — the sidebar paints once in its final shape instead of regrouping as data trickles in. While bootstrap runs, fleet shows a gradient FLEET wordmark splash with rotating ops-humor labels and a progress bar.
+- Steady-state git/PR refresh now fans out across all session repos every 2s (bounded 4-worker pool) instead of round-robining one repo per tick, so branch/dirty/PR badges feel near-instant after any change.
 - Sidebar and Preview now live in their own rounded-border cards with corner-inset titles (`╭─ Sessions ─...─╮` / `╭─ Preview ─...─╮`), so the two regions read as distinct surfaces instead of one stream split by a hairline. The focused panel switches its border to the accent color in focus mode.
-New `fleet-pink` flagship theme (accent `#ff77c6`) is the default for first-run users. Tokyo Night, Catppuccin Mocha, Rosé Pine, Nord and Gruvbox remain available via the `S` settings dialog.
-Sidebar cleanup: selected sessions drop the leading `▶` (it collided with the `▸` chevron used on collapsed headers — the inverted-background title was already carrying the selection signal). Worktree branch names render in italic so you can tell the main clone apart from its worktrees at a glance without an extra prefix column. In the default `icon` indicator mode, idle/starting sessions render a dim `·` anchor so the eye has a leftmost mark on every row (bar mode keeps them blank — the gutter bar carries the signal there). Selection background is one contiguous span across each row (PR badge and dirty marker sit inside the highlighted pill instead of bleeding out as separate boxes).
-Sidebar width is now responsive: targets 65 absolute columns capped at 45% of terminal width. On a Mac 14" (~150 cols) that's ~43% so long titles fit; on a wide monitor it shrinks to ~26% so the preview keeps its share. Scroll indicators replaced the `⋮` glyph (which rendered as `:` in some fonts) with `… N more above/below`.
-Visual rhythm pass: one blank row between origin groups carries the section break, and the indent tightened across the tree so long titles get more horizontal room. On boot, the cursor lands on the first session instead of the first origin, so your first keystroke does something useful.
-New `Status style` setting (`icon` default, or `bar` for a VS-Code gutter-style `┃`) lets you pick how non-idle state is shown. Toggle live in the settings dialog.
-Running/waiting/idle counts moved out of the top header and into a right-aligned pill embedded in the Sessions panel's top border, next to the title (`╭─ Sessions ── 2 RUN · 1 WAIT · 51 idle ─╮`). The header is just the `❯_ fleet` wordmark now.
-Command palette dims the underlying UI via an SGR-faint backdrop so it visually lifts above the content instead of merging with the preview pane.
+- New `fleet-pink` flagship theme (accent `#ff77c6`) is the default for first-run users. Tokyo Night, Catppuccin Mocha, Rosé Pine, Nord and Gruvbox remain available via the `S` settings dialog.
+- Sidebar cleanup: selected sessions drop the leading `▶` (it collided with the `▸` chevron used on collapsed headers — the inverted-background title was already carrying the selection signal). Worktree branch names render in italic so you can tell the main clone apart from its worktrees at a glance without an extra prefix column. In the default `icon` indicator mode, idle/starting sessions render a dim `·` anchor so the eye has a leftmost mark on every row (bar mode keeps them blank — the gutter bar carries the signal there). Selection background is one contiguous span across each row (PR badge and dirty marker sit inside the highlighted pill instead of bleeding out as separate boxes).
+- Sidebar width is now responsive: targets 65 absolute columns capped at 45% of terminal width. On a Mac 14" (~150 cols) that's ~43% so long titles fit; on a wide monitor it shrinks to ~26% so the preview keeps its share. Scroll indicators replaced the `⋮` glyph (which rendered as `:` in some fonts) with `… N more above/below`.
+- Visual rhythm pass: one blank row between origin groups carries the section break, and the indent tightened across the tree so long titles get more horizontal room. On boot, the cursor lands on the first session instead of the first origin, so your first keystroke does something useful.
+- New `Status style` setting (`icon` default, or `bar` for a VS-Code gutter-style `┃`) lets you pick how non-idle state is shown. Toggle live in the settings dialog.
+- Running/waiting/idle counts moved out of the top header and into a right-aligned pill embedded in the Sessions panel's top border, next to the title (`╭─ Sessions ── 2 RUN · 1 WAIT · 51 idle ─╮`). The header is just the `❯_ fleet` wordmark now.
+- Command palette dims the underlying UI via an SGR-faint backdrop so it visually lifts above the content instead of merging with the preview pane.
 
 ### Changed
 
@@ -476,12 +476,15 @@ Command palette dims the underlying UI via an SGR-faint backdrop so it visually 
 - Per-repo workspace config: `.fleet.json` / `.fleet.local.json` (legacy `.bc.json` / `.bc.local.json` still read for compatibility)
 - NMH manifest: `com.brizzai.fleet.tabcontrol.json`
 - Homebrew: `brew install brizzai/tap/fleet`
-**Auto-migration on first launch:** existing `~/.config/brizz-code/` is moved to `~/.config/fleet/`, live `brizzcode_*` tmux sessions are renamed to `fleet_*`, and stale `brizz-code hook-handler` entries are stripped from `~/.claude/settings.json`. Legacy `BRIZZ*` env vars are accepted as fallback for one release window so in-flight Claude processes survive the upgrade. The Chrome extension keeps the same extension ID (stable via `key` in manifest), so no reinstall is needed.
+- **Auto-migration on first launch:** existing `~/.config/brizz-code/` is moved to `~/.config/fleet/`, live `brizzcode_*` tmux sessions are renamed to `fleet_*`, and stale `brizz-code hook-handler` entries are stripped from `~/.claude/settings.json`. Legacy `BRIZZ*` env vars are accepted as fallback for one release window so in-flight Claude processes survive the upgrade. The Chrome extension keeps the same extension ID (stable via `key` in manifest), so no reinstall is needed.
+
 To upgrade from `brizz-code`:
+
 ```bash
 brew uninstall brizz-code
 brew install brizzai/tap/fleet
 ```
+
 Or run `fleet` directly — the migration shim handles config moves, tmux session renames, and hook cleanup transparently.
 
 ### Fixed


### PR DESCRIPTION
Backfill for the bug fixed in #257.

The roller prefixed a single `- ` to a whole fragment body, so a fragment carrying several items lost the marker on every item but the first. Two releases shipped that way and were never corrected — **ten orphaned lines are live in the public changelog today**:

- **v2.5.0** — nine bullets rendering as lazy continuations of the item above them
- **v2.0.0** — one

## v2.0.0 needed a different fix, and v2.5.0's would have made it worse

Its fragment (`4c7515e`) was prose with an embedded code block, not a list:

```
PARA 3: **Auto-migration on first launch:** …   ← a real item
PARA 4: To upgrade from `brizz-code`:          ← prose
PARA 5: ```bash … ```                          ← code block
PARA 6: Or run `fleet` directly — …            ← prose
```

Only PARA 3 is a bullet. The rest belong *after* the list, so they get a blank line to break out of it rather than a marker each. Reconstructed from the original fragment rather than inferred from the rendering.

## Verification

Every added line, with the marker stripped, matches the original verbatim — the orphan detector now returns nothing, and the only new lines are three blanks around the v2.0.0 code block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBQUYTfR7kzUjgozd58mr6