### PR TITLE
fix(status): keep a session waiting on a single-question AskUserQuestion

### DIFF
--- a/changelog/unreleased/askuserquestion-waiting-status.md
+++ b/changelog/unreleased/askuserquestion-waiting-status.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Question prompts stay waiting.** A session parked on a single-question `AskUserQuestion` dialog no longer flips to running — and no longer flaps between the two as you arrow between options.

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -657,11 +657,10 @@ func lastLeadTranscriptTimestamp(path string) time.Time {
 }
 
 // leadConversationTypes are the JSONL entry types that prove the LEAD turn advanced:
-// the agent spoke or called a tool ("assistant"), a tool result or user message landed
-// ("user"), or the attachment that follows one did ("attachment"). Only these count for
-// conversationActivePastHook. Everything else in a transcript is bookkeeping that fires
-// while the lead is parked, and reading it as progress flips a genuinely blocked session
-// to running:
+// the agent spoke or called a tool ("assistant"), or a tool result or user message landed
+// ("user"). Only these count for conversationActivePastHook. Everything else in a
+// transcript is bookkeeping that fires while the lead is parked, and reading it as
+// progress flips a genuinely blocked session to running:
 //
 //   - "queue-operation" is something arriving AT a blocked lead — a message the user
 //     typed while a prompt is on screen, or a background agent's task-notification being
