### PR TITLE
fix(ui): put mouse reporting back after an attach

### DIFF
--- a/changelog/unreleased/attach-restores-mouse-mode.md
+++ b/changelog/unreleased/attach-restores-mouse-mode.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Scrolling stays fast after you detach.** Attaching to a session left your terminal reporting mouse events — `Ctrl+Q` kills the tmux client before tmux can clean up — so the next scroll brought back the ~270 redraws/sec that pinned fleet at 250% CPU. Detaching now puts the terminal back.

--- a/changelog/unreleased/attach-restores-mouse-mode.md
+++ b/changelog/unreleased/attach-restores-mouse-mode.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**Scrolling stays fast after you detach.** Attaching to a session left your terminal reporting mouse events — `Ctrl+Q` kills the tmux client before tmux can clean up — so the next scroll brought back the ~270 redraws/sec that pinned fleet at 250% CPU. Detaching now puts the terminal back.
+**Scrolling after detach.** Attaching to a session used to leave your terminal sending mouse events to fleet, so the next scroll pinned it at 250% CPU until you stopped. Detaching now puts the terminal back.

--- a/internal/termkeys/termkeys.go
+++ b/internal/termkeys/termkeys.go
@@ -69,26 +69,38 @@ const disablePreamble = disableModifyOtherKeys + ansi.DisableKittyKeyboard +
 const disableMouseReporting = ansi.ResetModeMouseNormal + ansi.ResetModeMouseButtonEvent +
 	ansi.ResetModeMouseAnyEvent + ansi.ResetModeMouseExtSgr
 
-// Reassert re-applies what Disable asked for, for callers returning from a
-// full-screen attach that handed the terminal to tmux and got it back dirty:
-// fleet's attach ends by killing the tmux client (Ctrl+Q, see
-// internal/tmux/pty.go), so tmux never runs its own cleanup and whatever it
-// enabled stays on. It also turns mouse reporting off, which Disable never had
-// to: Bubble Tea owns that mode via Home.chrome, and owns it only on the way in
-// — its renderer emits a mouse-mode change only when the mode *differs* from
-// the last view's, and fleet's is MouseModeNone on every frame including the
-// first one after an attach. So nothing else will ever take reporting back off,
-// and the next scroll is a MouseWheelMsg burst costing a full View() apiece.
+// Reassert clears the terminal modes a full-screen attach leaves switched on,
+// for callers returning from one: fleet's attach ends by killing the tmux client
+// (Ctrl+Q, see internal/tmux/pty.go), so tmux never runs its own cleanup and
+// whatever it enabled stays on.
 //
-// It is deliberately not a second call to Disable, because two of Disable's
-// four sequences carry state and are not idempotent: XTSAVE (1007s) would
-// overwrite the saved original with the already-cleared value, so Restore would
-// hand the user back the wrong mode on exit, and ansi.DisableKittyKeyboard
-// pushes onto the Kitty keyboard stack, which Restore pops exactly once — every
-// extra push would leak an entry. What is left is the two sequences that are
-// plain idempotent sets, plus the mouse reset.
+// Mouse reporting is the one that matters, and Disable never had to touch it.
+// Bubble Tea owns that mode via Home.chrome — but owns it only on the way in: its
+// renderer emits a mouse-mode change only when the mode *differs* from the last
+// view's, and fleet's is MouseModeNone on every frame including the first one
+// after an attach, so nothing else will ever take reporting back off. The next
+// scroll is then a MouseWheelMsg burst costing a full View() apiece.
+//
+// Key reporting is deliberately *not* re-asserted, because it is not ours to
+// own here: tea.Exec calls RestoreTerminal the moment attachCmd.Run returns
+// (v2.0.7 exec.go:125), which reaches cursedRenderer.start() with a non-nil
+// lastView and unconditionally writes SetModifyOtherKeys2 — \x1b[>4;2m —
+// at cursed_renderer.go:136. A mode-0 written here would be overwritten
+// microseconds later, so including it would buy nothing but a comment the
+// terminal contradicts. Harmless in practice: Bubble Tea v2 decodes CSI-u and
+// modifyOtherKeys alike, which is why the Ctrl+K bug Disable exists for has not
+// come back. Disable itself is left as-is — its mode-0 is overwritten on frame
+// one for the same reason (cursed_renderer.go:386), but that predates this and
+// changing it is a separate question.
+//
+// What is left is two sequences, and both are plain idempotent resets — which is
+// also why this is not a second call to Disable. Two of Disable's four carry
+// state: XTSAVE (1007s) would overwrite the saved original with the
+// already-cleared value, so Restore would hand the terminal back wrong on exit,
+// and ansi.DisableKittyKeyboard pushes onto the Kitty keyboard stack, which
+// Restore pops exactly once — every extra push would leak an entry.
 func Reassert(w io.Writer) error {
-	_, err := io.WriteString(w, disableModifyOtherKeys+disableAltScreenScroll+disableMouseReporting)
+	_, err := io.WriteString(w, disableAltScreenScroll+disableMouseReporting)
 	return err
 }
 

