### PR TITLE
fix(status): match the prompt's no-break space separator

### DIFF
--- a/changelog/unreleased/nbsp-prompt-separator.md
+++ b/changelog/unreleased/nbsp-prompt-separator.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**Escaped prompts clear again.** A session no longer sits on `waiting` after you press `Esc` on a permission prompt and start typing a reply — the half-typed text in the input box was hiding the idle prompt from fleet.
+**Escaped prompts recover.** You can press `Esc` on a permission prompt and start typing a different instruction without the session staying stuck on `waiting`.

--- a/changelog/unreleased/nbsp-prompt-separator.md
+++ b/changelog/unreleased/nbsp-prompt-separator.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Escaped prompts clear again.** A session no longer sits on `waiting` after you press `Esc` on a permission prompt and start typing a reply — the half-typed text in the input box was hiding the idle prompt from fleet.

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -1180,3 +1180,35 @@ func TestScenarioProseQuotingAMenuDoesNotPinWaiting(t *testing.T) {
 		},
 	})
 }
+
+func TestScenarioNBSPPromptClearsStaleWaiting(t *testing.T) {
+	// Regression: the consequence of the NBSP prompt separator, which is what made
+	// the parsing slip matter rather than being cosmetic.
+	//
+	// The user gets a permission prompt, presses Esc, and starts typing a different
+	// instruction without submitting. Escaping fires NO hook, so the waiting hook is
+	// stale and the pane is the only thing that can clear it — applyHookWaiting's
+	// paneStatus == StatusFinished branch exists for exactly this.
+	//
+	// Claude renders the gap after "❯" as U+00A0, so with text in the box the prompt
+	// scan missed, and in default mode (no "⏵⏵" mode bar to fall back on) detectStatus
+	// returned no signal at all. The override never fired and the session sat on
+	// waiting for as long as the text stayed in the box.
+	const nbsp = " "
+
+	menu := "Read(~/code/foo/bar.ts)\n\nDo you want to proceed?\n\n❯ 1. Yes\n  2. No\n\nEsc to cancel · Tab to amend\n"
+	// Post-Esc, default permission mode: an input box with typed text and no mode bar.
+	typed := "⏺ Reading config…\n\n──────────\n❯" + nbsp + "actually do it differently\n──────────\n"
+
+	runScenario(t, Scenario{
+		Name: "hook=waiting + escaped prompt + typed text → pane clears it to finished",
+		Events: []ScenarioEvent{
+			{At: 0, Hook: "waiting", Pane: menu},
+			{At: 10 * time.Second, Pane: typed}, // Esc pressed, user starts typing; no hook fires
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusWaiting},
+			{At: 10 * time.Second, Expected: StatusFinished}, // before fix: stuck on waiting
+		},
+	})
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -2397,6 +2397,38 @@ func isNumberedMenuOption(s string) bool {
 	return false
 }
 