@@ -671,21 +670,34 @@ func lastLeadTranscriptTimestamp(path string) time.Time {
 //   - "system" (subtypes "stop_hook_summary", "turn_duration") is written as a turn ENDS.
 //   - "file-history-delta" is an edit snapshot, always paired with the "assistant"
 //     tool_use that caused it, so it carries no signal of its own.
+//   - "attachment" reads like part of the conversation and is not. Measured across the 39
+//     most recent local transcripts (8,474 attachments): 6,988 are "total_tokens_reminder",
+//     390 "task_reminder", and 174 "queued_command" — a message typed at a PARKED lead,
+//     structurally the same class as "queue-operation" above. Including it bought nothing
+//     to pay for that: it pushed the last-entry time past "assistant"/"user" in 3 of those
+//     39 transcripts, by at most 3 milliseconds.
 //
 // An allowlist rather than a denylist because Claude Code grows bookkeeping types far
 // more often than conversation types, so an unknown type is far likelier to be noise than
 // progress — and a resumed lead must emit "assistant" or "user", so there is no
-// resumption these miss.
+// resumption these two miss.
 var leadConversationTypes = map[string]bool{
-	"assistant":  true,
-	"user":       true,
-	"attachment": true,
+	"assistant": true,
+	"user":      true,
 }
 
-// scanTranscriptTimestamp walks the JSONL transcript at path and returns the first
-// (last=false) or last (last=true) entry timestamp it can parse. When leadOnly is set,
+// scanTranscriptTimestamp walks the JSONL transcript at path and returns the earliest
+// (last=false) or latest (last=true) entry timestamp it can parse. When leadOnly is set,
 // sub-agent (isSidechain:true) entries and bookkeeping entries are skipped, leaving only
 // the lead conversation (see leadConversationTypes).
+//
+// "latest" means the MAXIMUM, not the last line: transcripts are not written in timestamp
+// order. A message typed while the lead is parked is stamped when it is QUEUED and
+// appended when the lead RESUMES, so it lands out of order carrying a past timestamp —
+// measured backwards by up to 162s among "assistant"/"user" alone, in 28 of the 39 most
+// recent local transcripts. Overwriting on every match let one such entry understate how
+// far the conversation had got, which is the direction that demotes a live lead to
+// finished on exactly the between-bursts frame conversationActivePastHook exists to cover.
 func scanTranscriptTimestamp(path string, last bool, leadOnly bool) time.Time {
 	if path == "" {
 		return time.Time{}
@@ -712,8 +724,14 @@ func scanTranscriptTimestamp(path string, last bool, leadOnly bool) time.Time {
 		if err != nil {
 			return true
 		}
-		result = ts
-		return last // first match wins when we only want the earliest entry
+		if !last {
+			result = ts
+			return false // first match wins when we only want the earliest entry
+		}
+		if ts.After(result) {
+			result = ts
+		}
+		return true
 	})
 	return result
 }

--- a/internal/session/claude_name.go
+++ b/internal/session/claude_name.go
@@ -646,19 +646,47 @@ func lastTranscriptTimestamp(path string) time.Time {
 }
 
 // lastLeadTranscriptTimestamp returns the timestamp of the last lead-conversation
-// (non-sidechain) entry in the transcript at path, or the zero time if it's
-// missing/unreadable or has no such entries. Sub-agent (sidechain) entries are
-// skipped so a still-running sub-agent can't mask a finished lead turn. Used as the
+// entry in the transcript at path, or the zero time if it's missing/unreadable or has
+// no such entries. Sub-agent (sidechain) entries are skipped so a still-running
+// sub-agent can't mask a finished lead turn, and bookkeeping entries are skipped so
+// only the lead actually advancing counts (see leadConversationTypes). Used as the
 // out-of-pane tiebreaker for the between-bursts frame where the pane is
 // indistinguishable from finished (see conversationActivePastHook).
 func lastLeadTranscriptTimestamp(path string) time.Time {
 	return scanTranscriptTimestamp(path, true, true)
 }
 
+// leadConversationTypes are the JSONL entry types that prove the LEAD turn advanced:
+// the agent spoke or called a tool ("assistant"), a tool result or user message landed
+// ("user"), or the attachment that follows one did ("attachment"). Only these count for
+// conversationActivePastHook. Everything else in a transcript is bookkeeping that fires
+// while the lead is parked, and reading it as progress flips a genuinely blocked session
+// to running:
+//
+//   - "queue-operation" is something arriving AT a blocked lead — a message the user
+//     typed while a prompt is on screen, or a background agent's task-notification being
+//     enqueued. It fires *because* the lead is parked. A notification enqueued 4.9s after
+//     a PermissionRequest hook was enough to flip an unanswered AskUserQuestion dialog to
+//     running, and to keep it there for the whole 120s window.
+//   - "system" (subtypes "stop_hook_summary", "turn_duration") is written as a turn ENDS.
+//   - "file-history-delta" is an edit snapshot, always paired with the "assistant"
+//     tool_use that caused it, so it carries no signal of its own.
+//
+// An allowlist rather than a denylist because Claude Code grows bookkeeping types far
+// more often than conversation types, so an unknown type is far likelier to be noise than
+// progress — and a resumed lead must emit "assistant" or "user", so there is no
+// resumption these miss.
+var leadConversationTypes = map[string]bool{
+	"assistant":  true,
+	"user":       true,
+	"attachment": true,
+}
+
 // scanTranscriptTimestamp walks the JSONL transcript at path and returns the first
-// (last=false) or last (last=true) entry timestamp it can parse. When excludeSidechain
-// is set, sub-agent (isSidechain:true) entries are skipped.
-func scanTranscriptTimestamp(path string, last bool, excludeSidechain bool) time.Time {
+// (last=false) or last (last=true) entry timestamp it can parse. When leadOnly is set,
+// sub-agent (isSidechain:true) entries and bookkeeping entries are skipped, leaving only
+// the lead conversation (see leadConversationTypes).
+func scanTranscriptTimestamp(path string, last bool, leadOnly bool) time.Time {
 	if path == "" {
 		return time.Time{}
 	}
@@ -670,11 +698,12 @@ func scanTranscriptTimestamp(path string, last bool, excludeSidechain bool) time
 		var entry struct {
 			Timestamp   string `json:"timestamp"`
 			IsSidechain bool   `json:"isSidechain"`
+			Type        string `json:"type"`
 		}
 		if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Timestamp == "" {
 			return true
 		}
-		if excludeSidechain && entry.IsSidechain {
+		if leadOnly && (entry.IsSidechain || !leadConversationTypes[entry.Type]) {
 			return true
 		}
 		// RFC3339Nano: Claude transcripts stamp millisecond precision (e.g.

--- a/internal/session/claude_name_test.go
+++ b/internal/session/claude_name_test.go
@@ -443,8 +443,12 @@ func TestLastLeadTranscriptTimestamp(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "t.jsonl")
 		content := strings.Join([]string{
+			`{"type":"assistant","timestamp":"2026-08-23T14:17:52.532Z"}`,
 			`{"type":"user","timestamp":"2026-08-23T14:17:55.651Z"}`,
-			`{"type":"attachment","timestamp":"2026-08-23T14:17:55.667Z"}`,
+			// Reads like conversation and is not: 82% of attachments are
+			// "total_tokens_reminder", and "queued_command" is a message typed at a
+			// PARKED lead — the same class as "queue-operation" below.
+			`{"type":"attachment","attachment":{"type":"queued_command"},"timestamp":"2026-08-23T14:17:55.667Z"}`,
 			// Something arriving AT a parked lead, not the lead advancing.
 			`{"type":"queue-operation","operation":"enqueue","timestamp":"2026-08-23T14:18:57.857Z"}`,
 			// Written as a turn ENDS.
@@ -457,7 +461,7 @@ func TestLastLeadTranscriptTimestamp(t *testing.T) {
 			t.Fatal(err)
 		}
 		got := lastLeadTranscriptTimestamp(path)
-		want, _ := time.Parse(time.RFC3339Nano, "2026-08-23T14:17:55.667Z")
+		want, _ := time.Parse(time.RFC3339Nano, "2026-08-23T14:17:55.651Z")
 		if !got.Equal(want) {
 			t.Errorf("lastLeadTranscriptTimestamp = %v, want %v (bookkeeping entries should be skipped)", got, want)
 		}
@@ -467,6 +471,38 @@ func TestLastLeadTranscriptTimestamp(t *testing.T) {
 		wantAll, _ := time.Parse(time.RFC3339Nano, "2026-08-23T14:19:20.000Z")
 		if !gotAll.Equal(wantAll) {
 			t.Errorf("lastTranscriptTimestamp = %v, want %v (must NOT filter by type)", gotAll, wantAll)
+		}
+	})
+
+	// Transcripts are not written in timestamp order. A message typed while the lead is
+	// parked is stamped when it is QUEUED and appended when the lead RESUMES, so it lands
+	// out of order carrying a past timestamp — measured backwards by up to 162s among
+	// "assistant"/"user" alone, in 28 of 39 local transcripts. Taking the LAST matching
+	// line instead of the maximum understated how far the conversation had got, which is
+	// the direction that demotes a live lead to finished.
+	t.Run("takes the maximum, not the last line", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "t.jsonl")
+		content := strings.Join([]string{
+			`{"type":"user","timestamp":"2026-08-23T14:30:10.000Z"}`,
+			`{"type":"assistant","timestamp":"2026-08-23T14:30:26.239Z"}`,
+			// Queued 6s before the entry above, flushed after it.
+			`{"type":"user","timestamp":"2026-08-23T14:30:20.076Z"}`,
+		}, "\n") + "\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		want, _ := time.Parse(time.RFC3339Nano, "2026-08-23T14:30:26.239Z")
+		if got := lastLeadTranscriptTimestamp(path); !got.Equal(want) {
+			t.Errorf("lastLeadTranscriptTimestamp = %v, want %v (out-of-order entry must not pull it backwards)", got, want)
+		}
+		if got := lastTranscriptTimestamp(path); !got.Equal(want) {
+			t.Errorf("lastTranscriptTimestamp = %v, want %v", got, want)
+		}
+		// The earliest-entry scan still stops at the first match, unchanged.
+		wantFirst, _ := time.Parse(time.RFC3339Nano, "2026-08-23T14:30:10.000Z")
+		if got := firstTranscriptTimestamp(path); !got.Equal(wantFirst) {
+			t.Errorf("firstTranscriptTimestamp = %v, want %v", got, wantFirst)
 		}
 	})
 

--- a/internal/session/claude_name_test.go
+++ b/internal/session/claude_name_test.go
@@ -434,6 +434,42 @@ func TestLastLeadTranscriptTimestamp(t *testing.T) {
 		}
 	})
 
+	// A bookkeeping entry appended AFTER the last real lead entry must not move the
+	// timestamp: conversationActivePastHook reads it as "the lead resumed", and these
+	// fire precisely when it did not. "queue-operation" is the one that broke a live
+	// session — a background agent's task-notification enqueued 4.9s after a
+	// PermissionRequest hook flipped an unanswered AskUserQuestion dialog to running.
+	t.Run("skips bookkeeping entries after the last lead entry", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "t.jsonl")
+		content := strings.Join([]string{
+			`{"type":"user","timestamp":"2026-08-23T14:17:55.651Z"}`,
+			`{"type":"attachment","timestamp":"2026-08-23T14:17:55.667Z"}`,
+			// Something arriving AT a parked lead, not the lead advancing.
+			`{"type":"queue-operation","operation":"enqueue","timestamp":"2026-08-23T14:18:57.857Z"}`,
+			// Written as a turn ENDS.
+			`{"type":"system","subtype":"stop_hook_summary","timestamp":"2026-08-23T14:19:10.000Z"}`,
+			`{"type":"system","subtype":"turn_duration","timestamp":"2026-08-23T14:19:10.002Z"}`,
+			// Paired with the assistant tool_use that caused it; no signal of its own.
+			`{"type":"file-history-delta","timestamp":"2026-08-23T14:19:20.000Z"}`,
+		}, "\n") + "\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got := lastLeadTranscriptTimestamp(path)
+		want, _ := time.Parse(time.RFC3339Nano, "2026-08-23T14:17:55.667Z")
+		if !got.Equal(want) {
+			t.Errorf("lastLeadTranscriptTimestamp = %v, want %v (bookkeeping entries should be skipped)", got, want)
+		}
+		// lastTranscriptTimestamp is the rotation-detection signal, where ANY write
+		// proves the file is live — it must keep seeing all of them.
+		gotAll := lastTranscriptTimestamp(path)
+		wantAll, _ := time.Parse(time.RFC3339Nano, "2026-08-23T14:19:20.000Z")
+		if !gotAll.Equal(wantAll) {
+			t.Errorf("lastTranscriptTimestamp = %v, want %v (must NOT filter by type)", gotAll, wantAll)
+		}
+	})
+
 	t.Run("only sidechain entries returns zero", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "t.jsonl")

