### PR TITLE
fix(status): stop prose about a question prompt reading as one

### DIFF
--- a/changelog/unreleased/prose-footer-false-waiting.md
+++ b/changelog/unreleased/prose-footer-false-waiting.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**Talking about a prompt no longer looks like one.** A finished session whose output mentioned `n to add notes` and `Esc to cancel` in the same sentence was read as a live question dialog and stuck on waiting until the text scrolled away.
+**Finished sessions stay finished.** Your session no longer sticks on waiting when its own output happens to mention `n to add notes` and `Esc to cancel` in one sentence — fleet read that as a live question prompt.

--- a/changelog/unreleased/prose-footer-false-waiting.md
+++ b/changelog/unreleased/prose-footer-false-waiting.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Talking about a prompt no longer looks like one.** A finished session whose output mentioned `n to add notes` and `Esc to cancel` in the same sentence was read as a live question dialog and stuck on waiting until the text scrolled away.

--- a/changelog/unreleased/prose-footer-false-waiting.md
+++ b/changelog/unreleased/prose-footer-false-waiting.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**Finished sessions stay finished.** Your session no longer sticks on waiting when its own output happens to mention `n to add notes` and `Esc to cancel` in one sentence — fleet read that as a live question prompt.
+**Finished sessions stay finished.** Your session no longer sticks on waiting because its own output quoted a permission prompt — a numbered menu, or `n to add notes` and `Esc to cancel` in a sentence, read as a live prompt until the text scrolled away.

--- a/internal/session/golden_test.go
+++ b/internal/session/golden_test.go
@@ -40,6 +40,7 @@ var goldenTests = []struct {
 	{"pane_running_background_agents_multi.txt", StatusRunning, "three in-flight background Explore agents in the dock (`◯ Explore … · ↓ tokens`) while the lead is parked → running"},
 	{"pane_finished_quoted_dock_row.txt", StatusFinished, "idle pane whose conversation quotes a dock row verbatim (`◯ Explore … · ↓ tokens`) above the chrome — must NOT read as running (position guard: dock only scanned in bottom 3 lines)"},
 	{"pane_waiting_permission_with_dock.txt", StatusWaiting, "permission menu with live dock rows below it — waiting must win over the dock's running (detectWaiting precedes the dock check)"},
+	{"pane_finished_prose_mentions_askuserquestion_footer.txt", StatusFinished, "idle pane whose conversation summary describes the AskUserQuestion footer in prose (`… footer (n to add notes + Esc to cancel), so a dialog whose …`) — both hints on one line, 11 lines from the bottom. Substring matching read this as a live dialog and pinned the finished session to waiting; the hints must be whole fields of the footer's `·`-separated list"},
 	{"pane_running_compacting.txt", StatusRunning, "mid-`/compact` pane — the compaction activity line (`· Compacting conversation… (2m 27s)`) is matched now that the activity check no longer requires a token counter, so the pane reads running on its own instead of leaning entirely on the PreCompact hook. Safe because the line is replaced by the `⎿  Compacted (ctrl+o …)` result row on completion rather than left in scrollback — no captured pane holds both"},
 }
 

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -1144,3 +1144,39 @@ func TestScenarioProseAboutFooterDoesNotPinWaiting(t *testing.T) {
 		},
 	})
 }
