### PR TITLE
fix(ui): stop mouse reporting pinning the CPU on scroll

### DIFF
--- a/changelog/unreleased/mouse-repaint-storm.md
+++ b/changelog/unreleased/mouse-repaint-storm.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Scrolling no longer pegs the CPU.** fleet put your terminal into mouse-reporting mode but never handled a mouse event, so a trackpad scroll over the TUI fired ~300 ignored redraws a second and held fleet at 220% CPU until you stopped. Drag-select and scrollback now behave like they do in any other terminal app.

--- a/changelog/unreleased/mouse-repaint-storm.md
+++ b/changelog/unreleased/mouse-repaint-storm.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**Scrolling no longer pegs the CPU.** fleet put your terminal into mouse-reporting mode but never handled a mouse event, so a trackpad scroll over the TUI fired ~300 ignored redraws a second and held fleet at 220% CPU until you stopped. Drag-select and scrollback now behave like they do in any other terminal app.
+**Scrolling no longer pegs the CPU.** fleet put your terminal into mouse-reporting mode but never handled a mouse event, so a trackpad scroll over the TUI fired ~300 ignored redraws a second and held fleet at 220% CPU until you stopped. Drag-select now works without holding a modifier.

--- a/internal/termkeys/termkeys.go
+++ b/internal/termkeys/termkeys.go
@@ -13,6 +13,16 @@
 //
 // Asking the terminal for legacy key reporting forces Ctrl+K back to 0x0b, so
 // the palette opens reliably. Alt+<digit> slot bindings benefit the same way.