--- a/internal/session/golden_test.go
+++ b/internal/session/golden_test.go
@@ -34,6 +34,7 @@ var goldenTests = []struct {
 	{"pane_running_plan_checklist_deep.txt", StatusRunning, "plan execution with whimsical activity line pushed deep by expanding checklist"},
 	{"pane_finished_quoted_crashdump_whimsical.txt", StatusFinished, "idle prompt with embedded crash-dump example containing a whimsical activity line in scrollback (~30 lines from bottom)"},
 	{"pane_waiting_askuserquestion_checkbox_focus.txt", StatusWaiting, "AskUserQuestion dialog with focus on checkbox question header (no `❯ N.` cursor in numbered options)"},
+	{"pane_waiting_askuserquestion_single_preview.txt", StatusWaiting, "single-question AskUserQuestion dialog with a side-by-side preview panel — the panel pushes `❯ 1.` to recentLines[19], past the menu check's 15-line window, and a one-question dialog omits the `Tab to switch questions` hint, so only the `n to add notes` + `Esc to cancel` footer pair identifies it"},
 	{"pane_waiting_exitplanmode_approve.txt", StatusWaiting, "ExitPlanMode plan-approval menu — numbered options with `shift+tab to approve with this feedback` footer (no `Esc to cancel`)"},
 	{"finished_idle_background_agent.txt", StatusRunning, "lead parked (Stop) but a background sub-agent is still in-flight in the dock (`◯ databento-operator … 27m 30s · ↓ 93.8k tokens`) → running"},
 	{"pane_running_background_agents_multi.txt", StatusRunning, "three in-flight background Explore agents in the dock (`◯ Explore … · ↓ tokens`) while the lead is parked → running"},

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -2254,16 +2254,30 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 	}
 
 	// Structural check: AskUserQuestion tool dialog.