+
+func TestScenarioProseQuotingAMenuDoesNotPinWaiting(t *testing.T) {
+	// Regression (PR #269 review): the sibling of the prose-footer bug above.
+	// isAskUserQuestionFooter matches its hints as whole fields, but the numbered-menu
+	// check one block up still substring-matched its own footer anywhere in the bottom
+	// 15 lines. A session doing status-detection work prints both halves as ordinary
+	// conversation — a quoted menu and the words "Esc to cancel" — so the same finished
+	// session was pinned to waiting through applyHookFinished's pane override.
+	//
+	// Fix: a footer only counts within footerN (3) of the bottom. Measured across every
+	// pane_waiting_* fixture the real footer sits at index 0-2; prose about one sits
+	// above the input box and mode bar the TUI always renders below it.
+	menuProse := "⏺ The permission dialog renders options like:\n\n" +
+		"  ❯ 1. Yes\n  2. No, tell Claude what to do differently\n\n" +
+		"  The footer (n to add notes + Esc to cancel) is what identifies it.\n\n" +
+		"✻ Worked for 59s\n\n❯ \n  ⏵⏵ auto mode on (shift+tab to cycle)\n"
+
+	// The same menu, actually live: options and footer at the bottom, no chrome under
+	// them. Guards against "fixing" this by disabling the menu check outright.
+	liveMenu := "Read(~/code/foo/bar.ts)\n\nDo you want to proceed?\n\n" +
+		"❯ 1. Yes\n  2. No\n\nEsc to cancel · Tab to amend\n"
+
+	runScenario(t, Scenario{
+		Name: "hook=finished + prose quoting a menu → finished, not waiting",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "finished", Pane: menuProse},
+			{At: 30 * time.Second, Pane: menuProse},
+			{At: 60 * time.Second, Pane: liveMenu},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusFinished},                // before fix: waiting
+			{At: 30 * time.Second, Expected: StatusFinished}, // before fix: waiting
+			{At: 60 * time.Second, Expected: StatusWaiting},  // a real menu still overrides the finished hook
+		},
+	})
+}

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -1119,9 +1119,15 @@ func TestScenarioProseAboutFooterDoesNotPinWaiting(t *testing.T) {
 		t.Skipf("fixture %s not available", fixture)
 	}
 
-	// The real footer, for contrast: same two hints, but as fields of the "·" list.
-	// A genuine dialog must still hold the session at waiting.
-	realFooter := "Which approach?\n\n❯ 1. Rewrite\n  2. Patch\n\n" +
+	// The real footer, for contrast: the same two hints, but as fields of the "·"
+	// list. Carries no "❯ N." cursor line and no second numbered option, so the
+	// numbered-menu check above cannot fire and the footer is the only thing that
+	// can identify it — the checkbox-focus state, and the shape the single-question
+	// preview variant lands in when its panel pushes the cursor out of the window.
+	// The hook is deliberately left on "finished" here: a "waiting" hook would set
+	// the status on its own and the assertion would hold even with the footer check
+	// deleted.
+	realFooter := "Round 3: Architecture\n☒ Stack  ☐ Process model  ☐ V1 scope\n\n" +
 		"Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel\n"
 
 	runScenario(t, Scenario{
@@ -1129,12 +1135,12 @@ func TestScenarioProseAboutFooterDoesNotPinWaiting(t *testing.T) {
 		Events: []ScenarioEvent{
 			{At: 0, Hook: "finished", Pane: "@fixture:" + fixture},
 			{At: 30 * time.Second, Pane: "@fixture:" + fixture}, // still parked; must not drift to waiting
-			{At: 60 * time.Second, Hook: "waiting", Pane: realFooter},
+			{At: 60 * time.Second, Pane: realFooter},
 		},
 		Checks: []ScenarioCheck{
 			{At: 0, Expected: StatusFinished},                // before fix: waiting
 			{At: 30 * time.Second, Expected: StatusFinished}, // before fix: waiting
-			{At: 60 * time.Second, Expected: StatusWaiting},  // a real dialog still registers
+			{At: 60 * time.Second, Expected: StatusWaiting},  // genuine footer overrides the finished hook
 		},
 	})
 }

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -1097,3 +1097,44 @@ func TestScenarioStaleWaitingLatchRecoversToWaiting(t *testing.T) {
 		},
 	})
 }