+// promptRemainder reports whether line is Claude's input-prompt line and returns
+// whatever follows the marker. line is expected already trimmed.
+//
+// The separator is matched with unicode.IsSpace, not a literal " ", because Claude
+// renders the gap after the marker as a NO-BREAK SPACE (U+00A0). Matching a plain
+// space missed every prompt with text typed into the box: TrimSpace strips a
+// *trailing* NBSP, so a bare "❯" still matched and the empty-box case looked fine,
+// while "❯\u00a0fix the parser" did not. In auto mode the "⏵⏵" idle pattern covered
+// for it; in default mode there is no mode bar, so detectStatus returned no signal
+// at all — which disables applyHookWaiting's pane override, the one path that
+// clears a stale waiting hook after the user escapes a prompt (no hook fires on
+// Esc). The session stayed waiting for as long as text sat in the box.
+//
+// The menu-cursor check in detectWaiting keeps its literal " ": every captured
+// permission menu renders a normal space there, so it has no equivalent bug, and
+// this function still skips numbered options either way.
+func promptRemainder(line string) (string, bool) {
+	for _, marker := range []string{"❯", ">"} {
+		rest, ok := strings.CutPrefix(line, marker)
+		if !ok {
+			continue
+		}
+		if rest == "" {
+			return "", true
+		}
+		if r, size := utf8.DecodeRuneInString(rest); unicode.IsSpace(r) {
+			return strings.TrimSpace(rest[size:]), true
+		}
+	}
+	return "", false
+}
+
 // detectFinished checks for prompt indicators and idle patterns.
 func detectFinished(recentLines []string, recentContent string, log *slog.Logger) Status {
 	if len(recentLines) == 0 {
@@ -2407,18 +2439,12 @@ func detectFinished(recentLines []string, recentContent string, log *slog.Logger
 	scanLimit := min(5, len(recentLines))
 	for i := 0; i < scanLimit; i++ {
 		line := strings.TrimSpace(recentLines[i])
-		if line == ">" || line == "❯" || strings.HasPrefix(line, "> ") || strings.HasPrefix(line, "❯ ") {
+		remainder, isPrompt := promptRemainder(line)
+		if isPrompt {
 			// Skip permission-menu cursor lines ("❯ 2. Yes…") — those are
 			// waiting state, not idle prompts. Defense-in-depth: detectWaiting
 			// should have caught these earlier, but if a new menu variant
 			// slips past it, we don't want to silently flip to finished.
-			remainder := line
-			switch {
-			case strings.HasPrefix(line, "❯ "):
-				remainder = strings.TrimPrefix(line, "❯ ")
-			case strings.HasPrefix(line, "> "):
-				remainder = strings.TrimPrefix(line, "> ")
-			}
 			if isNumberedMenuOption(remainder) {
 				continue
 			}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -134,6 +134,17 @@ func TestDetectStatus(t *testing.T) {
 		// Single spaces are inside a hint, not between hints — widening must not
 		// shred "n to add notes" into words and match on fragments.
 		{"single-spaced prose not matched", "the footer has n to add notes and Esc to cancel in it\n❯\n⏵⏵\n", StatusFinished},
+		// NBSP prompt separator: Claude renders the gap after "❯" as U+00A0, so a
+		// literal " " missed every prompt with text typed into the box. TrimSpace
+		// strips a *trailing* NBSP, which is why the empty box always looked fine.
+		// No mode bar in these — that "⏵⏵" idle pattern is what masked the bug.
+		{"nbsp prompt with typed text", "⏺ Done.\n\n❯\u00a0fix the parser\n", StatusFinished},
+		{"nbsp prompt empty", "⏺ Done.\n\n❯\u00a0\n", StatusFinished},
+		{"normal-space prompt with typed text", "⏺ Done.\n\n❯ fix the parser\n", StatusFinished},
+		{"nbsp prompt with slash command", "⏺ Done.\n\n❯\u00a0/ship\n", StatusFinished},
+		// The numbered-option skip must survive the widened separator: a menu cursor
+		// is waiting, not an idle prompt, whichever space it uses.
+		{"nbsp menu cursor still skipped not finished", "output\n❯\u00a01. Yes\nsome trailing text\n", ""},
 		{"no match", "random output text\nmore text\n", ""},
 	}
 


### PR DESCRIPTION
Found while tracing #269. Reported there as noticed-not-fixed; this is the fix.

## The bug

`detectFinished` scans the bottom lines for Claude's input prompt:

```go
if line == ">" || line == "❯" || strings.HasPrefix(line, "> ") || strings.HasPrefix(line, "❯ ") {
```

Claude renders the gap after `❯` as **U+00A0 NO-BREAK SPACE**, not `U+0020`. So the `HasPrefix` arms never matched a real prompt line.

It hid for so long because `TrimSpace` strips a *trailing* NBSP — Go's `unicode.IsSpace` includes U+00A0 — so a bare `❯` collapses to `"❯"` and matches the equality arm. The empty input box always looked correct. Only a prompt **with text typed into it** failed:

| Pane | Before | After |
|---|---|---|
| `❯ ` (empty box) | `finished` | `finished` |
| `❯ fix the parser` (normal space) | `finished` | `finished` |
| `❯ fix the parser`, auto mode | `finished` | `finished` |
| `❯ fix the parser`, **default mode** | **`""`** | `finished` |

## Why it isn't cosmetic

The auto-mode row is carried by the `⏵⏵` idle pattern, which masks the miss. Default mode has no mode bar, so `detectStatus` returns **no signal at all**.

That disables `applyHookWaiting`'s `paneStatus == StatusFinished` branch — whose own comment says *"If user interrupts/escapes, no hook fires — pane override catches this"*. It's the only path that clears a stale `waiting` hook after an `Esc`, because escaping fires no hook. So: get a permission prompt, press `Esc`, start typing a different instruction — and the session sits on `waiting` for as long as that text stays in the box.

## The fix

`promptRemainder` matches the separator with `unicode.IsSpace` rather than a literal `" "`, and folds the four `HasPrefix`/`TrimPrefix` arms into one. The numbered-option skip is preserved, so a menu cursor (`❯ 2. Yes…`) is still never read as an idle prompt — verified for both separators.

`detectWaiting`'s menu-cursor check deliberately keeps its literal `" "`: I checked every captured permission menu and they all render a normal space there, so it has no equivalent bug. Widening it would be a guess at a rendering that doesn't exist.

## Tests

Five detection cases plus `TestScenarioNBSPPromptClearsStaleWaiting`, which pins the consequence rather than the parse — hook stuck on `waiting`, user escapes and types, pane must clear it to `finished`. Every assertion verified failing with the fix reverted (the scenario reports `got "running"` there, which is wrong a second way).

## Verification

`make build` OK · `make lint` 0 issues · `go test -race ./internal/session/` passes. Pre-existing and unrelated: `TestCredentialResolutionOrder` (`internal/linear`) fails on clean master too — it reads the real Linear keychain entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYcKP6MB1JNkFPvKszc1d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where dismissing a permission prompt with **Esc** and entering text could leave the session stuck in a waiting state.
  * Idle prompts now remain visible while partially typed responses are present.
  * Improved handling of prompts containing non-breaking spaces and Unicode whitespace.
  * Numbered permission-menu options continue to be recognized correctly without being mistaken for completed prompts.

* **Tests**
  * Added coverage for escaped prompts, non-breaking-space separators, slash commands, empty input, and permission menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->