--- a/internal/termkeys/termkeys.go
+++ b/internal/termkeys/termkeys.go
@@ -60,6 +60,38 @@ const (
 const disablePreamble = disableModifyOtherKeys + ansi.DisableKittyKeyboard +
 	saveAltScreenScroll + disableAltScreenScroll
 
+// disableMouseReporting turns off every mouse-reporting mode a tmux client can
+// leave switched on in our terminal. fleet sets `mouse on` per session
+// (tmux.Session.ApplyStatusBar), so an attach puts the outer terminal into
+// DECSET 1000/1002/1003 + SGR 1006; the modes are reset in that same broad
+// sweep because which ones tmux enabled is not knowable from here, and a reset
+// for a mode that was never set is a no-op.
+const disableMouseReporting = ansi.ResetModeMouseNormal + ansi.ResetModeMouseButtonEvent +
+	ansi.ResetModeMouseAnyEvent + ansi.ResetModeMouseExtSgr
+
+// Reassert re-applies what Disable asked for, for callers returning from a
+// full-screen attach that handed the terminal to tmux and got it back dirty:
+// fleet's attach ends by killing the tmux client (Ctrl+Q, see
+// internal/tmux/pty.go), so tmux never runs its own cleanup and whatever it
+// enabled stays on. It also turns mouse reporting off, which Disable never had
+// to: Bubble Tea owns that mode via Home.chrome, and owns it only on the way in
+// — its renderer emits a mouse-mode change only when the mode *differs* from
+// the last view's, and fleet's is MouseModeNone on every frame including the
+// first one after an attach. So nothing else will ever take reporting back off,
+// and the next scroll is a MouseWheelMsg burst costing a full View() apiece.
+//
+// It is deliberately not a second call to Disable, because two of Disable's
+// four sequences carry state and are not idempotent: XTSAVE (1007s) would
+// overwrite the saved original with the already-cleared value, so Restore would
+// hand the user back the wrong mode on exit, and ansi.DisableKittyKeyboard
+// pushes onto the Kitty keyboard stack, which Restore pops exactly once — every
+// extra push would leak an entry. What is left is the two sequences that are
+// plain idempotent sets, plus the mouse reset.
+func Reassert(w io.Writer) error {
+	_, err := io.WriteString(w, disableModifyOtherKeys+disableAltScreenScroll+disableMouseReporting)
+	return err
+}
+
 // Disable asks the terminal for legacy key reporting so modified keys (Ctrl+K
 // in particular) arrive in their legacy encoding instead of as CSI-u sequences
 // Bubble Tea v1 can't parse. Terminals that don't support a given mode ignore

--- a/internal/termkeys/termkeys_test.go
+++ b/internal/termkeys/termkeys_test.go
@@ -81,9 +81,10 @@ func TestReassertTurnsMouseReportingOff(t *testing.T) {
 	if err := Reassert(&b); err != nil {
 		t.Fatalf("Reassert returned error: %v", err)
 	}
-	// modifyOtherKeys off + clear alternate-screen scroll (no save, see below),
-	// then reset the four mouse-reporting modes a tmux client may have left on.
-	if got, want := b.String(), "\x1b[>4;0m\x1b[?1007l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l"; got != want {
+	// Clear alternate-screen scroll (no save, see below), then reset the four
+	// mouse-reporting modes a tmux client may have left on. No key-reporting
+	// sequence: see TestReassertLeavesKeyReportingToBubbleTea.
+	if got, want := b.String(), "\x1b[?1007l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l"; got != want {
 		t.Errorf("Reassert wrote %q, want %q", got, want)
 	}
 }
@@ -114,5 +115,23 @@ func TestReassertRepeatsNothingStateful(t *testing.T) {
 func TestReassertPropagatesWriteError(t *testing.T) {
 	if err := Reassert(errWriter{}); err == nil {
 		t.Error("expected error from failing writer, got nil")
+	}
+}
+
+// TestReassertLeavesKeyReportingToBubbleTea pins the omission, which is easy to
+// read as a bug and "fix" back in. Reassert cannot restore legacy key reporting:
+// tea.Exec calls RestoreTerminal as soon as attachCmd.Run returns (v2.0.7
+// exec.go:125), reaching cursedRenderer.start() with a non-nil lastView, which
+// unconditionally writes SetModifyOtherKeys2 at cursed_renderer.go:136. Anything
+// this wrote would be overwritten microseconds later — dead bytes plus a comment
+// the terminal contradicts.
+func TestReassertLeavesKeyReportingToBubbleTea(t *testing.T) {
+	var b strings.Builder
+	if err := Reassert(&b); err != nil {
+		t.Fatalf("Reassert returned error: %v", err)
+	}
+	if strings.Contains(b.String(), disableModifyOtherKeys) {
+		t.Errorf("Reassert wrote modifyOtherKeys-off (%q); Bubble Tea overwrites it with "+
+			"mode 2 microseconds later, so it asserts a state the terminal will not be in", b.String())
 	}
 }

--- a/internal/termkeys/termkeys_test.go
+++ b/internal/termkeys/termkeys_test.go
@@ -75,3 +75,44 @@ func TestRestorePropagatesWriteError(t *testing.T) {
 		t.Error("expected error from failing writer, got nil")
 	}
 }
+
+func TestReassertTurnsMouseReportingOff(t *testing.T) {
+	var b strings.Builder
+	if err := Reassert(&b); err != nil {
+		t.Fatalf("Reassert returned error: %v", err)
+	}
+	// modifyOtherKeys off + clear alternate-screen scroll (no save, see below),
+	// then reset the four mouse-reporting modes a tmux client may have left on.
+	if got, want := b.String(), "\x1b[>4;0m\x1b[?1007l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l"; got != want {
+		t.Errorf("Reassert wrote %q, want %q", got, want)
+	}
+}
+
+// TestReassertRepeatsNothingStateful is the reason Reassert exists as its own
+// function rather than a second call to Disable. Two of Disable's sequences
+// carry state across calls: XTSAVE (1007s) has a single save slot, so a repeat
+// would overwrite the user's original value with the already-cleared one and
+// Restore would hand back the wrong mode on exit; DisableKittyKeyboard pushes
+// onto a stack Restore pops exactly once, so a repeat leaks an entry per attach.
+// Reassert runs once per attach, so either would compound all session long.
+func TestReassertRepeatsNothingStateful(t *testing.T) {
+	var b strings.Builder
+	if err := Reassert(&b); err != nil {
+		t.Fatalf("Reassert returned error: %v", err)
+	}
+	if strings.Contains(b.String(), saveAltScreenScroll) {
+		t.Errorf("Reassert wrote the 1007 XTSAVE (%q); it would overwrite the value "+
+			"Disable saved with the cleared one, so Restore leaves the terminal wrong", b.String())
+	}
+	// ansi.DisableKittyKeyboard emits the flags-omitted push form \x1b[>u.
+	if strings.Contains(b.String(), "\x1b[>u") {
+		t.Errorf("Reassert pushed a Kitty keyboard entry (%q); Restore pops exactly "+
+			"one, so every attach past the first leaks an entry", b.String())
+	}
+}
+
+func TestReassertPropagatesWriteError(t *testing.T) {
+	if err := Reassert(errWriter{}); err == nil {
+		t.Error("expected error from failing writer, got nil")
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3298,10 +3298,10 @@ func (a attachCmd) Run() error {
 	// runs its terminal cleanup and the mouse reporting it enabled for `mouse on`
 	// stays on in our terminal — where nothing else would ever turn it off, and the
 	// next trackpad scroll lands as the MouseWheelMsg repaint storm #268 fixed.
-	// Before Bubble Tea's RestoreTerminal re-enters the alternate screen (exec.go
-	// calls it after Run), which is the order termkeys.Disable was verified in.
+	// Mouse and 1007 only: Bubble Tea's RestoreTerminal, which exec.go runs the
+	// moment this returns, rewrites key reporting itself (see termkeys.Reassert).
 	if rerr := termkeys.Reassert(os.Stdout); rerr != nil {
-		debuglog.Logger.Warn("failed to re-assert key/mouse reporting after attach", "err", rerr)
+		debuglog.Logger.Warn("failed to re-assert mouse reporting after attach", "err", rerr)
 	}
 	return err
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -40,6 +40,7 @@ import (
 	"github.com/brizzai/fleet/internal/session"
 	"github.com/brizzai/fleet/internal/shell"
 	"github.com/brizzai/fleet/internal/skill"
+	"github.com/brizzai/fleet/internal/termkeys"
 	"github.com/brizzai/fleet/internal/tmux"
 	"github.com/brizzai/fleet/internal/vterm"
 	"github.com/brizzai/fleet/internal/workspace"
@@ -3289,7 +3290,20 @@ type attachCmd struct {
 }
 
 func (a attachCmd) Run() error {
-	return a.session.Attach(context.Background())
+	err := a.session.Attach(context.Background())
+	// Every attach path (session, drawer shell, account login pane) runs through
+	// here, so the terminal is put back in one place rather than in three tea.Exec
+	// callbacks a fourth path could forget. The attach ends by killing the tmux
+	// client rather than detaching it (Ctrl+Q, internal/tmux/pty.go), so tmux never
+	// runs its terminal cleanup and the mouse reporting it enabled for `mouse on`
+	// stays on in our terminal — where nothing else would ever turn it off, and the
+	// next trackpad scroll lands as the MouseWheelMsg repaint storm #268 fixed.
+	// Before Bubble Tea's RestoreTerminal re-enters the alternate screen (exec.go
+	// calls it after Run), which is the order termkeys.Disable was verified in.
+	if rerr := termkeys.Reassert(os.Stdout); rerr != nil {
+		debuglog.Logger.Warn("failed to re-assert key/mouse reporting after attach", "err", rerr)
+	}
+	return err
 }
 
 func (a attachCmd) SetStdin(r io.Reader)  {}

--- a/internal/ui/attach_termkeys_test.go
+++ b/internal/ui/attach_termkeys_test.go
@@ -1,0 +1,113 @@
+package ui
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestAttachRestoresTerminalModes is the drift guard for the regression that
+// brought the #268 repaint storm back. fleet's attach ends by killing the tmux
+// client rather than detaching it (Ctrl+Q, internal/tmux/pty.go), so tmux never
+// runs its terminal cleanup and the mouse reporting it enabled for `mouse on`
+// is left switched on in fleet's own terminal. Bubble Tea will not take it back
+// off — its renderer emits a mouse-mode change only when the mode differs from
+// the last view's, and Home.chrome reports MouseModeNone on every frame — so a
+// single attach re-arms the ~270 MouseWheelMsg/sec repaint storm for the rest of
+// the process. Nothing about that failure is visible until someone scrolls.
+//
+// The three attach paths (attachSession, the drawer's full attach, the account
+// login pane) all run through attachCmd.Run, so this asserts the restore lives
+// there rather than in any one tea.Exec callback: a fourth path added later
+// gets it for free, and cannot forget it.
+func TestAttachRestoresTerminalModes(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "app.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse app.go: %v", err)
+	}
+
+	var body *ast.BlockStmt
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "Run" || fn.Recv == nil {
+			return true
+		}
+		if len(fn.Recv.List) != 1 {
+			return true
+		}
+		if ident, ok := fn.Recv.List[0].Type.(*ast.Ident); ok && ident.Name == "attachCmd" {
+			body = fn.Body
+		}
+		return true
+	})
+	if body == nil {
+		t.Fatal("attachCmd.Run not found in app.go — if the attach moved, move this guard with it")
+	}
+
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if ok && pkg.Name == "termkeys" && sel.Sel.Name == "Reassert" {
+			found = true
+		}
+		return true
+	})
+	if !found {
+		t.Error("attachCmd.Run does not call termkeys.Reassert: the terminal keeps " +
+			"whatever mouse/key reporting tmux left on, and the next scroll is a " +
+			"full-View() repaint storm that nothing in the process will stop")
+	}
+}
+
+// TestChromeKeepsMouseReportingOff pins the other half of the pair. Reassert
+// only holds while the view never asks for reporting: the renderer would emit a
+// DECSET the moment MouseMode differs from the previous frame's, and nothing in
+// the TUI has ever handled a mouse event, so every such event is a full View()
+// bought for nothing.
+func TestChromeKeepsMouseReportingOff(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "app.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse app.go: %v", err)
+	}
+
+	var body *ast.BlockStmt
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if ok && fn.Name.Name == "chrome" && fn.Recv != nil {
+			body = fn.Body
+		}
+		return true
+	})
+	if body == nil {
+		t.Fatal("Home.chrome not found in app.go")
+	}
+
+	var assigned string
+	ast.Inspect(body, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok || len(as.Lhs) != 1 || len(as.Rhs) != 1 {
+			return true
+		}
+		lhs, ok := as.Lhs[0].(*ast.SelectorExpr)
+		if !ok || lhs.Sel.Name != "MouseMode" {
+			return true
+		}
+		if rhs, ok := as.Rhs[0].(*ast.SelectorExpr); ok {
+			assigned = rhs.Sel.Name
+		}
+		return true
+	})
+	if !strings.EqualFold(assigned, "MouseModeNone") {
+		t.Errorf("Home.chrome sets MouseMode to %q, want MouseModeNone: v2 re-renders "+
+			"after every message, so each ignored mouse event costs a full View() — "+
+			"measured at ~270/sec and 250%% CPU while a scroll lasts", assigned)
+	}
+}

