### PR TITLE
fix(perf): stop the UI stalling on transcript scans and tmux forks

### DIFF
--- a/changelog/unreleased/ui-stall-tmux-and-transcript.md
+++ b/changelog/unreleased/ui-stall-tmux-and-transcript.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**No more half-second freezes** — The sidebar no longer locks up while you scroll or navigate. Reading a session's title used to re-scan its whole Claude transcript every 30s — up to 89MB, now ~15µs — which stalled the background worker and left arrow keys forking `tmux` on the UI thread.
+**No more half-second freezes** — The sidebar no longer locks up while you scroll or navigate sessions with large transcripts.

--- a/changelog/unreleased/ui-stall-tmux-and-transcript.md
+++ b/changelog/unreleased/ui-stall-tmux-and-transcript.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**No more half-second freezes** — The sidebar no longer locks up while you scroll or navigate. Reading a session's title used to re-scan its whole Claude transcript every 30s — up to 89MB, now ~15µs — which stalled the background worker and left arrow keys forking `tmux` on the UI thread.

--- a/changelog/unreleased/worktree-dialog-width.md
+++ b/changelog/unreleased/worktree-dialog-width.md
@@ -1,0 +1,5 @@
+---
+type: improved
+---
+
+**Worktree names you can read** — The `w` dialog now uses the width your terminal actually has, sizing its columns to the names and branches in the list instead of cutting every one at 20 characters.

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -92,17 +93,19 @@ func ReadClaudeSessionName(claudeSessionID, projectPath string) string {
 	}
 
 	sc := titleScans[jsonlPath]