+//
+// It also turns off xterm's alternate-screen scroll (DECSET 1007), which is a
+// key-reporting mode in the same sense: while the alternate screen is up and
+// mouse reporting is off, a terminal with 1007 on *synthesizes arrow keys from
+// the wheel*. fleet asks for no mouse reporting (see Home.chrome) and stays in
+// the alternate screen, which is exactly that combination — so without this a
+// trackpad scroll would arrive as a burst of Up/Down KeyPressMsg: walking the
+// sidebar cursor and forking a preview capture per tick, and, with the drawer
+// focused, walking the shell's readline history (arrows are not intercepted by
+// handleTypingKey, so they reach forwardKeyToPane).
 package termkeys
 
 import (
@@ -28,12 +38,27 @@ import (
 // instead of forcing off), so we keep the literal here.
 const disableModifyOtherKeys = "\x1b[>4;0m"
 
+// Alternate-screen scroll (DECSET 1007) is saved and reset rather than blindly
+// re-enabled on exit: the terminal's prior value is unknowable from here, so a
+// DECSET in Restore would be wrong for anyone who started with it off. XTSAVE
+// (Ps=s) / XTRESTORE (Ps=r) are the paired form xterm defines for exactly this.
+// Literals for the same reason disableModifyOtherKeys is one — x/ansi carries no
+// constant for 1007.
+const (
+	saveAltScreenScroll    = "\x1b[?1007s"
+	disableAltScreenScroll = "\x1b[?1007l"
+	restoreAltScreenScroll = "\x1b[?1007r"
+)
+
 // disablePreamble forces legacy key reporting across the two enhancement
 // mechanisms a Ctrl+K could be intercepted by: modifyOtherKeys off, plus a
 // flags=0 entry pushed onto the Kitty keyboard protocol stack
 // (ansi.DisableKittyKeyboard) so CSI-u reporting is suppressed while preserving
-// whatever state the shell/tmux had. Terminals without a mode ignore its bytes.
-const disablePreamble = disableModifyOtherKeys + ansi.DisableKittyKeyboard
+// whatever state the shell/tmux had. It then saves and clears alternate-screen
+// scroll, so the wheel stops being turned into arrow keys. Terminals without a
+// mode ignore its bytes.
+const disablePreamble = disableModifyOtherKeys + ansi.DisableKittyKeyboard +
+	saveAltScreenScroll + disableAltScreenScroll
 
 // Disable asks the terminal for legacy key reporting so modified keys (Ctrl+K
 // in particular) arrive in their legacy encoding instead of as CSI-u sequences
@@ -44,11 +69,12 @@ func Disable(w io.Writer) error {
 	return err
 }
 
-// Restore undoes Disable in reverse: it pops the Kitty keyboard entry we pushed
-// (ansi.PopKittyKeyboard, a func so it can't be a package const) and resets
-// modifyOtherKeys to the terminal's initial value. Call on exit to leave the
-// terminal's key-reporting state as we found it.
+// Restore undoes Disable in reverse: it restores the saved alternate-screen
+// scroll value, pops the Kitty keyboard entry we pushed (ansi.PopKittyKeyboard,
+// a func so it can't be a package const) and resets modifyOtherKeys to the
+// terminal's initial value. Call on exit to leave the terminal's key-reporting
+// state as we found it.
 func Restore(w io.Writer) error {
-	_, err := io.WriteString(w, ansi.PopKittyKeyboard(1)+ansi.ResetModifyOtherKeys)
+	_, err := io.WriteString(w, restoreAltScreenScroll+ansi.PopKittyKeyboard(1)+ansi.ResetModifyOtherKeys)
 	return err
 }

--- a/internal/termkeys/termkeys_test.go
+++ b/internal/termkeys/termkeys_test.go
@@ -11,8 +11,10 @@ func TestDisableWritesLegacyKeyReporting(t *testing.T) {
 		t.Fatalf("Disable returned error: %v", err)
 	}
 	// modifyOtherKeys off + push Kitty flags=0 (legacy); ansi.DisableKittyKeyboard
-	// emits the flags-omitted form (\x1b[>u), equivalent to an explicit 0.
-	if got, want := b.String(), "\x1b[>4;0m\x1b[>u"; got != want {
+	// emits the flags-omitted form (\x1b[>u), equivalent to an explicit 0. Then
+	// save + clear alternate-screen scroll (1007), so the terminal stops turning
+	// the wheel into arrow keys while fleet is on the alternate screen.
+	if got, want := b.String(), "\x1b[>4;0m\x1b[>u\x1b[?1007s\x1b[?1007l"; got != want {
 		t.Errorf("Disable wrote %q, want %q", got, want)
 	}
 }
@@ -22,10 +24,32 @@ func TestRestoreUndoesDisableSymmetrically(t *testing.T) {
 	if err := Restore(&b); err != nil {
 		t.Fatalf("Restore returned error: %v", err)
 	}
-	// Pop the Kitty entry we pushed + reset modifyOtherKeys to default;
-	// ansi.PopKittyKeyboard(1) emits the explicit count form (\x1b[<1u).
-	if got, want := b.String(), "\x1b[<1u\x1b[>4m"; got != want {
+	// Restore 1007 to whatever Disable saved, then pop the Kitty entry we pushed
+	// + reset modifyOtherKeys to default; ansi.PopKittyKeyboard(1) emits the
+	// explicit count form (\x1b[<1u).
+	if got, want := b.String(), "\x1b[?1007r\x1b[<1u\x1b[>4m"; got != want {
 		t.Errorf("Restore wrote %q, want %q", got, want)
+	}
+}
+
+// TestRestoreNeverForcesAltScreenScrollOn pins the save/restore pairing rather
+// than the bytes: Disable clears mode 1007, and the obvious "undo" is a DECSET
+// on the way out — which silently turns the mode ON for every user who started
+// with it off, since the terminal's prior value is unknowable from here. XTSAVE
+// (1007s) / XTRESTORE (1007r) is the only form that leaves both kinds of user
+// as they were, so a DECSET appearing in Restore is a regression, not a cleanup.
+func TestRestoreNeverForcesAltScreenScrollOn(t *testing.T) {
+	var b strings.Builder
+	if err := Restore(&b); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	if strings.Contains(b.String(), "\x1b[?1007h") {
+		t.Errorf("Restore wrote a DECSET for 1007 (%q); it must restore the saved "+
+			"value with \\x1b[?1007r, not force the mode on", b.String())
+	}
+	if !strings.Contains(b.String(), restoreAltScreenScroll) {
+		t.Errorf("Restore wrote %q, missing the 1007 XTRESTORE — Disable saved a "+
+			"value that nothing puts back", b.String())
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2233,7 +2233,10 @@ func (h *Home) chrome(content string) tea.View {
 	// with cell-motion on, one trackpad scroll over the window became ~300 ignored
 	// MouseWheelMsg/sec, each buying a full View() — measured at 220% CPU for as
 	// long as the finger moved, with nothing on screen changing. Off also hands
-	// drag-select and scrollback back to the terminal.
+	// drag-select back to the terminal — not scrollback, which the alternate
+	// screen does not have. Reporting off is only half of it: internal/termkeys
+	// clears DECSET 1007 alongside, or the terminal would synthesize arrow keys
+	// from the wheel instead and the events would land as KeyPressMsg.
 	v.MouseMode = tea.MouseModeNone
 	return v
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2228,7 +2228,13 @@ func (h *Home) View() tea.View {
 func (h *Home) chrome(content string) tea.View {
 	v := tea.NewView(content)
 	v.AltScreen = true
-	v.MouseMode = tea.MouseModeCellMotion
+	// MouseModeNone, deliberately: nothing in the TUI handles a mouse event, and
+	// reporting is not free. v2's eventLoop re-renders after *every* message, so
+	// with cell-motion on, one trackpad scroll over the window became ~300 ignored
+	// MouseWheelMsg/sec, each buying a full View() — measured at 220% CPU for as
+	// long as the finger moved, with nothing on screen changing. Off also hands
+	// drag-select and scrollback back to the terminal.
+	v.MouseMode = tea.MouseModeNone
 	return v
 }
 


### PR DESCRIPTION
## What

`chrome()` set `MouseModeCellMotion` on every frame, putting the terminal into DECSET 1002. **Nothing in the TUI has ever handled a mouse event** — that line was the only `Mouse` reference in the entire non-test tree:

```
internal/ui/app.go:2231   v.MouseMode = tea.MouseModeCellMotion
internal/diagnostics/…    (only reports tmux's own mouse setting)
```

It was carried forward from v1's `NewProgram` options during the v2 migration (#153); a handler was never written.

## Why it hurt

Bubble Tea v2's `eventLoop` calls `p.render(model)` **unconditionally** after every message — there's no dirty check (`bubbletea/v2/tea.go:888`). So every ignored `MouseWheelMsg` still bought a full `View()`.

A trackpad scroll over the window produced ~300 msg/sec. `Update()` itself is free (**83ns** — the message is ignored), but the render is not:

```
18:07:10.375  tea.MouseWheelMsg    83ns
18:07:10.378  tea.MouseWheelMsg    83ns
...  (31 of 32 ring slots, in all 8 dumps)
```

Measured from `perfwatch` heartbeats: +287 msg/sec for +123 points of CPU ≈ **4.3ms of CPU per frame**, sustaining **220% CPU** (2.2 cores) for 45s, with nothing on screen changing. `updates_slow=1` for the whole 37k-update run — nothing blocked; it was pure repaint volume.

Seven goroutine samples across the storm caught the main goroutine mid-render every time, never in Update logic and never on I/O:

| Samples | Location |
|---|---|
| 4/7 | `ansi.StringWidth` → `FirstGraphemeCluster` → uax29 grapheme scan, via `lipgloss.JoinHorizontal` |
| 1/7 | `lipgloss.Style.Render` in `renderBorderedPanel` |
| 2/7 | `ultraviolet` cell diff / `Layer.Draw` |

Not a one-off: **115 storm dumps over ~20 days**, 8 in a single hour on the day this was diagnosed.

## The change

One line — `v.MouseMode = tea.MouseModeNone` — plus a comment recording why, so it doesn't get "restored" later.

Turning reporting off also hands **drag-select** back to the terminal, which cell-motion had been taking (selection needed a modifier) with nothing to show for it. Not scrollback — fleet stays in `AltScreen`, which has none.

## Follow-up from review (e08f111)

@hayke102 caught that `MouseModeNone` doesn't remove the wheel events, it *re-sources* them: with the alternate screen up, a terminal with DECSET 1007 on synthesizes arrow keys from the wheel. Those land on `case "j", "down"` (cursor walk + an unthrottled preview fork per tick) and, with the drawer focused, on `forwardKeyToPane` → tmux `Up`/`Down`, walking the shell's readline history.

So the commit also clears mode 1007, in `internal/termkeys` — which already writes raw mode escapes as literals and already has a `Restore()` wired on exit, so no new package and no new call site. Saved with XTSAVE and put back with XTRESTORE rather than re-enabled with a DECSET, since the terminal's prior value is unknowable from here and a blind DECSET would turn the mode *on* for anyone who started with it off. A test pins that.

**Not yet measured** — the one thing the reviewer actually asked for. Pending, and the thread is deliberately left open until it lands: (1) does the terminal translate wheel→arrows at all; (2) does entering the alt screen reset 1007, given `termkeys.Disable` runs before `p.Run()`; (3) does it survive an attach round trip, since tmux sets its own modes.

## Known limitation

This removes the *source*, not the *amplifier*. v2 still re-renders after every message and `View()` still costs ~4.3ms, so any future high-rate message source reproduces the same shape. The durable fix is memoizing `View()` behind a dirty flag — deliberately out of scope here.

## Test plan

- [x] `make build`
- [ ] Run with `FLEET_DEBUG=1`, scroll hard over the TUI for ~10s, confirm no new `update_storm` dump in `~/.config/fleet/stalls/`
- [ ] Confirm drag-to-select works in the fleet window without a modifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjtVGXqcpwvUXmGCzWVUrk