+
+func TestScenarioProseAboutFooterDoesNotPinWaiting(t *testing.T) {
+	// Regression: a session whose own conversation describes the AskUserQuestion
+	// footer read as waiting forever after it had finished.
+	//
+	// detectWaiting matched "n to add notes" and "esc to cancel" as substrings of a
+	// single line, so an agent summary reading "detectWaiting accepts the
+	// single-question AskUserQuestion footer (n to add notes + Esc to cancel), so a
+	// dialog whose …" satisfied both. The sentence sat 11 lines from the bottom —
+	// inside detectWaiting's 15-line window — so paneStatus=Waiting, and
+	// applyHookFinished's pane override turned a correct finished hook into waiting
+	// on every tick ("hook says finished but pane shows waiting, overriding"). Only
+	// scrolling the sentence out of the window cleared it.
+	//
+	// Fix: the hints must be whole fields of the footer's "·"-separated hint list
+	// (isAskUserQuestionFooter), which prose has no reason to produce.
+	// Captured from snapshot 2026-08-23T18-11-15_fix-1-and-2-with-tests.
+	fixture := "pane_finished_prose_mentions_askuserquestion_footer.txt"
+	if _, err := os.Stat(filepath.Join("testdata", fixture)); err != nil {
+		t.Skipf("fixture %s not available", fixture)
+	}
+
+	// The real footer, for contrast: same two hints, but as fields of the "·" list.
+	// A genuine dialog must still hold the session at waiting.
+	realFooter := "Which approach?\n\n❯ 1. Rewrite\n  2. Patch\n\n" +
+		"Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel\n"
+
+	runScenario(t, Scenario{
+		Name: "hook=finished + prose describing the footer → finished, not waiting",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "finished", Pane: "@fixture:" + fixture},
+			{At: 30 * time.Second, Pane: "@fixture:" + fixture}, // still parked; must not drift to waiting
+			{At: 60 * time.Second, Hook: "waiting", Pane: realFooter},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusFinished},                // before fix: waiting
+			{At: 30 * time.Second, Expected: StatusFinished}, // before fix: waiting
+			{At: 60 * time.Second, Expected: StatusWaiting},  // a real dialog still registers
+		},
+	})
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -2213,6 +2213,17 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 	if bottomN > len(recentLines) {
 		bottomN = len(recentLines)
 	}
+	// A footer is chrome pinned to the bottom of the dialog, so it only counts
+	// when it is actually at the bottom. Measured across every pane_waiting_*
+	// fixture, the footer sits at index 0-2 from the bottom (max 2, the permission
+	// menu with dock rows under it). Prose *about* a footer sits wherever the
+	// conversation left it, under the input box and mode bar the TUI always
+	// renders below — index 5 and 6 in the two panes that prompted this guard.
+	// Same shape as the dock-row check's bottom-3 position guard.
+	//
+	// Deliberately narrower than bottomN, which the *options* scan still needs:
+	// the single-question preview variant puts its "❯ N." cursor line at index 19.
+	footerN := min(3, len(recentLines))
 
 	// Structural check: numbered permission menu.
 	// Requires three cues: a cursor-on-numbered-option line ("❯ N."), at least
@@ -2221,7 +2232,10 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 	// The footer ("Esc to cancel" for a standard permission menu, or "approve
 	// with this feedback" for the ExitPlanMode plan-approval menu — which has no
 	// "Esc to cancel") only appears in Claude's interactive prompts, preventing
-	// false-positives from user-typed numbered lists.
+	// false-positives from user-typed numbered lists. It is matched only within
+	// footerN of the bottom: a session discussing permission prompts prints both a
+	// numbered menu and the words "Esc to cancel" in ordinary prose, and matching
+	// that anywhere in bottomN pinned a finished session to waiting.
 	hasCursorOnOption := false
 	hasOtherOption := false
 	hasMenuFooter := false
@@ -2232,9 +2246,11 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 		} else if isNumberedMenuOption(trimmed) {
 			hasOtherOption = true
 		}