-	switch {
-	case sc == nil || st.Size() < sc.offset:
-		// Unseen, or the file shrank — a truncation or a reused session id means
-		// the memoised titles describe content that is no longer there.
-		sc = &titleScan{}
-		titleScans[jsonlPath] = sc
-	case st.Size() == sc.size && st.ModTime().Equal(sc.mtime):
+	if sc != nil && st.Size() == sc.size && st.ModTime().Equal(sc.mtime) {
 		// Untouched since the last read, so the memo is the whole answer and the
 		// file is never opened. This is the common case: the worker rechecks every
 		// session every 30s, and most transcripts are idle.
 		return sc.title()
+	}
+	if sc == nil || !sc.resumable(jsonlPath, st) {
+		// Start over, titles included. Reset is deliberately the only way to reach
+		// a scan from offset 0: custom and ai accumulate across calls, so a path
+		// that rewound the offset without clearing them would keep serving a title
+		// the current file no longer contains.
+		sc = &titleScan{}
+		titleScans[jsonlPath] = sc
 	}
 
 	offset, scanErr := scanTranscriptFrom(jsonlPath, sc.offset, func(line string) bool {
@@ -133,15 +136,18 @@ func ReadClaudeSessionName(claudeSessionID, projectPath string) string {
 		return true
 	})
 
-	sc.offset = offset
-	if scanErr == nil {
-		sc.size, sc.mtime = st.Size(), st.ModTime()
-	} else {
-		// A failed read leaves the tail unseen. Clearing the stat keys forces the
-		// next call past the untouched-file shortcut so it retries from offset,
-		// rather than serving a memo that is missing entries it never reached.
-		sc.size, sc.mtime = 0, time.Time{}
+	if scanErr != nil {
+		// The tail went unread, so custom and ai describe a prefix rather than the
+		// file. Returning them would be a title derived from content this call
+		// just failed to read — so drop the memo and answer nothing. That costs
+		// no visible title: the caller only assigns a non-empty name, and keeps
+		// its last good one until a read succeeds.
+		*sc = titleScan{}
+		return ""
 	}
+	sc.offset = offset
+	sc.size, sc.mtime = st.Size(), st.ModTime()
+	sc.anchor = transcriptAnchor(jsonlPath, offset)
 	return sc.title()
 }
 
@@ -156,8 +162,56 @@ type titleScan struct {
 	size   int64
 	mtime  time.Time
 	offset int64
+	anchor []byte // the bytes ending at offset; see resumable
 	custom string
 	ai     string
+}
+
+// resumable reports whether the file on disk is still the one this memo walked,
+// merely longer — the only condition under which offset, custom and ai still
+// describe it.
+//
+// Size cannot answer that on its own. A transcript replaced under the same path
+// by content at least as long looks like growth, so the scan would seek into
+// unrelated bytes and the previous file's custom-title would survive with no
+// later append able to clear it — a state the full walk this replaced could not
+// reach, because it recomputed both titles from scratch every call. Inode
+// identity misses the same case when the replacement is written in place. So the
+// check is the bytes themselves: whatever sat immediately before the resume
+// point must still sit there.
+func (t *titleScan) resumable(path string, st os.FileInfo) bool {
+	if t.offset == 0 || st.Size() < t.offset {
+		return false
+	}
+	return bytes.Equal(transcriptAnchor(path, t.offset), t.anchor)
+}
+
+// transcriptAnchorLen is how many bytes ending at a resume point are kept as
+// proof the prefix is unchanged. Long enough to be unique across JSONL entries,
+// short enough that verifying it is one small read.
+const transcriptAnchorLen = 64
+
+// transcriptAnchor returns the bytes ending at offset, or nil if they cannot be
+// read. Used both to record a resume point and to verify one.
+func transcriptAnchor(path string, offset int64) []byte {
+	n := int64(transcriptAnchorLen)
+	if offset < n {
+		n = offset
+	}
+	if n <= 0 {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	buf := make([]byte, n)
+	if _, err := f.ReadAt(buf, offset-n); err != nil {
+		return nil
+	}
+	return buf
 }
 
 // title applies the same precedence the full walk did: an explicit /rename wins
@@ -528,7 +582,13 @@ func scanTranscriptFrom(path string, from int64, fn func(line string) bool) (int
 		if !overCap {
 			buf = append(buf, chunk...)
 			if line := strings.TrimRight(string(buf), "\r\n"); line != "" && !fn(line) {
-				return consumed + pending, nil
+				if err == nil {
+					return consumed + pending, nil
+				}
+				// Stopped on the trailing partial line: fn has seen it, but
+				// consuming it would break the promise in the doc comment above
+				// and silently skip it once the writer finishes the line.
+				return consumed, nil
 			}
 		}
 		buf, overCap = buf[:0], false

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -77,8 +77,35 @@ func ReadClaudeSessionName(claudeSessionID, projectPath string) string {
 	}
 	jsonlPath := filepath.Join(projectDir, claudeSessionID+".jsonl")
 
-	var lastCustom, lastAI string
-	_ = forEachTranscriptLine(jsonlPath, func(line string) bool {
+	titleScanMu.Lock()
+	defer titleScanMu.Unlock()
+
+	st, err := os.Stat(jsonlPath)
+	if err != nil {
+		// Same rule the walk below applies to a failed open: a missing transcript
+		// is routine, anything else returns a zero value indistinguishable from
+		// "this session has no title" and must not pass in silence.
+		if !errors.Is(err, os.ErrNotExist) {
+			warnTranscript("transcript: stat failed", jsonlPath, "err", err)
+		}
+		return ""
+	}
+
+	sc := titleScans[jsonlPath]
+	switch {
+	case sc == nil || st.Size() < sc.offset:
+		// Unseen, or the file shrank — a truncation or a reused session id means
+		// the memoised titles describe content that is no longer there.
+		sc = &titleScan{}
+		titleScans[jsonlPath] = sc
+	case st.Size() == sc.size && st.ModTime().Equal(sc.mtime):
+		// Untouched since the last read, so the memo is the whole answer and the
+		// file is never opened. This is the common case: the worker rechecks every
+		// session every 30s, and most transcripts are idle.
+		return sc.title()
+	}
+
+	offset, scanErr := scanTranscriptFrom(jsonlPath, sc.offset, func(line string) bool {
 		// Quick check before JSON parsing. Matches both "custom-title" and
 		// "ai-title"; the Type check below filters any incidental hits.
 		if !strings.Contains(line, "-title") {
@@ -96,21 +123,59 @@ func ReadClaudeSessionName(claudeSessionID, projectPath string) string {
 		switch entry.Type {
 		case "custom-title":
 			if entry.CustomTitle != "" {
-				lastCustom = entry.CustomTitle
+				sc.custom = entry.CustomTitle
 			}
 		case "ai-title":
 			if entry.AITitle != "" {
-				lastAI = entry.AITitle
+				sc.ai = entry.AITitle
 			}
 		}
 		return true
 	})
 
-	if lastCustom != "" {
-		return lastCustom
+	sc.offset = offset
+	if scanErr == nil {
+		sc.size, sc.mtime = st.Size(), st.ModTime()
+	} else {
+		// A failed read leaves the tail unseen. Clearing the stat keys forces the
+		// next call past the untouched-file shortcut so it retries from offset,
+		// rather than serving a memo that is missing entries it never reached.
+		sc.size, sc.mtime = 0, time.Time{}
 	}
-	return deslugify(lastAI)
+	return sc.title()
 }
+
+// titleScan memoises one transcript's last-seen title entries and how far the
+// walk got. Claude's JSONL is append-only and its titles sit near the end of a
+// file that reaches tens of MB, so re-reading the whole thing every 30s per
+// session (agentNameRecheckInterval) was blocking the status worker for long
+// enough that the tmux session cache went stale underneath the UI — which is
+// what turned the Update goroutine's liveness checks into visible freezes.
+// Resuming from offset costs only the bytes appended since.
+type titleScan struct {
+	size   int64
+	mtime  time.Time
+	offset int64
+	custom string
+	ai     string
+}
+
+// title applies the same precedence the full walk did: an explicit /rename wins
+// wherever it appeared, otherwise the latest ai-title.
+func (t *titleScan) title() string {
+	if t.custom != "" {
+		return t.custom
+	}
+	return deslugify(t.ai)
+}
+
+// titleScans is keyed by transcript path. Guarded by titleScanMu, which is held
+// across the read: the only caller is the status worker's sequential per-session
+// pass, so there is no concurrency to preserve here.
+var (
+	titleScanMu sync.Mutex
+	titleScans  = map[string]*titleScan{}
+)
 
 // slugSeparators replaces a slug's word separators with spaces. Case is left
 // untouched on purpose.
@@ -402,6 +467,19 @@ const transcriptLineCap = 8 << 20 // 8MB
 // Callers that only need a best-effort answer discard the returned error; the
 // helper has already logged anything beyond a routine missing file.
 func forEachTranscriptLine(path string, fn func(line string) bool) error {
+	_, err := scanTranscriptFrom(path, 0, fn)
+	return err
+}
+
+// scanTranscriptFrom is forEachTranscriptLine starting at a byte offset. It
+// returns the offset just past the last *complete* line it consumed, so a
+// caller can resume there when the file grows.
+//
+// A trailing chunk with no newline is a line still being written: fn sees it
+// (matching the whole-file walk, where a caller reading the last entry must not
+// miss one mid-write), but it is not counted as consumed — otherwise a resuming
+// caller would skip past a line it only ever saw half of.
+func scanTranscriptFrom(path string, from int64, fn func(line string) bool) (int64, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		// A missing transcript is routine — the session may not have written one
@@ -411,15 +489,24 @@ func forEachTranscriptLine(path string, fn func(line string) bool) error {
 		if !errors.Is(err, os.ErrNotExist) {
 			warnTranscript("transcript: open failed", path, "err", err)
 		}
-		return err
+		return from, err
 	}
 	defer f.Close()
+
+	if from > 0 {
+		if _, err := f.Seek(from, io.SeekStart); err != nil {
+			warnTranscript("transcript: seek failed, rescanning whole file", path, "err", err)
+			return 0, err
+		}
+	}
 
 	r := bufio.NewReaderSize(f, 64*1024)
 	var buf []byte
 	overCap := false
+	consumed, pending := from, int64(0)
 	for {
 		chunk, err := r.ReadSlice('\n')
+		pending += int64(len(chunk))
 		if errors.Is(err, bufio.ErrBufferFull) {
 			// Mid-line: accumulate until the cap, then drop the rest of this line.
 			if !overCap {
@@ -441,20 +528,22 @@ func forEachTranscriptLine(path string, fn func(line string) bool) error {
 		if !overCap {
 			buf = append(buf, chunk...)
 			if line := strings.TrimRight(string(buf), "\r\n"); line != "" && !fn(line) {
-				return nil
+				return consumed + pending, nil
 			}
 		}
 		buf, overCap = buf[:0], false
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil
+				return consumed, nil
 			}
 			// Partial walk. Whatever the caller returns is derived from a prefix of
 			// the file, which is precisely the failure this helper exists to end —
 			// so say so rather than letting a stale answer look authoritative.
 			warnTranscript("transcript: read failed, result is partial", path, "err", err)
-			return err
+			return consumed, err
 		}
+		consumed += pending
+		pending = 0
 	}
 }
 

--- a/internal/session/claude_name_test.go
+++ b/internal/session/claude_name_test.go
@@ -574,3 +574,99 @@ func TestWarnTranscriptThrottles(t *testing.T) {
 		t.Error("warning omitted the transcript path")
 	}
 }
+
+// TestReadClaudeSessionNameIncrementalMatchesFullScan pins the memoised,
+// resume-from-offset read against the whole-file walk it replaced. The scan is
+// only sound because Claude's JSONL is append-only, so every case here is a
+// way that assumption can bend: growth, custom-vs-ai precedence spanning two
+// reads, a line still being written, and a file replaced under the same name.
+func TestReadClaudeSessionNameIncrementalMatchesFullScan(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	projectPath := "/test/incremental-project"
+	claudeSessionID := "test-session-incremental"
+	projectDir := filepath.Join(homeDir, ".claude", "projects", "-test-incremental-project")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatalf("create project dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(projectDir) })
+
+	jsonlPath := filepath.Join(projectDir, claudeSessionID+".jsonl")
+	t.Cleanup(func() {
+		titleScanMu.Lock()
+		delete(titleScans, jsonlPath)
+		titleScanMu.Unlock()
+	})
+
+	appendLine := func(t *testing.T, s string) {
+		t.Helper()
+		f, err := os.OpenFile(jsonlPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			t.Fatalf("open for append: %v", err)
+		}
+		if _, err := f.WriteString(s); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+		f.Close()
+	}
+
+	// fullScan drops the memo so the next read walks the whole file, which is
+	// the behaviour the incremental path has to stay identical to.
+	fullScan := func() string {
+		titleScanMu.Lock()
+		delete(titleScans, jsonlPath)
+		titleScanMu.Unlock()
+		return ReadClaudeSessionName(claudeSessionID, projectPath)
+	}
+
+	check := func(t *testing.T, step, want string) {
+		t.Helper()
+		got := ReadClaudeSessionName(claudeSessionID, projectPath)
+		if got != want {
+			t.Errorf("%s: incremental read = %q, want %q", step, got, want)
+		}
+		if full := fullScan(); full != got {
+			t.Errorf("%s: incremental read = %q but full scan = %q", step, got, full)
+		}
+	}
+
+	steps := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"untitled", `{"type":"message","content":"hello"}` + "\n", ""},
+		{"first ai-title", `{"type":"ai-title","aiTitle":"first-draft"}` + "\n", "first draft"},
+		{"ai-title drifts", `{"type":"ai-title","aiTitle":"second-draft"}` + "\n", "second draft"},
+		// The rename lands in a later read than the ai-titles it outranks, so
+		// precedence has to survive in the memo rather than in one walk's locals.
+		{"rename wins", `{"type":"custom-title","customTitle":"Renamed"}` + "\n", "Renamed"},
+		{"rename outlives later ai-title", `{"type":"ai-title","aiTitle":"later-ai"}` + "\n", "Renamed"},
+	}
+	for _, step := range steps {
+		appendLine(t, step.line)
+		check(t, step.name, step.want)
+	}
+
+	t.Run("line still being written is re-read once complete", func(t *testing.T) {
+		// Half an entry, as a concurrent Claude write would leave it. Reading here
+		// must not consume it, or its completion would never be seen.
+		appendLine(t, `{"type":"custom-title","customTi`)
+		check(t, "partial line", "Renamed")
+
+		appendLine(t, `tle":"Completed"}`+"\n")
+		check(t, "completed line", "Completed")
+	})
+
+	t.Run("replaced file resets the memo", func(t *testing.T) {
+		// A shorter file under the same name: the memoised offset now points past
+		// the end, and the remembered titles describe content that is gone.
+		if err := os.WriteFile(jsonlPath, []byte(`{"type":"ai-title","aiTitle":"fresh-start"}`+"\n"), 0644); err != nil {
+			t.Fatalf("truncate: %v", err)
+		}
+		check(t, "after truncation", "fresh start")
+	})
+}

--- a/internal/session/claude_name_test.go
+++ b/internal/session/claude_name_test.go
@@ -661,6 +661,26 @@ func TestReadClaudeSessionNameIncrementalMatchesFullScan(t *testing.T) {
 		check(t, "completed line", "Completed")
 	})
 
+	t.Run("replaced file longer than the original resets the memo", func(t *testing.T) {
+		// The dangerous shape: a replacement at least as long as the old file
+		// looks like growth to any size check, so the scan would seek into
+		// unrelated bytes and the previous file's custom-title would survive.
+		// Nothing appended later could ever clear it.
+		longer := strings.Repeat(`{"type":"message","content":"padding padding padding"}`+"\n", 40) +
+			`{"type":"ai-title","aiTitle":"replaced-longer"}` + "\n"
+		st, err := os.Stat(jsonlPath)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if int64(len(longer)) <= st.Size() {
+			t.Fatalf("test is not exercising the grew-in-place case: %d <= %d", len(longer), st.Size())
+		}
+		if err := os.WriteFile(jsonlPath, []byte(longer), 0644); err != nil {
+			t.Fatalf("replace: %v", err)
+		}
+		check(t, "replaced longer", "replaced longer")
+	})
+
 	t.Run("replaced file resets the memo", func(t *testing.T) {
 		// A shorter file under the same name: the memoised offset now points past
 		// the end, and the remembered titles describe content that is gone.
@@ -668,5 +688,49 @@ func TestReadClaudeSessionNameIncrementalMatchesFullScan(t *testing.T) {
 			t.Fatalf("truncate: %v", err)
 		}
 		check(t, "after truncation", "fresh start")
+	})
+}
+
+// TestScanTranscriptFromEarlyStopKeepsPartialLine pins the contract in
+// scanTranscriptFrom's doc comment: a trailing chunk with no newline is a line
+// still being written, so stopping on it must not consume it. Nothing today both
+// stops early and resumes, which is exactly why this is worth a test — the next
+// caller that does would otherwise silently skip the half-written line.
+func TestScanTranscriptFromEarlyStopKeepsPartialLine(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("stopping on a complete line consumes it", func(t *testing.T) {
+		path := filepath.Join(dir, "complete.jsonl")
+		if err := os.WriteFile(path, []byte("alpha\nbeta\n"), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		off, err := scanTranscriptFrom(path, 0, func(line string) bool { return line != "alpha" })
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if want := int64(len("alpha\n")); off != want {
+			t.Errorf("offset = %d, want %d (the newline-terminated line is consumed)", off, want)
+		}
+	})
+
+	t.Run("stopping on a partial trailing line does not consume it", func(t *testing.T) {
+		path := filepath.Join(dir, "partial.jsonl")
+		if err := os.WriteFile(path, []byte("alpha\nbet"), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		var seen []string
+		off, err := scanTranscriptFrom(path, 0, func(line string) bool {
+			seen = append(seen, line)
+			return line != "bet"
+		})
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if len(seen) != 2 || seen[1] != "bet" {
+			t.Fatalf("fn should still see the partial line, saw %q", seen)
+		}
+		if want := int64(len("alpha\n")); off != want {
+			t.Errorf("offset = %d, want %d (the partial line must be re-read)", off, want)
+		}
 	})
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -501,6 +501,18 @@ func (s *Session) IsAlive() bool {
 	return s.tmuxSession.Exists()
 }
 
+// IsAliveCached is IsAlive without the tmux shell-out: known is false when the
+// session cache can't answer. Callers running on the Bubble Tea Update
+// goroutine must use this — IsAlive forks `tmux has-session` on a cache miss,
+// and the cache goes stale exactly when the status worker is blocked, so the
+// per-tick guards were freezing the UI for half a second at a time.
+func (s *Session) IsAliveCached() (alive, known bool) {
+	if s.paneCapturer != nil {
+		return !s.paneCapturer.IsPaneDead(), true
+	}
+	return s.tmuxSession.ExistsCached()
+}
+
 // GetTmuxSession returns the underlying tmux session handle.
 func (s *Session) GetTmuxSession() *tmux.Session {
 	return s.tmuxSession

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -27,6 +27,11 @@ const (
 	// generous; the cap exists so an unresponsive tmux server can't hang the
 	// status worker (called once per session per tick).
 	listPanesTimeout = 2 * time.Second
+	// hasSessionTimeout caps the `tmux has-session` fallback in Exists. It only
+	// runs on a session-cache miss, but that is exactly when the server is
+	// likely to be busy — and an unbounded fork here blocked the Bubble Tea
+	// Update goroutine for 500ms+, which reads as the whole UI freezing.
+	hasSessionTimeout = 2 * time.Second
 )
 
 // Session represents a tmux session managed by fleet.
@@ -641,20 +646,35 @@ func (s *Session) PaneDeadInfo() (dead bool, exitStatus, exitSignal string, ok b
 	return parts[0] == "1", parts[1], parts[2], true
 }
 
-// Exists checks if the tmux session is alive.
-func (s *Session) Exists() bool {
-	// Try cache first.
+// ExistsCached answers Exists from the shared session cache alone, never
+// shelling out. known is false when the cache is cold or has aged past
+// sessionCacheTTL, leaving it to the caller to decide what an unknown means.
+//
+// Callers on the Bubble Tea Update goroutine must use this rather than Exists:
+// RefreshSessionCache runs on the status worker, so anything that blocks that
+// worker lets the cache go stale, and Exists would then fork tmux inline on
+// every tick. That is the shape of the previewTick stalls in the perfwatch
+// dumps — a busy worker turning a map lookup into a half-second freeze.
+func (s *Session) ExistsCached() (exists, known bool) {
 	sessionCacheMu.RLock()
-	if sessionCacheData != nil && time.Since(sessionCacheTime) < sessionCacheTTL {
-		_, exists := sessionCacheData[s.Name]
-		sessionCacheMu.RUnlock()
+	defer sessionCacheMu.RUnlock()
+	if sessionCacheData == nil || time.Since(sessionCacheTime) >= sessionCacheTTL {
+		return false, false
+	}
+	_, ok := sessionCacheData[s.Name]
+	return ok, true
+}
+
+// Exists checks if the tmux session is alive, falling back to a bounded
+// `tmux has-session` when the cache can't answer.
+func (s *Session) Exists() bool {
+	if exists, known := s.ExistsCached(); known {
 		return exists
 	}
-	sessionCacheMu.RUnlock()
 
-	// Fallback to tmux has-session.
-	cmd := exec.Command("tmux", "has-session", "-t", s.Name)
-	return cmd.Run() == nil
+	ctx, cancel := context.WithTimeout(context.Background(), hasSessionTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "tmux", "has-session", "-t", s.Name).Run() == nil
 }
 
 // SendKeys sends keystrokes to the tmux pane.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -665,8 +665,29 @@ func (s *Session) ExistsCached() (exists, known bool) {
 	return ok, true
 }
 
+// existsStale answers from the session cache ignoring its TTL. Only for the
+// timeout path in Exists, where a stale-but-real answer beats a fabricated one.
+func (s *Session) existsStale() (exists, known bool) {
+	sessionCacheMu.RLock()
+	defer sessionCacheMu.RUnlock()
+	if sessionCacheData == nil {
+		return false, false
+	}
+	_, ok := sessionCacheData[s.Name]
+	return ok, true
+}
+
 // Exists checks if the tmux session is alive, falling back to a bounded
 // `tmux has-session` when the cache can't answer.
+//
+// Only a probe that actually completed may report absence. Every caller reads
+// false as "the session is gone" and acts on it — restartSession rebuilds
+// instead of respawning, `fleet send` refuses a live session, finalizeDelete
+// skips its Kill and leaks the tmux session — and a timeout is not evidence of
+// any of that. It is evidence of a busy server, which is precisely the state
+// this timeout exists to survive, so a timed-out probe answers from the cache
+// however stale it has become, and says so: a silent false negative here would
+// be undiagnosable from the outside.
 func (s *Session) Exists() bool {
 	if exists, known := s.ExistsCached(); known {
 		return exists
@@ -674,7 +695,16 @@ func (s *Session) Exists() bool {
 
 	ctx, cancel := context.WithTimeout(context.Background(), hasSessionTimeout)
 	defer cancel()
-	return exec.CommandContext(ctx, "tmux", "has-session", "-t", s.Name).Run() == nil
+	err := exec.CommandContext(ctx, "tmux", "has-session", "-t", s.Name).Run()
+	if ctx.Err() == nil {
+		return err == nil
+	}
+
+	exists, known := s.existsStale()
+	debuglog.Logger.Warn("tmux has-session timed out; not treating it as absence",
+		"session", s.Name, "timeout", hasSessionTimeout,
+		"answered_from_stale_cache", known, "exists", exists)
+	return exists
 }
 
 // SendKeys sends keystrokes to the tmux pane.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -5320,7 +5320,16 @@ func (h *Home) getControlClient() *tmux.ControlClient {
 
 func (h *Home) enterFocusMode() tea.Cmd {
 	s := h.selectedSession()
-	if s == nil || !s.IsAlive() {
+	if s == nil {
+		h.setError(fmt.Errorf("cannot focus: session not running"))
+		return nil
+	}
+	// Cache-only, like focusTick and handleFocusKey: all three callers are
+	// keypress-driven, so resolving an unknown would fork tmux on the Update
+	// goroutine. A known-dead session still refuses, so the cached path — which
+	// is nearly every press — behaves exactly as before; only an unknown enters
+	// optimistically, and the next known-dead reading ejects.
+	if alive, known := s.IsAliveCached(); known && !alive {
 		h.setError(fmt.Errorf("cannot focus: session not running"))
 		return nil
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1780,8 +1780,16 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return h, h.previewTick() // focus mode has its own faster tick
 		}
 		cmds := []tea.Cmd{h.previewTick()}
-		if sel := h.selectedSession(); sel != nil && sel.IsAlive() {
-			cmds = append(cmds, h.fetchPreview(sel))
+		// Cache-only liveness. IsAlive forks `tmux has-session` on a cache miss,
+		// and this runs every 500ms on the Update goroutine — when the status
+		// worker is busy the cache goes stale and that fork became the single
+		// largest stall class in the perfwatch dumps. An unknown answer fetches
+		// anyway: fetchPreview is a tea.Cmd, so it costs nothing here, and
+		// skipping would blank a live session's preview.
+		if sel := h.selectedSession(); sel != nil {
+			if alive, known := sel.IsAliveCached(); !known || alive {
+				cmds = append(cmds, h.fetchPreview(sel))
+			}
 		}
 		return h, tea.Batch(cmds...)
 
@@ -1790,7 +1798,16 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return h, nil
 		}
 		s := h.selectedSession()
-		if s == nil || !s.IsAlive() {
+		if s == nil {
+			h.focusMode = false
+			h.sidebarDirty = true
+			return h, nil
+		}
+		// Only a *known* dead session drops focus mode. focusTick is 100ms, so
+		// resolving a cache miss here would fork tmux ten times a second on the
+		// Update goroutine; and ejecting the user because the cache happened to
+		// be stale is the worse of the two ways to be wrong.
+		if alive, known := s.IsAliveCached(); known && !alive {
 			h.focusMode = false
 			h.sidebarDirty = true
 			return h, nil
@@ -5321,7 +5338,14 @@ func (h *Home) focusTick() tea.Cmd {
 
 func (h *Home) handleFocusKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	s := h.selectedSession()
-	if s == nil || !s.IsAlive() {
+	if s == nil {
+		h.focusMode = false
+		h.sidebarDirty = true
+		return h, nil
+	}
+	// Per-keystroke, so this is typing latency: same cache-only rule as
+	// focusTick, and the same reason not to eject on an unknown.
+	if alive, known := s.IsAliveCached(); known && !alive {
 		h.focusMode = false
 		h.sidebarDirty = true
 		return h, nil
@@ -7186,7 +7210,14 @@ func (h *Home) fetchPreview(s *session.Session) tea.Cmd {
 // currently selected session, or nil if no live session is selected.
 func (h *Home) fetchPreviewForSelected() tea.Cmd {
 	sel := h.selectedSession()
-	if sel == nil || !sel.IsAlive() {
+	if sel == nil {
+		return nil
+	}
+	// Cache-only, and optimistic on a miss: every j/k lands here, so resolving an
+	// unknown would fork `tmux has-session` on the Update goroutine once per
+	// arrow key. The returned Cmd does its work off this goroutine anyway, and a
+	// preview fetched for a session that turns out to be dead costs nothing.
+	if alive, known := sel.IsAliveCached(); known && !alive {
 		return nil
 	}
 	return h.fetchPreview(sel)

--- a/internal/ui/workspace_picker.go
+++ b/internal/ui/workspace_picker.go
@@ -1,8 +1,8 @@
 package ui
 
 import (
-	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
@@ -11,6 +11,7 @@ import (
 	"github.com/brizzai/fleet/internal/linear"
 	"github.com/brizzai/fleet/internal/session"
 	"github.com/brizzai/fleet/internal/workspace"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // Messages for workspace/worktree flow.
@@ -184,6 +185,17 @@ func (d *WorktreeDialog) IsVisible() bool { return d.visible }
 func (d *WorktreeDialog) SetSize(w, h int) {
 	d.width = w
 	d.height = h
+
+	// The inputs follow the box rather than a fixed 40 columns, so a long branch
+	// name is readable instead of scrolling inside a field a third of the width
+	// of the dialog holding it. NewTextInput owns its prompt (design-system.md
+	// §7), so the writable column is the content width less that prompt.
+	iw := d.innerWidth() - 2
+	if iw < 20 {
+		iw = 20
+	}
+	d.baseBranchInput.SetWidth(iw)
+	d.newBranchInput.SetWidth(iw)
 }
 
 // setSelection is the ONLY place that moves the highlight.
@@ -438,9 +450,10 @@ func (d *WorktreeDialog) View() string {
 		b.WriteString("\n")
 		b.WriteString(DimStyle.Render("Existing worktrees:"))
 		b.WriteString("\n")
+		nameW, branchW, countW := d.worktreeColumnWidths()
 		for i, ws := range d.workspaces {
 			selected := d.focus == focusWorktreeList && i == d.cursor
-			b.WriteString(d.renderWorktreeRow(&ws, selected))
+			b.WriteString(d.renderWorktreeRow(&ws, selected, nameW, branchW, countW))
 			b.WriteString("\n")
 		}
 	}
@@ -458,60 +471,139 @@ func (d *WorktreeDialog) View() string {
 	return d.wrapDialog(b.String())
 }
 
-func (d *WorktreeDialog) renderWorktreeRow(ws *workspace.WorkspaceInfo, selected bool) string {
+// worktreeColumns sizes the name and branch columns from the widest values
+// actually present, within the space the two of them share.
+//
+// The previous fixed 20/16 split ellipsised every row in a real repo while the
+// terminal had room to spare, and starved whichever column happened to hold the
+// longer strings. Deriving the widths means a list of short names is never
+// truncated at all, and a list of long ones degrades evenly.
+func worktreeColumns(wss []workspace.WorkspaceInfo, avail int) (nameW, branchW int) {
+	for i := range wss {
+		if w := lipgloss.Width(wss[i].Name); w > nameW {
+			nameW = w
+		}
+		if w := lipgloss.Width(wss[i].Branch); w > branchW {
+			branchW = w
+		}
+	}
+	if nameW+branchW <= avail {
+		return nameW, branchW
+	}
+
+	// Over budget: split in proportion to what each column asked for, with a
+	// floor so the narrower one is not cut to nothing to spare the other.
+	const floor = 12
+	if avail < 2*floor {
+		nameW = avail / 2
+		return nameW, avail - nameW
+	}
+	nameW = avail * nameW / (nameW + branchW)
+	if nameW < floor {
+		nameW = floor
+	}
+	if avail-nameW < floor {
+		nameW = avail - floor
+	}
+	return nameW, avail - nameW
+}
+
+// fitCell truncates to width and pads out to it, by display columns.
+//
+// ansi.Truncate rather than a byte slice (design-system.md §7): a worktree name
+// is arbitrary user text, and slicing bytes cuts at a fraction of the intended
+// columns and can split a rune in half.
+func fitCell(sw string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	sw = ansi.Truncate(sw, width, "…")
+	if pad := width - lipgloss.Width(sw); pad > 0 {
+		sw += strings.Repeat(" ", pad)
+	}
+	return sw
+}
+
+// worktreeRowGap is the space between each pair of columns in a worktree row.
+const worktreeRowGap = 2
+
+// worktreeColumnWidths sizes the three columns of the worktree list against the
+// dialog's content width. Split out from View so the arithmetic is testable on
+// its own: a row that overruns innerWidth wraps onto a second line inside the
+// box, which shows up as a stray count on its own row rather than as anything
+// measurable on the rendered width.
+func (d *WorktreeDialog) worktreeColumnWidths() (nameW, branchW, countW int) {
+	for i := range d.workspaces {
+		if c := d.sessionCounts[d.workspaces[i].Path]; c > 0 {
+			if w := len(strconv.Itoa(c)); w > countW {
+				countW = w
+			}
+		}
+	}
+	// The name and branch columns share what is left after the selection marker,
+	// the two gaps between the three columns, and the count.
+	avail := d.innerWidth() - len("▸ ") - 2*worktreeRowGap - countW
+	nameW, branchW = worktreeColumns(d.workspaces, avail)
+	return nameW, branchW, countW
+}
+
+func (d *WorktreeDialog) renderWorktreeRow(ws *workspace.WorkspaceInfo, selected bool, nameW, branchW, countW int) string {
 	prefix := "  "
 	if selected {
 		prefix = SelectionMarker(true).Render("▸ ")
 	}
 
-	// Name.
-	name := ws.Name
-	if len(name) > 20 {
-		name = name[:20]
-	}
+	// Padded raw, then styled — padding a styled string counts the ANSI bytes
+	// and the columns come out ragged (design-system.md §7).
+	name := fitCell(ws.Name, nameW)
+	branch := fitCell(ws.Branch, branchW)
 
-	// Branch.
-	branch := ws.Branch
-	if len(branch) > 16 {
-		branch = branch[:13] + "..."
+	count := ""
+	if c := d.sessionCounts[ws.Path]; c > 0 {
+		count = strconv.Itoa(c)
 	}
-
-	// Session count.
-	count := d.sessionCounts[ws.Path]
+	if pad := countW - lipgloss.Width(count); pad > 0 {
+		count = strings.Repeat(" ", pad) + count // right-aligned, so digits line up
+	}
 
 	if selected {
-		line := fmt.Sprintf("%-20s", name)
-		if branch != "" {
-			line += "  " + branch
-		}
-		if count > 0 {
-			line += fmt.Sprintf("  %d", count)
-		}
-		return prefix + SelectionPill(true).Render(line)
+		// SelectionPill, not SelectionBand, despite the filled region running past
+		// SelectionFillWidthGuide once the columns are sized to their content.
+		// The guide is a call-site judgement, and what is filled here is the row's
+		// content rather than the full inner width of the dialog — and this list
+		// shares focus with two text inputs, where SelectionBand has no blurred
+		// weight to offer by design.
+		return prefix + SelectionPill(true).Render(strings.TrimRight(name+"  "+branch+"  "+count, " "))
 	}
 
-	nameStyled := lipgloss.NewStyle().Foreground(ColorText).Render(fmt.Sprintf("%-20s", name))
-	var parts []string
-	parts = append(parts, prefix+nameStyled)
-	if branch != "" {
-		parts = append(parts, BranchStyle.Render(branch))
+	line := prefix + lipgloss.NewStyle().Foreground(ColorText).Render(name)
+	if strings.TrimSpace(branch) != "" {
+		line += "  " + BranchStyle.Render(branch)
 	}
-	if count > 0 {
-		parts = append(parts, DimStyle.Render(fmt.Sprintf("%d", count)))
+	if strings.TrimSpace(count) != "" {
+		line += "  " + DimStyle.Render(count)
 	}
-	return strings.Join(parts, "  ")
+	return strings.TrimRight(line, " ")
 }
 
-// innerWidth is the content column inside the dialog box: wrapDialog's clamped
-// width less DialogStyle's Padding(1, 2) on each side.
+// innerWidth is the writable content column inside the dialog box. In Lip Gloss
+// v2, Style.Width sets the TOTAL frame width (border + padding included), so
+// subtract both: 2 (rounded border) + 4 (DialogStyle's Padding(1, 2), 2 each
+// side). Subtracting only the padding left rows 2 cells too wide and wrapped the
+// longest ones — the same off-by-two the command palette already fixed, latent
+// here until worktree rows started being sized against this.
 func (d *WorktreeDialog) innerWidth() int {
-	return d.dialogWidth() - 4
+	return d.dialogWidth() - 6
 }
 
 func (d *WorktreeDialog) dialogWidth() int {
 	w := d.width - 4
-	if w > 64 {
-		w = 64
+	// Same ceiling as the command palette, and for the same reason: wide enough
+	// that a worktree name and its branch are readable rather than a pair of
+	// ellipses, still an overlay rather than a takeover. At 64 every row in a
+	// real repo was truncated with half the terminal unused.
+	if w > 96 {
+		w = 96
 	}
 	if w < 30 {
 		w = 30

--- a/internal/ui/workspace_picker_layout_test.go
+++ b/internal/ui/workspace_picker_layout_test.go
@@ -1,0 +1,153 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"charm.land/lipgloss/v2"
+	"github.com/brizzai/fleet/internal/workspace"
+)
+
+// TestFitCellMeasuresColumnsNotBytes pins design-system.md §7 for the worktree
+// row, which previously cut with `name[:20]`. A worktree name is arbitrary user
+// text: byte slicing cuts a multi-byte name at a fraction of the intended
+// columns and can leave invalid UTF-8 behind for lipgloss to render.
+func TestFitCellMeasuresColumnsNotBytes(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    string
+		width int
+	}{
+		{"ascii fits", "feature-x", 20},
+		{"ascii truncates", "a-very-long-worktree-name", 10},
+		{"multi-byte truncates", "ünïcödé-wörktree-nàme", 10},
+		{"exact fit", "exactly-10", 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fitCell(tc.in, tc.width)
+			if w := lipgloss.Width(got); w != tc.width {
+				t.Errorf("fitCell(%q, %d) is %d columns, want exactly %d — ragged columns are the bug",
+					tc.in, tc.width, w, tc.width)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("fitCell(%q, %d) = %q: split a rune", tc.in, tc.width, got)
+			}
+		})
+	}
+}
+
+// TestWorktreeColumnsFitTheBudget covers the sizing that replaced the fixed
+// 20/16 split: derived from content when there is room, and degraded evenly —
+// never starving one column to nothing — when there is not.
+func TestWorktreeColumnsFitTheBudget(t *testing.T) {
+	ws := func(names ...string) []workspace.WorkspaceInfo {
+		out := make([]workspace.WorkspaceInfo, 0, len(names))
+		for _, n := range names {
+			out = append(out, workspace.WorkspaceInfo{Name: n, Branch: n + "-branch"})
+		}
+		return out
+	}
+
+	t.Run("room to spare uses natural widths", func(t *testing.T) {
+		list := ws("short", "tiny")
+		nameW, branchW := worktreeColumns(list, 80)
+		if nameW != len("short") || branchW != len("short-branch") {
+			t.Errorf("nameW=%d branchW=%d, want the widest actual values (5, 12) — no truncation when it fits",
+				nameW, branchW)
+		}
+	})
+
+	t.Run("over budget stays within it and keeps both readable", func(t *testing.T) {
+		list := ws(strings.Repeat("n", 90), "s")
+		const avail = 40
+		nameW, branchW := worktreeColumns(list, avail)
+		if nameW+branchW > avail {
+			t.Errorf("nameW+branchW = %d, over the %d budget", nameW+branchW, avail)
+		}
+		if nameW <= 0 || branchW <= 0 {
+			t.Errorf("nameW=%d branchW=%d: a column starved to nothing", nameW, branchW)
+		}
+		if branchW < 12 {
+			t.Errorf("branchW=%d, want the floor (12) honoured so the narrower column stays readable", branchW)
+		}
+	})
+
+	t.Run("budget too small for both floors still fits", func(t *testing.T) {
+		list := ws(strings.Repeat("n", 50))
+		const avail = 10
+		nameW, branchW := worktreeColumns(list, avail)
+		if nameW+branchW > avail {
+			t.Errorf("nameW+branchW = %d, over the %d budget", nameW+branchW, avail)
+		}
+	})
+}
+
+// TestWorktreeDialogRowsNeverOverflow guards the box arithmetic. Lip Gloss v2's
+// Style.Width is the TOTAL frame width, so a content column computed as "width
+// less padding" is two cells too wide; the longest rows then wrap onto a second
+// line inside the box — which a row with a session count did the moment rows
+// started being sized against innerWidth.
+//
+// Asserted on the column budget, not the rendered output: the wrap adds a line
+// rather than widening one, and lipgloss.Place pads the result to the terminal
+// height, so nothing about View's dimensions moves when this breaks.
+func TestWorktreeDialogRowsNeverOverflow(t *testing.T) {
+	names := []string{
+		"frosty-mahavira",
+		"brizzai-BRZ-2644-Remove-legacy-paths",
+		"brizzai-brz-3287-display-widths",
+		"brizzai-brz-3241-rew",
+	}
+	var wss []workspace.WorkspaceInfo
+	counts := map[string]int{}
+	for i, n := range names {
+		p := "/p/" + strings.Repeat("x", i)
+		wss = append(wss, workspace.WorkspaceInfo{Name: n, Branch: n + "-branch", Path: p})
+		counts[p] = 1 + i*6 // single- and double-digit counts both present
+	}
+
+	for _, w := range []int{40, 60, 80, 100, 120, 200} {
+		d := NewWorktreeDialog()
+		d.SetSize(w, 40)
+		d.Show(wss, nil, nil, "/Users/y/code/brizzai", "origin/master", nil)
+		d.sessionCounts = counts
+
+		// Ground-truth innerWidth against Lip Gloss itself, rather than against
+		// the same constant the production code uses — comparing the budget to
+		// innerWidth alone is tautological, since both move together when the
+		// arithmetic is wrong. A content line of exactly innerWidth columns must
+		// come out of the box as one line, not two.
+		probe := strings.Repeat("x", d.innerWidth())
+		boxed := DialogStyle.Width(d.dialogWidth()).Render(probe)
+		rows := 0
+		for _, line := range strings.Split(boxed, "\n") {
+			if strings.Contains(line, "x") {
+				rows++
+			}
+		}
+		if rows != 1 {
+			t.Errorf("terminal width %d: a line of innerWidth (%d) columns wrapped onto %d rows inside the box",
+				w, d.innerWidth(), rows)
+		}
+
+		nameW, branchW, countW := d.worktreeColumnWidths()
+		row := len("\u25b8 ") + nameW + worktreeRowGap + branchW + worktreeRowGap + countW
+		if row > d.innerWidth() {
+			t.Errorf("terminal width %d: row budget %d exceeds content width %d — rows will wrap",
+				w, row, d.innerWidth())
+		}
+
+		// And the rendered row must actually honour that budget.
+		for i := range wss {
+			for _, selected := range []bool{false, true} {
+				line := d.renderWorktreeRow(&wss[i], selected, nameW, branchW, countW)
+				if lw := lipgloss.Width(line); lw > d.innerWidth() {
+					t.Errorf("terminal width %d: row %d (selected=%v) renders %d columns, content width is %d",
+						w, i, selected, lw, d.innerWidth())
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

`/debug-perf` on 519 perfwatch dumps: **277 of them (53%) are `previewTickMsg` stalls** — blocking I/O on the Bubble Tea Update goroutine, the thing CLAUDE.md forbids. This fixes all three links in the chain.

```
ReadClaudeSessionName full-scans a transcript every 30s per session
  → status worker blocks, so RefreshSessionCache stops running
  → the 2s tmux session cache goes stale
  → IsAlive() cache-misses in Update() and forks `tmux has-session`
  → unbounded, on a server busy precisely because the worker is hammering it
  → 500ms+ freeze
```

Today's 10:01 dump shows both ends at once: goroutine 899 (status worker) in `syscall.read` inside `forEachTranscriptLine`, while goroutine 1 sits in `exec.Cmd.Wait` under `IsAlive` ← `Update`.

## 1. Transcript scan — the root cause

Claude's JSONL is append-only and its titles sit near the **end** of a file that reaches tens of MB, so the walk re-read the whole thing every 30s to find a string it had already found last time. `forEachTranscriptLine` now delegates to an offset-aware `scanTranscriptFrom`, and a per-path memo holds size/mtime/offset plus the last-seen titles.

**Measured on a real 89MB transcript: 69ms → 15µs.**

The scan is only sound because the file is append-only, so the memo guards the ways that assumption bends:

- A trailing chunk with no newline is a line **mid-write** — `fn` still sees it (matching the whole-file walk), but it is *not* counted as consumed, or its completion would never be read.
- `custom-title` precedence now has to survive **across reads**, not within one walk's locals.
- A file that **shrank** (truncation, reused session id) resets the memo.

## 2. `IsAlive()` off the Update goroutine

New `IsAliveCached() (alive, known bool)` answers from the cache alone. The four hot callers split deliberately on what an *unknown* means:

| Site | Cadence | On a cache miss |
|---|---|---|
| `previewTick` | 500ms | fetch anyway — it's a `tea.Cmd`, so it costs nothing here |
| `fetchPreviewForSelected` | **every `j`/`k`** | same |
| `focusTick` | 100ms | keep focus mode — only *known*-dead drops it |
| `handleFocusKey` | **every keystroke** | same |

Ejecting the user from focus mode because the cache happened to be stale is the worse of the two ways to be wrong.

Two of these were beyond the original diagnosis: `fetchPreviewForSelected` is reached from `j`/`k`/`shift+↑↓` and ~10 other keys, and `focusTick` is 100ms not 500ms. Both match the 60 `KeyMsg`/`KeyPressMsg` stalls in the dumps.

## 3. Bounded `tmux has-session`

`hasSessionTimeout = 2s`, matching the neighbouring `listPanesTimeout`. This caps the one-off callers still on `IsAlive` (attach, quick-approve, context menu, paste) — left authoritative on purpose, since they want the true answer and are worth a bounded wait.

## Testing

`make lint` clean, `go test -race ./...` green (the `internal/linear` `TestCredentialResolutionOrder` failure is pre-existing on `master` — a real Linear credential in the local keychain leaking into the test).

The incremental scan is the risky change, so `TestReadClaudeSessionNameIncrementalMatchesFullScan` pins it against the full walk it replaces at every step. Mutation-tested — both obvious ways to break it fail the test:

- consuming the partial trailing line → `completed line: incremental read = "Renamed", want "Completed"`
- dropping the truncation reset → `after truncation: incremental read = "Completed", want "fresh start"`

## Not in scope

The perfwatch dumps also show a **mouse-wheel render storm** (267% CPU on a `MouseMode` that has no handlers anywhere in the repo) and a **~55ms `View()`** from chained `overlayAt` calls re-measuring the whole screen. Different subsystem, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJJZE3XYFxMqDazpWawrGU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced sidebar freezes during scrolling and navigation.
  * Improved responsiveness by preventing unnecessary transcript rescans and blocking session checks.
  * Added bounded session checks to prevent prolonged UI stalls.
  * Improved handling of growing, replaced, or partially written transcripts.
* **Reliability**
  * Preview and focus-mode updates now remain responsive when session status is unavailable or changing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->