-	// The footer "Tab to switch questions" only appears in this tool's UI —
-	// no other Claude prompt has tabs between questions. Pair with "Esc to cancel"
-	// to avoid matching conversation text that mentions tabs.
+	// Two hints appear only in this tool's footer: "Tab to switch questions" and
+	// "n to add notes". Either one paired with "Esc to cancel" on the same line
+	// identifies the dialog; the pairing is what keeps conversation text mentioning
+	// tabs or notes from matching.
+	//
+	// "n to add notes" is what covers the SINGLE-question variant, which omits the Tab
+	// hint because there is nothing to switch to. That variant can also fall outside the
+	// menu check's bottomN window above: when the dialog renders a side-by-side preview
+	// panel beside the options, the panel is ~20 lines tall and pushes the "❯ N." cursor
+	// line past the window while the options and footer stay inside it. Nothing else
+	// structurally confirms the prompt, so the session read as running while it was
+	// blocked — and flapped as the user arrowed between options whose panels differ in
+	// height, sliding the cursor line in and out of the window.
+	//
 	// The cursor `❯` and numbered options here are unstable as the user navigates
 	// (Tab moves focus to checkbox-style question rows where `❯` disappears),
 	// so the menu structural check above misses these states. The footer is
 	// rendered identically on every tick regardless of which question has focus.
 	for i := 0; i < bottomN; i++ {
 		lower := strings.ToLower(recentLines[i])
-		if strings.Contains(lower, "tab to switch questions") && strings.Contains(lower, "esc to cancel") {
+		if !strings.Contains(lower, "esc to cancel") {
+			continue
+		}
+		if strings.Contains(lower, "tab to switch questions") || strings.Contains(lower, "n to add notes") {
 			log.Debug("detectStatus: matched askuserquestion footer")
 			return StatusWaiting
 		}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -2,11 +2,15 @@ package session
 
 import (
 	"log/slog"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/brizzai/fleet/internal/agent"
+	"github.com/brizzai/fleet/internal/debuglog"
 )
 
 func TestStripANSI(t *testing.T) {
@@ -284,5 +288,101 @@ func TestInitialPromptIsOneShot(t *testing.T) {
 		if strings.HasPrefix(e, "FLEET_INITIAL_PROMPT=") {
 			t.Errorf("relaunch env still carries the prompt: %q", e)
 		}
+	}
+}
+
+// TestConversationActivePastHookIgnoresQueuedWork covers the bug where a session
+// blocked on an unanswered AskUserQuestion dialog reported Running.
+//
+// Two signals had to fail together to get there, and this is the second one. The pane
+// went silent (a side-by-side preview panel pushed the "❯ N." cursor line past
+// detectWaiting's window — see the pane_waiting_askuserquestion_single_preview golden),
+// which handed the deciding vote to the transcript tiebreaker. The transcript's newest
+// entry was:
+//
+//	{"type":"queue-operation","operation":"enqueue", … "Agent \"…\" finished" …}
+//
+// a background agent's task-notification being enqueued 4.9s after the PermissionRequest
+// hook. It fires *because* the lead is parked, so counting it as progress inverted the
+// tiebreaker's own premise — "the LEAD-only transcript stays static while the lead is
+// truly blocked" — and pinned the session to running for the whole 120s window.
+func TestConversationActivePastHookIgnoresQueuedWork(t *testing.T) {
+	debuglog.Init()
+
+	// Anchor on wall-clock: the tiebreaker also requires the last entry to be recent
+	// (conversationActiveWindow), so fixed dates would fail on age alone and the test
+	// would pass for the wrong reason.
+	now := time.Now().UTC()
+	hookAt := now.Add(-45 * time.Second)
+	stamp := func(d time.Duration) string {
+		return hookAt.Add(d).Format(time.RFC3339Nano)
+	}
+	// Real lead work, a full minute BEFORE the hook — the lead has not moved since.
+	lead := []string{
+		`{"type":"assistant","timestamp":"` + stamp(-61*time.Second) + `"}`,
+		`{"type":"user","timestamp":"` + stamp(-58*time.Second) + `"}`,
+		`{"type":"attachment","timestamp":"` + stamp(-57*time.Second) + `"}`,
+	}
+	// Past the hook by more than conversationActiveSkew, and recent enough to be inside
+	// conversationActiveWindow — exactly the frame that flipped the live session.
+	pastHook := stamp(5 * time.Second)
+
+	cases := []struct {
+		name string
+		tail string
+		want bool
+	}{
+		{
+			name: "queued task-notification is not progress",
+			tail: `{"type":"queue-operation","operation":"enqueue","timestamp":"` + pastHook + `","content":"<task-notification>Agent finished</task-notification>"}`,
+			want: false,
+		},
+		{
+			name: "turn-end bookkeeping is not progress",
+			tail: `{"type":"system","subtype":"stop_hook_summary","timestamp":"` + pastHook + `"}`,
+			want: false,
+		},
+		{
+			name: "still-running sub-agent is not progress",
+			tail: `{"type":"assistant","isSidechain":true,"timestamp":"` + pastHook + `"}`,
+			want: false,
+		},
+		{
+			// Positive control. Without it every assertion above would also pass on a
+			// scanner that had stopped finding anything at all.
+			name: "a resumed lead turn IS progress",
+			tail: `{"type":"assistant","timestamp":"` + pastHook + `"}`,
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			project := t.TempDir()
+			const claudeID = "a9045325-69ee-4103-9cd5-d7cf07c8c9a8"
+
+			dir := filepath.Join(home, ".claude", "projects", ClaudeProjectDirName(project))
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			body := strings.Join(append(append([]string{}, lead...), tc.tail), "\n") + "\n"
+			path := filepath.Join(dir, claudeID+".jsonl")
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			s := &Session{
+				ID:              "test-conv-active",
+				Agent:           agent.Claude,
+				ClaudeSessionID: claudeID,
+				ProjectPath:     project,
+				hookUpdatedAt:   hookAt,
+			}
+			if got := s.conversationActivePastHook(); got != tc.want {
+				t.Errorf("conversationActivePastHook() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -321,7 +321,6 @@ func TestConversationActivePastHookIgnoresQueuedWork(t *testing.T) {
 	lead := []string{
 		`{"type":"assistant","timestamp":"` + stamp(-61*time.Second) + `"}`,
 		`{"type":"user","timestamp":"` + stamp(-58*time.Second) + `"}`,
-		`{"type":"attachment","timestamp":"` + stamp(-57*time.Second) + `"}`,
 	}
 	// Past the hook by more than conversationActiveSkew, and recent enough to be inside
 	// conversationActiveWindow — exactly the frame that flipped the live session.
@@ -345,6 +344,14 @@ func TestConversationActivePastHookIgnoresQueuedWork(t *testing.T) {
 		{
 			name: "still-running sub-agent is not progress",
 			tail: `{"type":"assistant","isSidechain":true,"timestamp":"` + pastHook + `"}`,
+			want: false,
+		},
+		{
+			// "attachment" reads like conversation but is overwhelmingly bookkeeping,
+			// and "queued_command" is a message typed at a PARKED lead — the same class
+			// as the queue-operation above, arriving through a different type.
+			name: "queued_command attachment is not progress",
+			tail: `{"type":"attachment","attachment":{"type":"queued_command"},"timestamp":"` + pastHook + `"}`,
 			want: false,
 		},
 		{

--- a/internal/session/testdata/pane_waiting_askuserquestion_single_preview.txt
+++ b/internal/session/testdata/pane_waiting_askuserquestion_single_preview.txt
@@ -1,0 +1,54 @@
+  ⎿  Read 1 file (ctrl+o to expand)
+
+⏺ Two of the three log lines are truncated mid-token, so the tail is unreadable.
+  Let me check how long they actually are before proposing a fix.
+
+  Ran 2 shell commands 
+
+⏺ Measured across the sample: 412 of 1,208 lines exceed the column budget, and 37 of
+  those are more than half padding by character count.
+
+  Here is what the renderer can reach, best to worst:
+
+  ┌───────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────┐
+  │               Source              │                                           Value                                           │
+  ├───────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+  │ line_template.sample (shown now)  │ log: request failed: {<str>:{<str>:[{<str>:<str>,…                                          │
+  ├───────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+  │ record message (raw)              │ log: request failed: {"detail":[{"msg":"request failed",…                                  │
+  ├───────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+  │ record summary                    │ timeout on the batch endpoint                                                              │
+  ├───────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+  │ record description (generated)    │ already shown at the top of the panel — repeating it is pointless                          │
+  └───────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────┘
+
+  The padding is not incidental: sample is padded because it is stored on the record and served that way. Raw text lives per-record instead.
+
+[2m──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[39m
+ [1m☐ Degenerate line[0m 
+
+How should the renderer handle a sample that is mostly padding?
+
+[36m❯ 1. Trim at the payload[39m          ┌──────────────────────────────────────────────────┐
+[36m    boundary (Recommended)[39m        │ BEFORE                                            │
+  2. Fall back to the record     │ ┌──────────────────────────────────────────┐     │
+    summary                       │ │ log: request failed: {<str>:{<str>: │ │
+  3. Use the raw message from     │ │ [{<str>:<str>,<str>:[{<str>:1,<str>:33}],   │  │
+    records                       │ │ <str>:[<str>],<str>:{<str>:500,<str>:<st    │  │
+  4. Trim, and keep the           │ └──────────────────────────────────────────┘     │
+    payload behind a toggle       │                                                  │
+                                  │ AFTER                                             │
+                                  │ ┌──────────────────────────────────────────┐     │
+                                  │ │ log: request failed                        │  │
+                                  │ │                    View in context ↗   │  │
+                                  │ └──────────────────────────────────────────┘     │
+                                  │                                                  │
+                                  │ 🔧 batch_endpoint  12 of 37 records · 32%       │
+                                  └──────────────────────────────────────────────────┘
+
+                                  [2mNotes: press n to add notes[39m
+
+[2m──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[39m
+  [2mChat about this[39m
+
+[2mEnter to select · ↑/↓ to navigate · n to add notes · Esc to cancel[39m


### PR DESCRIPTION
A session blocked on an unanswered `AskUserQuestion` dialog reported **Running**, and flapped between Running and Waiting as the user arrowed between options. Diagnosed from a `D` snapshot: hook said `waiting`, `pane_detected` was empty, TUI showed `running`.

Two independent signals had to fail together, and both did.

## 1. The pane went silent

The dialog renders a **side-by-side preview panel** next to the options. That panel is ~20 lines tall, so the cursor line sits well above the window `detectWaiting` scans:

```
 0 | Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel   ← footer ✓
13 |   4. Trim, and keep the           │ └────────┘                       ← other option ✓
19 | ❯ 1. Trim at the payload          ┌────────────                      ← cursor ✗ (bottomN = 15)
```

`hasMenuFooter` and `hasOtherOption` were true, `hasCursorOnOption` false → no match. The dedicated AskUserQuestion check didn't rescue it either: it required `Tab to switch questions`, and a **single-question** dialog omits that hint because there is nothing to switch to.

`detectWaiting` now accepts `n to add notes` **or** `Tab to switch questions`, each paired with `Esc to cancel` on the same line.

## 2. The transcript tiebreaker voted, and was wrong

With the pane silent, `conversationActivePastHook` decided. Its newest "lead" entry:

```json
{"type":"queue-operation","operation":"enqueue","timestamp":"2026-08-23T14:18:57.857Z",
 "content":"<task-notification>… Agent \"Commit and push BRZ-3287\" finished …"}
```

A background agent's completion notification being **enqueued** while the lead sat blocked. It fires *because* the lead is parked — the exact inverse of the tiebreaker's stated premise, *"the LEAD-only transcript stays static while the lead is truly blocked."* Last genuine lead activity was 62s **before** the hook.

`scanTranscriptTimestamp` accepted any timestamped line and filtered only `isSidechain: true`; `queue-operation` entries carry `isSidechain: null`. 4.9s past the hook (> 2s skew) and 40s old (< 120s window) → `convActive = true` → running, pinned for the whole window.

The lead scan now allowlists the conversation types (`assistant` / `user` / `attachment`). An allowlist rather than a denylist because Claude Code grows bookkeeping types far more often than conversation types, so an unknown type is likelier noise than progress — and a resumed lead must emit `assistant` or `user`, so there is no resumption it misses. `lastTranscriptTimestamp`, the rotation-detection signal where *any* write is the point, stays unfiltered.

## The flapping

Same bug from the other side. At 17:20:24–28 the log reads `matched permission menu structure`; at 17:20:29, `no pattern matched`. The status tracked **which option was highlighted** — a shorter preview panel pulled `❯ N.` back inside the window, a taller one pushed it out.

## Not done here

Widening `bottomN` for the option lines (scan further up for the cursor while keeping the footer anchored to the bottom 15) would also have caught this. Left out: the footer path covers this dialog structurally, and loosening the menu gate deserves its own decision.

## Tests

Each fails without its fix:

- `TestGoldenDetection/pane_waiting_askuserquestion_single_preview.txt` — sanitized fixture reproducing the real geometry byte-for-byte (`❯ 1.` at index 19, option at 13, footer at 0, no Tab hint). The menu check still misses it, as it did live; the footer check catches it.
- `TestLastLeadTranscriptTimestamp/skips_bookkeeping_entries…` — also asserts `lastTranscriptTimestamp` still sees every entry, so the filter can't leak into rotation detection.
- `TestConversationActivePastHookIgnoresQueuedWork` — end-to-end over a real temp transcript, with a positive control (a genuine resumed `assistant` entry must still return true) so the negative cases can't pass on a scanner that simply found nothing.

`make lint` clean. `TestCredentialResolutionOrder` fails on master too (it reads the developer's real Linear keychain entry) — unrelated.

## Loose end

The *first* flip happened 722ms after the hook, before the `queue-operation` existed, so a third path put it into running initially. `debug.log` had rotated past that window. Most likely the content-hash branch (`content changed while waiting, assuming running`) firing on a stale `lastContentHash` from the prior waiting episode. Worth revisiting if it recurs at sub-second hook age.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJJZE3XYFxMqDazpWawrGU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Single-question prompts now remain in the waiting state while navigating options, without incorrectly switching to running.
  * Improved detection of question prompts even when options or cursor indicators are not visible.
  * Background notifications, hooks, and sidechain activity no longer incorrectly appear as active conversation progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->