--- a/internal/ui/attach_termkeys_test.go
+++ b/internal/ui/attach_termkeys_test.go
@@ -61,7 +61,7 @@ func TestAttachRestoresTerminalModes(t *testing.T) {
 	})
 	if !found {
 		t.Error("attachCmd.Run does not call termkeys.Reassert: the terminal keeps " +
-			"whatever mouse/key reporting tmux left on, and the next scroll is a " +
+			"whatever mouse reporting tmux left on, and the next scroll is a " +
 			"full-View() repaint storm that nothing in the process will stop")
 	}
 }


### PR DESCRIPTION
Follow-up to #268, which fixed the scroll repaint storm but listed the attach round trip as untested. That was the one path that undoes it.

Reported as "fleet was very slow"; perfwatch had caught it as two `update_storm` dumps at **255 and 272 MouseWheelMsg/sec holding 250% CPU**, each event buying a full `View()` over 69 sessions.

## The chain

1. fleet sets `mouse on` per session, so attaching puts the outer terminal into DECSET 1000/1002/1006.
2. The attach ends by **killing** the tmux client (`Ctrl+Q` → `close(detachCh); cancel()` in `internal/tmux/pty.go`) rather than detaching it, so tmux never runs its terminal cleanup and those modes stay on in fleet's own terminal.
3. Bubble Tea never takes them off. Its renderer emits a mouse-mode change only when the mode *differs* from the last view's, and `Home.chrome` reports `MouseModeNone` on every frame; the post-Exec resume path writes nothing at all for `None`. Its input parser decodes the incoming bytes into `MouseWheelMsg` regardless of the mode it asked for.