-		lower := strings.ToLower(trimmed)
-		if strings.Contains(lower, "esc to cancel") || strings.Contains(lower, "approve with this feedback") {
-			hasMenuFooter = true
+		if i < footerN {
+			lower := strings.ToLower(trimmed)
+			if strings.Contains(lower, "esc to cancel") || strings.Contains(lower, "approve with this feedback") {
+				hasMenuFooter = true
+			}
 		}
 	}
 	if hasCursorOnOption && hasOtherOption && hasMenuFooter {
@@ -2273,7 +2289,7 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 	// (Tab moves focus to checkbox-style question rows where `❯` disappears),
 	// so the menu structural check above misses these states. The footer is
 	// rendered identically on every tick regardless of which question has focus.
-	for i := 0; i < bottomN; i++ {
+	for i := 0; i < footerN; i++ {
 		if isAskUserQuestionFooter(recentLines[i]) {
 			log.Debug("detectStatus: matched askuserquestion footer")
 			return StatusWaiting
@@ -2310,8 +2326,8 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 // covers the SINGLE-question variant, which omits the Tab hint (see above).
 func isAskUserQuestionFooter(line string) bool {
 	var hasCancel, hasHint bool
-	for _, field := range strings.Split(line, "·") {
-		switch strings.ToLower(strings.TrimSpace(field)) {
+	for _, field := range footerFields(line) {
+		switch field {
 		case "esc to cancel":
 			hasCancel = true
 		case "n to add notes", "tab to switch questions":
@@ -2319,6 +2335,51 @@ func isAskUserQuestionFooter(line string) bool {
 		}
 	}
 	return hasCancel && hasHint
+}
+
+// footerFields splits a hint-list line into its individual hints, lowercased and
+// trimmed. Fields are separated by "·" or by a run of two or more spaces; a line
+// with neither is one field, so a hint rendered alone on its own line still counts.
+//
+// Claude renders the footer with "·" today and that is the only separator any
+// captured pane shows. The extra accepted forms are not speculation for its own
+// sake — this footer is the SOLE signal for the single-question preview variant
+// (its "❯ N." cursor line is out of the options window), and the failure direction
+// is the silent one: a false not-waiting means fleet never tells you the session is
+// blocked, where a false waiting is immediately obvious on screen. Padding and line
+// boundaries are what a hint list is separated by; prose separates its words with
+// words, so widening to them costs nothing in false positives.
+func footerFields(line string) []string {
+	var out []string
+	for _, part := range strings.Split(line, "·") {
+		for _, field := range splitOnWideGaps(part) {
+			if f := strings.ToLower(strings.TrimSpace(field)); f != "" {
+				out = append(out, f)
+			}
+		}
+	}
+	return out
+}
+
+// splitOnWideGaps splits s on runs of two or more spaces. A single space is left
+// alone — it is the space *inside* a hint ("n to add notes"), not between hints.
+func splitOnWideGaps(s string) []string {
+	var out []string
+	start, run := 0, -1
+	for i := 0; i <= len(s); i++ {
+		if i < len(s) && s[i] == ' ' {
+			if run < 0 {
+				run = i
+			}
+			continue
+		}
+		if run >= 0 && i-run >= 2 {
+			out = append(out, s[start:run])
+			start = i
+		}
+		run = -1
+	}
+	return append(out, s[start:])
 }
 
 // isNumberedMenuOption reports whether s starts with "<digits>.".

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -2255,9 +2255,10 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 
 	// Structural check: AskUserQuestion tool dialog.
 	// Two hints appear only in this tool's footer: "Tab to switch questions" and
-	// "n to add notes". Either one paired with "Esc to cancel" on the same line
-	// identifies the dialog; the pairing is what keeps conversation text mentioning
-	// tabs or notes from matching.
+	// "n to add notes". Either one paired with "Esc to cancel" as whole fields of
+	// the footer's "·"-separated hint list identifies the dialog; matching fields
+	// rather than substrings is what keeps conversation text mentioning tabs or
+	// notes from matching (see isAskUserQuestionFooter).
 	//
 	// "n to add notes" is what covers the SINGLE-question variant, which omits the Tab
 	// hint because there is nothing to switch to. That variant can also fall outside the
@@ -2273,11 +2274,7 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 	// so the menu structural check above misses these states. The footer is
 	// rendered identically on every tick regardless of which question has focus.
 	for i := 0; i < bottomN; i++ {
-		lower := strings.ToLower(recentLines[i])
-		if !strings.Contains(lower, "esc to cancel") {
-			continue
-		}
-		if strings.Contains(lower, "tab to switch questions") || strings.Contains(lower, "n to add notes") {
+		if isAskUserQuestionFooter(recentLines[i]) {
 			log.Debug("detectStatus: matched askuserquestion footer")
 			return StatusWaiting
 		}
@@ -2294,6 +2291,34 @@ func detectWaiting(recentLines []string, _ string, log *slog.Logger) Status {
 	}
 
 	return ""
+}
+
+// isAskUserQuestionFooter reports whether line is the AskUserQuestion dialog's
+// key-hint footer. The footer is a "·"-separated list of hints, so the hints are
+// matched as whole fields of that list rather than as substrings of the line.
+//
+// Substring matching was a false-positive generator, because the hint wording is
+// ordinary English that a session discussing status detection prints verbatim: an
+// agent summary reading "detectWaiting accepts the single-question AskUserQuestion
+// footer (n to add notes + Esc to cancel)" carried both hints on one line, pinned a
+// finished session to waiting through applyHookFinished's pane override, and did so
+// on every tick for as long as the sentence stayed in the bottom 15 lines. Requiring
+// whole fields keeps prose out: a sentence mentioning the hints has no "·" between
+// them, so the hints are never fields of their own.
+//
+// "Esc to cancel" is required, plus either sibling hint. "n to add notes" is what
+// covers the SINGLE-question variant, which omits the Tab hint (see above).
+func isAskUserQuestionFooter(line string) bool {
+	var hasCancel, hasHint bool
+	for _, field := range strings.Split(line, "·") {
+		switch strings.ToLower(strings.TrimSpace(field)) {
+		case "esc to cancel":
+			hasCancel = true
+		case "n to add notes", "tab to switch questions":
+			hasHint = true
+		}
+	}
+	return hasCancel && hasHint
 }
 
 // isNumberedMenuOption reports whether s starts with "<digits>.".

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -114,6 +114,26 @@ func TestDetectStatus(t *testing.T) {
 		{"idle pattern", "⏵⏵\n", StatusFinished},
 		{"spinner char mid-line not matched", "⏺ The test checks that ⠋ is gone\n❯\n", StatusFinished},
 		{"busy pattern in scrollback not matched", "1. Busy patterns → Running (`ctrl+c to interrupt`, `esc to interrupt`)\nmore text\nmore text\nmore text\nmore text\nmore text\n❯\n", StatusFinished},
+		// Footer position guard (PR #269 review): a session discussing permission
+		// prompts prints a numbered menu and the words "Esc to cancel" in ordinary
+		// prose. Both are real conversation content sitting above the input box, so
+		// the footer is nowhere near the bottom and must not complete the menu.
+		{"menu quoted in prose not matched", "The dialog renders options like:\n  ❯ 1. Yes\n  2. No, tell Claude what to do differently\n\nThe footer (n to add notes + Esc to cancel) identifies it.\n\n✻ Worked for 59s\n\n❯ \n⏵⏵\n", StatusFinished},
+		{"exitplanmode footer quoted in prose not matched", "We discussed the plan menu:\n  ❯ 1. Yes, and use auto mode\n  2. No, refine\n\nIts footer says shift+tab to approve with this feedback.\n\n✻ Worked for 12s\n\n❯ \n⏵⏵\n", StatusFinished},
+		{"askuserquestion footer quoted verbatim in prose not matched", "⏺ The footer we match renders as:\n\n  Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel\n\n  That is the whole hint list.\n\n✻ Worked for 12s\n\n❯ \n⏵⏵\n", StatusFinished},
+		// The same footer text, actually at the bottom, still registers.
+		{"askuserquestion footer at bottom matched", "Round 3: Architecture\n☒ Stack  ☐ Process model\n\nEnter to select · ↑/↓ to navigate · n to add notes · Esc to cancel\n", StatusWaiting},
+		// Delimiter widening (PR #269 review): the footer is this variant's sole
+		// signal, so a rendering change must not silently stop firing.
+		{"footer separated by wide gaps matched", "Which approach?\n\nEnter to select   n to add notes   Esc to cancel\n", StatusWaiting},
+		// Documented bound, not an oversight: the check is per-line, so a footer that
+		// WRAPS onto two lines (narrow pane) is not matched. Widening the delimiter
+		// cannot fix that — the hints are no longer on one line to be separated.
+		// Pinned so the limit is a known quantity rather than a surprise.
+		{"footer hints split across lines not matched (wrap bound)", "Which approach?\n\nn to add notes\nEsc to cancel\n", ""},
+		// Single spaces are inside a hint, not between hints — widening must not
+		// shred "n to add notes" into words and match on fragments.
+		{"single-spaced prose not matched", "the footer has n to add notes and Esc to cancel in it\n❯\n⏵⏵\n", StatusFinished},
 		{"no match", "random output text\nmore text\n", ""},
 	}
 

--- a/internal/session/testdata/pane_finished_prose_mentions_askuserquestion_footer.txt
+++ b/internal/session/testdata/pane_finished_prose_mentions_askuserquestion_footer.txt
@@ -1,0 +1,57 @@
+
+[38;5;231m⏺[39m [1mExecution Summary[0m
+
+  [1mFixed (2 issues)[0m
+
+  - [38;5;153minternal/session/claude_name.go[39m — [38;5;153mscanTranscriptTimestamp[39m keeps the [1mmaximum[0m when [38;5;153mlast[39m is set, instead of overwriting on every match. Thread resolved.
+  - [38;5;153minternal/session/claude_name.go[39m — [38;5;153mattachment[39m [1mremoved[0m from [38;5;153mleadConversationTypes[39m; the incorrect rationale replaced with the measurement that justifies the exclusion. Thread resolved.
+
+  [1mSkipped / Replied only[0m
+
+  None.
+
+  [1mReady to Commit[0m
+
+  Already committed and pushed as [38;5;153mf76844d[39m:
+  - [38;5;153minternal/session/claude_name.go[39m
+  - [38;5;153minternal/session/claude_name_test.go[39m
+  - [38;5;153minternal/session/session_test.go[39m
+
+  Resolves 2 review threads — PR #267 now has 0 unresolved.
+
+  [1mWhat the verification turned up[0m, since both claims were broader than sampled:
+
+  - Timestamp inversions hit [1m38/39[0m transcripts among the allowlisted types (largest 1661s), and still [1m28/39[0m after the [38;5;153mattachment[39m removal (largest 162s). Same root cause for both threads: a message typed at a parked lead is stamped at [3mqueue[0m time and appended at [3mresume[0m time.
+  - [38;5;153mattachment[39m census over 8,474 entries: 6,988 [38;5;153mtotal_tokens_reminder[39m, 390 [38;5;153mtask_reminder[39m, 174 [38;5;153mqueued_command[39m. The number that decided removal over subtype-narrowing — it extended the last-entry time past [38;5;153massistant[39m/[38;5;153muser[39m in [1m3 of 39[0m transcripts, by at most [1m3ms[0m.
+
+  I recorded one honest qualification in the reply to thread #1: today's exposure is latent, not live — [38;5;153mlast != max[39m at the [3mfile tail[0m in 0/39 files, because a flushed queued entry is immediately followed by the real entries. The fix still stands on direction-of-error and ordering-independence, not on an observed
+  misread.
+
+  New tests fail without their fixes (verified by reverting). [38;5;153mmake lint[39m clean. [38;5;153mTestCredentialResolutionOrder[39m still fails on master too — pre-existing, reads your real Linear keychain entry.
+
+[38;5;246m✻[39m [38;5;246mCrunched for 2m 53s[39m
+
+[38;5;239m[48;5;237m❯ [38;5;231mmerge it[39m
+[49m
+  [38;5;246mRan [1m5[0m[38;5;246m shell commands [39m
+
+[38;5;231m⏺[39m Merged. [1mPR #267[0m squash-merged into [38;5;153mmaster[39m as [38;5;153m3a61647[39m, remote and local branches deleted, you're back on [38;5;153mmaster[39m in sync with origin.
+
+  All six checks passed before merge (test, check, lint, vulncheck, CodeRabbit), both review threads resolved.
+
+  What shipped:
+  - [38;5;153mdetectWaiting[39m accepts the single-question [38;5;153mAskUserQuestion[39m footer ([38;5;153mn to add notes[39m + [38;5;153mEsc to cancel[39m), so a dialog whose preview panel pushes the cursor line out of the 15-line window is still seen.
+  - [38;5;153mleadConversationTypes[39m allowlist ([38;5;153massistant[39m/[38;5;153muser[39m) — [38;5;153mqueue-operation[39m, [38;5;153msystem[39m, [38;5;153mfile-history-delta[39m, and [38;5;153mattachment[39m no longer count as the lead advancing.
+  - [38;5;153mscanTranscriptTimestamp[39m keeps the maximum rather than the last matching line.
+  - Golden fixture + three test groups, each verified failing without its fix.
+  - Changelog fragment in [38;5;153mchangelog/unreleased/[39m, not flagged as a highlight.
+
+  The untracked [38;5;153m.github/hooks/[39m is still sitting there, untouched — it predates this work.
+
+[38;5;246m✻[39m [38;5;246mWorked for 59s[39m
+
+[38;5;244m──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m❯ [2m/ship[0m
+[38;5;244m──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m  [36m󰧑 Opus 5 (1M context)[38;5;246m [90m│[38;5;246m [32m██░░░░░░░░[38;5;246m [90m│[38;5;246m [32m23%[38;5;246m [90m│[38;5;246m [35m󰍛 230.0k/1000k[38;5;246m [90m│[38;5;246m [33m master[38;5;246m [90m│[38;5;246m [1m[37m  brizz-code[0m                                                                                                                                                                                                                                   [38;5;114m]8;id=1thuzbh;https://claude.ai/code/session_01LJJZE3XYFxMqDazpWawrGU?from=cli\/rc[39m]8;;\
+  [38;5;220m⏵⏵ auto mode on[38;5;246m (shift+tab to cycle) · ← for agents[39m


### PR DESCRIPTION
## The bug

A finished session showed **waiting** indefinitely. From the snapshot (`2026-08-23T18-11-15_fix-1-and-2-with-tests`), every layer but one was correct:

| Layer | Says | Correct? |
|---|---|---|
| Hook file (`Stop`) | `finished` | ✅ |
| Conversation log (`advanced_past_hook: false`) | not active | ✅ |
| Worker (274ms cycle) | not stalled | ✅ |
| `detectWaiting` | `waiting` | ❌ |
| `detectFinished` | `finished` | ✅ (never reached) |
| TUI | `waiting` | ❌ |

The pane was at rest — `✻ Worked for 59s`, an empty input box, no menu. What tripped it was the session's own summary of what it had just shipped:

> `- detectWaiting accepts the single-question AskUserQuestion footer (n to add notes + Esc to cancel), so a dialog whose preview panel…`

`detectWaiting` required only that one line contain `"esc to cancel"` **and** `"n to add notes"` as substrings. That sentence has both, at `recentLines[11]` — inside the 15-line window. `detectWaiting` runs before `detectFinished`, so the false positive won, and `applyHookFinished`'s `paneStatus == StatusWaiting` branch overrode a correct hook. `debug.log` shows *"hook says finished but pane shows waiting, overriding"* on every tick.

Reachable since #267 added the `"n to add notes"` branch two minutes before the capture; the prior check required `"tab to switch questions"`, which the prose lacks. The session that shipped the change tripped it by describing it — the self-referential false positive the package already warns about.

## The fix

The real footer renders as a `·`-separated hint list:

```
Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel
```

So `isAskUserQuestionFooter` matches the hints as **whole fields** of that list rather than substrings of the line. Prose mentioning the hints has no `·` between them, so neither is ever a field. This keeps the function's stated philosophy — structural layout checks over text patterns.

## Verification

- Both new tests **fail without the fix, pass with it** (checked by reverting the predicate).
- Across all 20 existing fixtures: **0 behavior differences** old vs new.
- `make build` OK · `make lint` 0 issues · `go test -race ./internal/session/` passes.
- Pre-existing and unrelated: `TestCredentialResolutionOrder` (`internal/linear`) fails on a clean master too — it reads the real Linear keychain entry.

## Tests

- **Golden** `pane_finished_prose_mentions_askuserquestion_footer.txt` — the actual captured pane, expected `StatusFinished`.
- **Scenario** `TestScenarioProseAboutFooterDoesNotPinWaiting` — pins the `applyHookFinished` override path (finished at t=0 and t=30s), and asserts a genuine `·`-delimited footer at t=60s still registers as waiting, so the fix can't be "solved" by disabling the check.

## Noticed, not fixed

`detectFinished`'s prompt scan tests `strings.HasPrefix(line, "❯ ")` with a normal space, but the live input line is `❯ ` (non-breaking space), so that path is dead against real panes — only `idlePatterns` is carrying it. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYcKP6MB1JNkFPvKszc1d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed completed sessions being incorrectly shown as active question dialogs when their text merely mentions prompt-related footer wording.
  - Improved waiting-state detection to recognize only genuine question prompts, preventing sessions from becoming stuck in a waiting state.
  - Preserved correct detection for active prompts with valid footer hints.
  - Improved recognition of valid prompts with varied spacing and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->