So one attach re-arms the #268 storm for the rest of the process, and nothing looks wrong until someone scrolls.

The timeline from this user's machine is what pins it as a regression rather than an incomplete fix — 23 storms the day before #268 shipped, then **35 hours clean**, then an attach, then storms again.

## Measured, not reasoned

A probe reproducing fleet's exact sequence (tmux session, `mouse on`, PTY attach, SIGKILL the client the way `Ctrl+Q` does):

```
mode 1000: ON  <-- LEAKED
mode 1002: ON  <-- LEAKED
mode 1006: ON  <-- LEAKED
```

Exactly the SGR wheel-reporting combination. `Reassert` clears all of them.

## Why `Reassert` is not just a second `Disable`

Two of `Disable`'s four sequences carry state:

- **XTSAVE (`1007s`)** has a single save slot — repeating it overwrites the user's original value with the already-cleared one, so `Restore` hands the terminal back wrong on exit.
- **`DisableKittyKeyboard`** pushes onto a stack `Restore` pops exactly once — each repeat leaks an entry, once per attach, all session long.

What's left is the two plain idempotent sets plus the mouse reset. Pinned by `TestReassertRepeatsNothingStateful`.

## Placement

In `attachCmd.Run` rather than a `tea.Exec` callback: all three attach paths (session, drawer shell, account login pane) run through that one type, so a fourth gets it for free instead of having to remember. Before Bubble Tea's `RestoreTerminal` re-enters the alternate screen — the order `termkeys.Disable` was verified in.

## Testing

- `TestReassertTurnsMouseReportingOff`, `TestReassertRepeatsNothingStateful`, `TestReassertPropagatesWriteError`
- `TestAttachRestoresTerminalModes` and `TestChromeKeepsMouseReportingOff` — AST guards, **each confirmed to fail with the fix removed**
- `go test -race ./...` clean, `golangci-lint` 0 issues

`TestCredentialResolutionOrder` (`internal/linear`) fails on this branch and identically on clean `master` — it reads the real keychain. Pre-existing, untouched.

## Out of scope, found while investigating

- `refreshAllGitAndPR` cycles drifting 745ms → 2725ms across 31 repos every ~2s; top of the mutex profile via fork-lock contention.
- `~/.config/fleet/stalls/` at 480 MB / 38 files — each dump is 13.8 MB and costs ~1.2s stop-the-world, re-firing every 5s during a storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8LQCFMKTuXAVEx54H6GyX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored terminal keyboard and mouse settings after attaching to a session.
  * Prevented excessive screen redraws and CPU usage caused by lingering mouse-reporting modes.
  * Preserved terminal behavior when returning from full-screen sessions.

* **Tests**
  * Added coverage to verify terminal modes are restored correctly and restoration errors are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->