### PR TITLE
fix(status): repair hooks pointing at a deleted binary, and stop one frame ending a run

### DIFF
--- a/changelog/unreleased/hooks-repair-deleted-binary.md
+++ b/changelog/unreleased/hooks-repair-deleted-binary.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**Status survives a deleted binary.** Hooks pointed at the exact `fleet` binary that installed them, so removing that git worktree — or upgrading past that Homebrew version — silently killed status detection for every session while screen scraping quietly stood in. fleet now re-points them within a minute and names the sessions you need to restart.
+**Status stops going dark.** Every session could lose status detection at once, silently, if the `fleet` binary that installed the hooks was later deleted or upgraded away — the sidebar kept showing a status, just a guessed one. fleet now repairs the hooks within a minute and names the sessions to restart.

--- a/changelog/unreleased/hooks-repair-deleted-binary.md
+++ b/changelog/unreleased/hooks-repair-deleted-binary.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Status survives a deleted binary.** Hooks pointed at the exact `fleet` binary that installed them, so removing that git worktree — or upgrading past that Homebrew version — silently killed status detection for every session while screen scraping quietly stood in. fleet now re-points them within a minute and names the sessions you need to restart.

--- a/changelog/unreleased/typed-prompt-false-finished.md
+++ b/changelog/unreleased/typed-prompt-false-finished.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+**Typing no longer marks a session done.** Starting a message while the agent was still working could flip it to finished for ~18s — long enough for `Space` to jump you to a session that was busy. A single frame can no longer end a run.

--- a/changelog/unreleased/typed-prompt-false-finished.md
+++ b/changelog/unreleased/typed-prompt-false-finished.md
@@ -2,4 +2,4 @@
 type: fixed
 ---
 
-**Typing no longer marks a session done.** Starting a message while the agent was still working could flip it to finished for ~18s — long enough for `Space` to jump you to a session that was busy. A single frame can no longer end a run.
+**Busy sessions stay busy.** Starting a message while the agent was still working could mark it finished for ~18s — long enough for `Space` to jump you onto a session that was mid-run.

--- a/internal/hooks/claude_hooks.go
+++ b/internal/hooks/claude_hooks.go
@@ -2,7 +2,9 @@ package hooks
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -446,10 +448,18 @@ func hookBinaryMissing(hooks map[string]json.RawMessage) bool {
 				if bin == "" || !filepath.IsAbs(bin) {
 					continue
 				}
-				if _, err := os.Stat(bin); err != nil {
+				// Strictly "not there", never "could not tell". EACCES, ELOOP, a
+				// stalled network mount or a parent dir that lost +x all report an
+				// error while the binary may be perfectly fine — and treating those
+				// as deleted would rewrite settings.json every cycle forever and
+				// reopen the cross-instance fight this function exists to avoid.
+				if _, err := os.Stat(bin); errors.Is(err, fs.ErrNotExist) {
 					debuglog.Logger.Warn("claude hooks: hook command no longer exists",
 						"event", cfg.Event, "binary", bin)
 					return true
+				} else if err != nil {
+					debuglog.Logger.Warn("claude hooks: could not stat hook command; assuming it is fine",
+						"event", cfg.Event, "binary", bin, "err", err)
 				}
 			}
 		}
@@ -497,10 +507,15 @@ func RepairClaudeHooks(configDir string) (bool, error) {
 
 	debuglog.Logger.Warn("claude hooks: repairing a hook command that no longer exists",
 		"path", settingsPath, "newCommand", GetHookCommand())
-	if _, err := InjectClaudeHooks(configDir); err != nil {
+	// Report what was actually written, not what we set out to write.
+	// InjectClaudeHooks re-reads settings.json, so a sibling instance that
+	// repaired it between our read and its own leaves nothing to do — and
+	// claiming a repair we did not make latches the caller's tip on for good.
+	wrote, err := InjectClaudeHooks(configDir)
+	if err != nil {
 		return false, err
 	}
-	return true, nil
+	return wrote, nil
 }
 
 // hooksNeedUpdate checks if the hook command path has changed (e.g., after rebuild).

--- a/internal/hooks/claude_hooks.go
+++ b/internal/hooks/claude_hooks.go
@@ -183,7 +183,8 @@ func InjectClaudeHooks(configDir string) (bool, error) {
 		existingHooks = make(map[string]json.RawMessage)
 	}
 
-	if hooksAlreadyInstalled(existingHooks) && !hooksNeedUpdate(existingHooks) && !hasStaleHookEvents(existingHooks) {
+	if hooksAlreadyInstalled(existingHooks) && !hooksNeedUpdate(existingHooks) &&
+		!hasStaleHookEvents(existingHooks) && !hookBinaryMissing(existingHooks) {
 		debuglog.Logger.Debug("claude hooks: already installed and up to date")
 		return false, nil
 	}
@@ -390,6 +391,116 @@ func hooksAlreadyInstalled(hooks map[string]json.RawMessage) bool {
 		}
 	}
 	return true
+}
+
+// fleetHookBinary extracts the binary path from a fleet hook command. The
+// command is built by GetHookCommand as `<shell-quoted path> hook-handler
+// --fleet-hook`, so cutting at " hook-handler" recovers the path whatever the
+// binary is named. Returns "" when there is nothing to recover.
+func fleetHookBinary(command string) string {
+	path, _, ok := strings.Cut(strings.TrimSpace(command), " hook-handler")
+	if !ok {
+		return ""
+	}
+	path = strings.TrimSpace(path)
+	if len(path) >= 2 && strings.HasPrefix(path, "'") && strings.HasSuffix(path, "'") {
+		path = strings.ReplaceAll(path[1:len(path)-1], `'\''`, "'")
+	}
+	return path
+}
+
+// hookBinaryMissing reports whether a fleet hook names an absolute path that is
+// no longer on disk.
+//
+// This is the failure mode that silences status detection completely and says
+// nothing: the hook still fires, Claude runs a command that doesn't resolve, no
+// status file is written, and every session falls back to pane capture with
+// nothing anywhere reporting why. It is reachable in ordinary use because the
+// injected path routinely points inside a git worktree's build/ — run fleet from
+// a worktree once and the path it writes outlives the worktree's removal.
+// FleetBinaryPath already guards the sibling case (a `go run` binary that
+// vanishes at exit) for exactly this reason; a deleted worktree is the same
+// invariant broken a different way.
+//
+// A bare or relative name is left alone: there is nothing absolute to stat, and
+// PATH is resolved by the shell when the hook fires.
+func hookBinaryMissing(hooks map[string]json.RawMessage) bool {
+	for _, cfg := range hookEventConfigs {
+		raw, ok := hooks[cfg.Event]
+		if !ok {
+			continue
+		}
+		var matchers []claudeHookMatcher
+		if err := json.Unmarshal(raw, &matchers); err != nil {
+			continue
+		}
+		for _, m := range matchers {
+			if cfg.Matcher != "" && m.Matcher != cfg.Matcher {
+				continue
+			}
+			for _, h := range m.Hooks {
+				if !isFleetHook(h.Command) {
+					continue
+				}
+				bin := fleetHookBinary(h.Command)
+				if bin == "" || !filepath.IsAbs(bin) {
+					continue
+				}
+				if _, err := os.Stat(bin); err != nil {
+					debuglog.Logger.Warn("claude hooks: hook command no longer exists",
+						"event", cfg.Event, "binary", bin)
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// RepairClaudeHooks re-injects fleet's hooks when the command they name no
+// longer exists on disk, and writes nothing otherwise.
+//
+// Safe to call on a timer, which InjectClaudeHooks is not: that one also
+// rewrites a path that merely *differs* from this process's own, so two fleet
+// instances running from different worktrees would overwrite each other's
+// settings.json on every call. A path that resolves works whoever wrote it —
+// hook-handler writes into one global status-file directory, not an
+// instance-scoped one — so "missing" is the only condition worth acting on
+// unprompted, and it is also the only one that actually breaks anything.
+//
+// Returns true when a repair was made.
+func RepairClaudeHooks(configDir string) (bool, error) {
+	settingsPath := filepath.Join(configDir, "settings.json")
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read settings.json: %w", err)
+	}
+	var rawSettings map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawSettings); err != nil {
+		return false, fmt.Errorf("parse settings.json: %w", err)
+	}
+	raw, ok := rawSettings["hooks"]
+	if !ok {
+		return false, nil
+	}
+	var existingHooks map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &existingHooks); err != nil {
+		return false, fmt.Errorf("parse hooks section: %w", err)
+	}
+	if !hookBinaryMissing(existingHooks) {
+		return false, nil
+	}
+
+	debuglog.Logger.Warn("claude hooks: repairing a hook command that no longer exists",
+		"path", settingsPath, "newCommand", GetHookCommand())
+	if _, err := InjectClaudeHooks(configDir); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // hooksNeedUpdate checks if the hook command path has changed (e.g., after rebuild).

--- a/internal/hooks/claude_hooks_test.go
+++ b/internal/hooks/claude_hooks_test.go
@@ -628,3 +628,134 @@ func TestInjectAndRemoveClaudeHooks(t *testing.T) {
 		}
 	})
 }
+
+func TestFleetHookBinary(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"quoted path", "'/Users/dev/code/fleet/build/fleet' hook-handler --fleet-hook", "/Users/dev/code/fleet/build/fleet"},
+		{"unquoted path", "/usr/local/bin/fleet hook-handler --fleet-hook", "/usr/local/bin/fleet"},
+		{"legacy command without the marker arg", "'/usr/local/bin/fleet' hook-handler", "/usr/local/bin/fleet"},
+		{"bare PATH fallback", "fleet hook-handler --fleet-hook", "fleet"},
+		// shellQuote escapes an embedded quote as '\'' — the path has to come
+		// back out intact or the stat below it checks the wrong file.
+		{"path containing a quote", `'/Users/o'\''brien/build/fleet' hook-handler --fleet-hook`, "/Users/o'brien/build/fleet"},
+		{"not a hook command", "/usr/local/bin/fleet chrome-host", ""},
+		{"empty", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := fleetHookBinary(c.command); got != c.want {
+				t.Errorf("fleetHookBinary(%q) = %q, want %q", c.command, got, c.want)
+			}
+		})
+	}
+}
+
+// writeHookSettings writes a settings.json whose SessionStart carries one fleet
+// hook running cmd, and returns the path.
+func writeHookSettings(t *testing.T, dir, cmd string) string {
+	t.Helper()
+	settings := map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"hooks": []any{
+						map[string]any{"type": "command", "command": cmd, "async": true},
+					},
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal settings: %v", err)
+	}
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	return path
+}
+
+func TestRepairClaudeHooksHealsADeletedCommand(t *testing.T) {
+	// The failure this exists for: fleet injects its own binary path, which in a
+	// dev checkout lives inside a git worktree's build/. Remove that worktree and
+	// every hook silently fails — Claude runs a path that doesn't resolve, no
+	// status file is written, and nothing anywhere reports it.
+	dir := t.TempDir()
+	gone := filepath.Join(t.TempDir(), "deleted-worktree", "build", "fleet")
+	path := writeHookSettings(t, dir, shellQuote(gone)+" hook-handler "+fleetHookArg)
+
+	repaired, err := RepairClaudeHooks(dir)
+	if err != nil {
+		t.Fatalf("RepairClaudeHooks failed: %v", err)
+	}
+	if !repaired {
+		t.Fatal("expected a repair when the hook command no longer exists")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if strings.Contains(string(data), gone) {
+		t.Errorf("settings still name the deleted binary %q", gone)
+	}
+	if !strings.Contains(string(data), GetHookCommand()) {
+		t.Errorf("settings do not name the current hook command %q", GetHookCommand())
+	}
+}
+
+func TestRepairClaudeHooksLeavesAResolvablePathAlone(t *testing.T) {
+	// The reason RepairClaudeHooks exists separately from InjectClaudeHooks.
+	// InjectClaudeHooks also rewrites a path that merely DIFFERS from this
+	// process's own, which is correct once at launch and ruinous on a timer: two
+	// fleet instances launched from different worktrees would overwrite each
+	// other's settings.json every cycle. A path that resolves works whoever wrote
+	// it — hook-handler writes into one global status-file dir — so only a
+	// missing path may be acted on unprompted.
+	dir := t.TempDir()
+	sibling := filepath.Join(t.TempDir(), "fleet")
+	if err := os.WriteFile(sibling, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("write sibling binary: %v", err)
+	}
+	cmd := shellQuote(sibling) + " hook-handler " + fleetHookArg
+	path := writeHookSettings(t, dir, cmd)
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+
+	repaired, err := RepairClaudeHooks(dir)
+	if err != nil {
+		t.Fatalf("RepairClaudeHooks failed: %v", err)
+	}
+	if repaired {
+		t.Error("repaired a hook command that resolves — instances would fight over settings.json")
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("settings.json was rewritten despite the hook command resolving")
+	}
+}
+
+func TestRepairClaudeHooksIgnoresAMissingSettingsFile(t *testing.T) {
+	// A machine that has never run Claude Code has no settings.json. That is not
+	// a broken hook, and the timer must not create one behind the user's back —
+	// InjectClaudeHooks at launch is what owns first install.
+	repaired, err := RepairClaudeHooks(t.TempDir())
+	if err != nil {
+		t.Fatalf("RepairClaudeHooks failed: %v", err)
+	}
+	if repaired {
+		t.Error("expected no repair when settings.json does not exist")
+	}
+}

--- a/internal/hooks/claude_hooks_test.go
+++ b/internal/hooks/claude_hooks_test.go
@@ -2,6 +2,8 @@ package hooks
 
 import (
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -757,5 +759,86 @@ func TestRepairClaudeHooksIgnoresAMissingSettingsFile(t *testing.T) {
 	}
 	if repaired {
 		t.Error("expected no repair when settings.json does not exist")
+	}
+}
+
+func TestRepairClaudeHooksLeavesAnUnstattableCommandAlone(t *testing.T) {
+	// Only "not there" justifies an unprompted write. A path we merely cannot
+	// stat — EACCES here, but equally ELOOP, a stalled network mount, or a parent
+	// that lost +x — must not read as deleted: RepairClaudeHooks runs on a timer,
+	// so a wrong answer rewrites settings.json every cycle forever and puts two
+	// instances from different worktrees back into the fight this function exists
+	// to avoid.
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	dir := t.TempDir()
+
+	// A binary inside a directory with no +x: Stat returns EACCES, not ENOENT.
+	sealed := filepath.Join(t.TempDir(), "sealed")
+	if err := os.MkdirAll(sealed, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	bin := filepath.Join(sealed, "fleet")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	if err := os.Chmod(sealed, 0000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sealed, 0755) })
+
+	if _, err := os.Stat(bin); errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("test setup produced ENOENT, not the permission error it needs: %v", err)
+	}
+
+	path := writeHookSettings(t, dir, shellQuote(bin)+" hook-handler "+fleetHookArg)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+
+	repaired, err := RepairClaudeHooks(dir)
+	if err != nil {
+		t.Fatalf("RepairClaudeHooks failed: %v", err)
+	}
+	if repaired {
+		t.Error("repaired a hook command that could not be stat'd — only ENOENT may trigger a repair")
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("settings.json was rewritten for a command that is not known to be missing")
+	}
+}
+
+func TestRepairClaudeHooksReportsWhatWasWritten(t *testing.T) {
+	// The bool must describe this process's own write. InjectClaudeHooks re-reads
+	// settings.json, so a sibling instance that repaired the file first leaves
+	// nothing to do — and reporting a repair we did not make latches the caller's
+	// tip on permanently.
+	dir := t.TempDir()
+	gone := filepath.Join(t.TempDir(), "deleted-worktree", "build", "fleet")
+	writeHookSettings(t, dir, shellQuote(gone)+" hook-handler "+fleetHookArg)
+
+	repaired, err := RepairClaudeHooks(dir)
+	if err != nil {
+		t.Fatalf("RepairClaudeHooks failed: %v", err)
+	}
+	if !repaired {
+		t.Fatal("expected the first call to report the repair it performed")
+	}
+
+	// Second call: the path now resolves, so there is nothing to repair and
+	// nothing to report.
+	repaired, err = RepairClaudeHooks(dir)
+	if err != nil {
+		t.Fatalf("RepairClaudeHooks failed: %v", err)
+	}
+	if repaired {
+		t.Error("reported a repair on an already-healthy settings.json")
 	}
 }

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -38,6 +38,11 @@ type ScenarioEvent struct {
 	ActivityAge time.Duration // simulate tmux window_activity this long ago (0 = no activity data)
 	HookAge     time.Duration // backdate the hook's UpdatedAt by this much (0 = now); simulates a stale hook
 	ConvActive  *bool         // inject conversationActivePastHook result; nil = leave unchanged
+	// Sleep blocks for real before the event is applied. The engine replays a
+	// timeline in an instant, which is fine for everything keyed off an injected
+	// timestamp but not for a guard that reads the wall clock directly — see
+	// paneFinishedConfirmDelay. Keep the durations small.
+	Sleep time.Duration
 }
 
 // ScenarioCheck asserts the session status at a point in time.
@@ -104,6 +109,10 @@ func runScenario(t *testing.T, sc Scenario) {
 	for _, entry := range timeline {
 		if entry.event != nil {
 			e := entry.event
+
+			if e.Sleep > 0 {
+				time.Sleep(e.Sleep)
+			}
 
 			// Apply hook status change.
 			if e.Hook != "" {
@@ -1282,16 +1291,100 @@ func TestScenarioSustainedIdlePromptStillFinishes(t *testing.T) {
 	const idle = head + tip + chrome
 
 	runScenario(t, Scenario{
-		Name: "no hook + idle prompt held for two passes → finished",
+		Name: "no hook + idle prompt held past the confirm delay → finished",
 		Events: []ScenarioEvent{
 			{At: 0, Pane: working},
 			{At: 500 * time.Millisecond, Pane: idle},
+			// A real pause, so the confirming reading is a genuinely later frame
+			// rather than the same one read twice (paneFinishedConfirmDelay).
+			{At: 1 * time.Second, Sleep: paneFinishedConfirmDelay + 50*time.Millisecond},
 		},
 		Checks: []ScenarioCheck{
 			{At: 0, Expected: StatusRunning},
 			{At: 500 * time.Millisecond, Expected: StatusRunning},
-			// Same pane on the next pass — the turn really did end.
+			// Same pane, a full pass later — the turn really did end.
 			{At: 1 * time.Second, Expected: StatusFinished},
+		},
+	})
+}
+
+// blinkPanes returns the three pane shapes the typed-prompt blink cycles through:
+// the agent working, the same pane with the activity line not drawn, and a pane
+// detectStatus cannot classify at all.
+func blinkPanes() (working, blink, unclassified string) {
+	const nbsp = " "
+	const chrome = "───────── missing-artifact-investigation ─\n" +
+		"❯" + nbsp + "/ren\n" +
+		"─────────\n" +
+		"  Opus 5 (1M context) | 8% | brz-3374-analytics-autoscaler\n" +
+		"  ⏸ plan mode on (shift+tab to cycle) · ← for agents\n"
+	const head = "⏺ Plan mode active — read-only from here. Launching parallel exploration.\n\n"
+	const tip = "  ⎿  Tip: Use --agent <agent_name> to directly start a conversation with a subagent\n\n"
+
+	working = head + "✽ Sock-hopping… (33s · ↓ 1.6k tokens · thinking with xhigh effort)\n" + tip + chrome
+	blink = head + tip + chrome
+	unclassified = "⏺ Reading config…\n\nsome output with no prompt, no menu and no activity line\n"
+	return
+}
+
+// TestScenarioOneFrameReadTwiceDoesNotConfirm pins the time floor.
+//
+// A reading is not a frame. statusWorkerCycle runs on its 500ms ticker OR on any
+// statusTrigger kick — a hook change on any session, attach exit, reload-all —
+// and tmux.Session.CapturePane serves a 400ms cache verbatim (with fewer than two
+// active sessions seedActiveCaptures does not re-capture at all). Two cycles
+// inside that window read the SAME pane, so counting readings alone lets one
+// blink frame confirm itself and demote a working session — the exact bug the
+// confirmation exists to prevent, and likeliest on a busy fleet where
+// hook-driven kicks are frequent.
+//
+// The replay engine models this for free: it runs checks back to back in real
+// time, so two consecutive checks with no Sleep are two readings microseconds
+// apart.
+func TestScenarioOneFrameReadTwiceDoesNotConfirm(t *testing.T) {
+	working, blink, _ := blinkPanes()
+
+	runScenario(t, Scenario{
+		Name: "no hook + one blink frame read twice inside the capture cache → stays running",
+		Events: []ScenarioEvent{
+			{At: 0, Pane: working},
+			{At: 500 * time.Millisecond, Pane: blink},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusRunning},
+			// Two readings of the one blink frame, no wall-clock gap between them.
+			{At: 500 * time.Millisecond, Expected: StatusRunning},
+			{At: 600 * time.Millisecond, Expected: StatusRunning}, // before fix: finished
+			{At: 700 * time.Millisecond, Expected: StatusRunning},
+		},
+	})
+}
+
+// TestScenarioUnclassifiedFrameBreaksTheConfirmation pins that the readings must
+// be consecutive, which is what the field doc promises.
+//
+// detectStatus returning "" is the common case, not a quiet vote for finished.
+// Without a reset in the default branch, a blink, then a long stretch of
+// unclassified frames, then another blink would demote a running session on two
+// frames far apart — and the wall-clock floor would be satisfied by the gap
+// itself, so the time check alone does not cover this.
+func TestScenarioUnclassifiedFrameBreaksTheConfirmation(t *testing.T) {
+	working, blink, unclassified := blinkPanes()
+
+	runScenario(t, Scenario{
+		Name: "no hook + blink, unclassified, blink → stays running",
+		Events: []ScenarioEvent{
+			{At: 0, Pane: working},
+			{At: 500 * time.Millisecond, Pane: blink},
+			{At: 1 * time.Second, Pane: unclassified, Sleep: paneFinishedConfirmDelay + 50*time.Millisecond},
+			// Far enough past the first blink that the delay alone would pass.
+			{At: 2 * time.Second, Pane: blink, Sleep: paneFinishedConfirmDelay + 50*time.Millisecond},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusRunning},
+			{At: 500 * time.Millisecond, Expected: StatusRunning},
+			{At: 1 * time.Second, Expected: StatusRunning},
+			{At: 2 * time.Second, Expected: StatusRunning}, // before fix: finished
 		},
 	})
 }

--- a/internal/session/scenario_test.go
+++ b/internal/session/scenario_test.go
@@ -1212,3 +1212,86 @@ func TestScenarioNBSPPromptClearsStaleWaiting(t *testing.T) {
 		},
 	})
 }
+
+// TestScenarioTypedPromptBlinkDoesNotDemoteRunning pins the no-hook half of the
+// between-bursts frame that applyHookFinished already guards for hook-driven
+// sessions.
+//
+// Captured live (snapshot 2026-08-26T12-38-45): a Claude session in plan mode was
+// working — `✳ Sock-hopping… (33s · ↓ 1.6k tokens · thinking with xhigh effort)`
+// — while the user typed a slash command into the input box. On one repaint the
+// activity line was absent, leaving `❯<nbsp>/ren` four lines from the bottom.
+// detectFinished reads that as an idle prompt, which is correct and deliberate
+// (TestScenarioNBSPPromptClearsStaleWaiting depends on it), but this session had
+// no hook data at all — its hook command pointed at a deleted worktree's binary —
+// so the pane was the only vote and that one frame demoted it to finished. Being
+// finished then dropped it off the ~500ms fast pass onto the round-robin, where
+// the wrong status stood for 18s and pulled the Space rotation onto a busy
+// session.
+//
+// Note there is no `⏵⏵` mode bar here: plan mode renders `⏸`, so detectFinished's
+// idlePatterns fallback does not fire and the prompt line is the whole signal.
+func TestScenarioTypedPromptBlinkDoesNotDemoteRunning(t *testing.T) {
+	const nbsp = " "
+
+	const chrome = "───────── missing-artifact-investigation ─\n" +
+		"❯" + nbsp + "/ren\n" +
+		"─────────\n" +
+		"  Opus 5 (1M context) | 8% | brz-3374-analytics-autoscaler\n" +
+		"  ⏸ plan mode on (shift+tab to cycle) · ← for agents\n"
+
+	const head = "⏺ Plan mode active — read-only from here. Launching parallel exploration.\n\n"
+	const tip = "  ⎿  Tip: Use --agent <agent_name> to directly start a conversation with a subagent\n\n"
+
+	// The agent is working: the activity line sits above the input box.
+	const working = head + "✽ Sock-hopping… (33s · ↓ 1.6k tokens · thinking with xhigh effort)\n" + tip + chrome
+	// The same pane one repaint later, activity line not drawn.
+	const blink = head + tip + chrome
+
+	runScenario(t, Scenario{
+		Name: "no hook + typed prompt on a single blink frame → stays running",
+		Events: []ScenarioEvent{
+			{At: 0, Pane: working},
+			{At: 500 * time.Millisecond, Pane: blink},
+			{At: 1 * time.Second, Pane: working},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusRunning},
+			{At: 500 * time.Millisecond, Expected: StatusRunning}, // before fix: finished
+			{At: 1 * time.Second, Expected: StatusRunning},
+		},
+	})
+}
+
+// TestScenarioSustainedIdlePromptStillFinishes is the counterweight: the
+// confirmation above must delay a demotion by one pass, never prevent one.
+// Guards against "fixing" the blink by pinning a running session forever.
+func TestScenarioSustainedIdlePromptStillFinishes(t *testing.T) {
+	const nbsp = " "
+
+	const chrome = "───────── missing-artifact-investigation ─\n" +
+		"❯" + nbsp + "/ren\n" +
+		"─────────\n" +
+		"  Opus 5 (1M context) | 8% | brz-3374-analytics-autoscaler\n" +
+		"  ⏸ plan mode on (shift+tab to cycle) · ← for agents\n"
+
+	const head = "⏺ Plan mode active — read-only from here. Launching parallel exploration.\n\n"
+	const tip = "  ⎿  Tip: Use --agent <agent_name> to directly start a conversation with a subagent\n\n"
+
+	const working = head + "✽ Sock-hopping… (33s · ↓ 1.6k tokens · thinking with xhigh effort)\n" + tip + chrome
+	const idle = head + tip + chrome
+
+	runScenario(t, Scenario{
+		Name: "no hook + idle prompt held for two passes → finished",
+		Events: []ScenarioEvent{
+			{At: 0, Pane: working},
+			{At: 500 * time.Millisecond, Pane: idle},
+		},
+		Checks: []ScenarioCheck{
+			{At: 0, Expected: StatusRunning},
+			{At: 500 * time.Millisecond, Expected: StatusRunning},
+			// Same pane on the next pass — the turn really did end.
+			{At: 1 * time.Second, Expected: StatusFinished},
+		},
+	})
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -141,6 +141,11 @@ type Session struct {
 	// Reset whenever a new hook arrives (see UpdateHookStatus).
 	waitingPaneConfirmed bool
 
+	// paneFinishedFrames counts consecutive pane captures that read finished while
+	// no hook data is available. A running session is only demoted once this
+	// reaches paneFinishedConfirmFrames — see updateStatusFromPane.
+	paneFinishedFrames int
+
 	deathRecorded bool // crash dump already written for the current life of this session; reset by Restart
 
 	// Transcript tiebreaker cache. conversationActivePastHook runs on the ~500ms fast
@@ -796,6 +801,7 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 		s.lastContentChangeAt = time.Time{}
 		s.hookOverriddenAt = time.Time{} // allow fresh evaluation of new hook
 		s.waitingPaneConfirmed = false   // re-observe the prompt before trusting a pane spinner
+		s.paneFinishedFrames = 0         // a fresh hook supersedes any half-confirmed pane demotion
 		// A non-dead hook means Claude is alive again. Re-arm the crash-dump
 		// trigger so the NEXT real death gets a dump even if a prior false
 		// transition (e.g. brief stale-hook flash before this fresh hook
@@ -1629,6 +1635,12 @@ const finishedHoldMaxAge = 5 * time.Second
 // status prematurely.
 const waitingHookRenderBackstop = 5 * time.Second
 
+// paneFinishedConfirmFrames is how many consecutive finished readings the pane
+// must give before a running session with no hook data is demoted. Two: the
+// frame this guards against is a single repaint, and anything higher would delay
+// every genuine finish for no further protection.
+const paneFinishedConfirmFrames = 2
+
 // conversationActiveWindow bounds how recent the last lead-conversation transcript
 // entry must be for conversationActivePastHook to count the agent as actively
 // working. Sized above the longest observed gap between lead entries during silent
@@ -1727,10 +1739,36 @@ func (s *Session) updateStatusFromPane(oldStatus Status, log *slog.Logger) {
 	case StatusRunning:
 		s.Status = StatusRunning
 		s.Acknowledged = false
+		s.paneFinishedFrames = 0
 	case StatusWaiting:
 		s.Status = StatusWaiting
 		s.Acknowledged = false
+		s.paneFinishedFrames = 0
 	case StatusFinished:
+		// One frame is not enough to demote a running session. Claude repaints the
+		// input box as the user types into it, and on that frame the activity line
+		// is briefly absent — leaving `❯ <typed text>`, which detectFinished reads
+		// as an idle prompt. That reading is deliberate and must stay: it is the
+		// only thing that clears a stale waiting hook when the user escapes a
+		// permission prompt and starts typing in default mode, where there is no
+		// `⏵⏵` mode bar to fall back on (see applyHookWaiting).
+		//
+		// With hook data the hook holds the session running through the blink, and
+		// applyHookFinished has its own guards for the same between-bursts frame.
+		// Here there is no hook at all, so the pane is the only vote and a single
+		// bad frame decides everything — it demoted a working session to finished,
+		// which also dropped it off the ~500ms fast pass onto the round-robin,
+		// where the wrong status then stood for ~18s and pulled the Space rotation
+		// onto a session that was busy. So the demotion has to be seen twice.
+		//
+		// Costs one extra pass (~500ms, since a running session is on the fast
+		// pass) before a genuine finish shows.
+		s.paneFinishedFrames++
+		if oldStatus == StatusRunning && s.paneFinishedFrames < paneFinishedConfirmFrames {
+			log.Debug("pane read finished while running — holding for confirmation",
+				"frames", s.paneFinishedFrames, "need", paneFinishedConfirmFrames)
+			return
+		}
 		if s.Acknowledged {
 			s.Status = StatusIdle
 		} else {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -142,9 +142,13 @@ type Session struct {
 	waitingPaneConfirmed bool
 
 	// paneFinishedFrames counts consecutive pane captures that read finished while
-	// no hook data is available. A running session is only demoted once this
-	// reaches paneFinishedConfirmFrames — see updateStatusFromPane.
-	paneFinishedFrames int
+	// a running session has no hook data, and paneFinishedFirstAt stamps the first
+	// of them. A running session is only demoted once the count reaches
+	// paneFinishedConfirmFrames AND paneFinishedConfirmDelay has elapsed — see
+	// updateStatusFromPane. Both are cleared by any reading that does not agree,
+	// including an unclassified one and a failed capture, so "consecutive" holds.
+	paneFinishedFrames  int
+	paneFinishedFirstAt time.Time
 
 	deathRecorded bool // crash dump already written for the current life of this session; reset by Restart
 
@@ -802,6 +806,7 @@ func (s *Session) UpdateHookStatus(hs *HookStatus, resolveRotation bool) bool {
 		s.hookOverriddenAt = time.Time{} // allow fresh evaluation of new hook
 		s.waitingPaneConfirmed = false   // re-observe the prompt before trusting a pane spinner
 		s.paneFinishedFrames = 0         // a fresh hook supersedes any half-confirmed pane demotion
+		s.paneFinishedFirstAt = time.Time{}
 		// A non-dead hook means Claude is alive again. Re-arm the crash-dump
 		// trigger so the NEXT real death gets a dump even if a prior false
 		// transition (e.g. brief stale-hook flash before this fresh hook
@@ -1641,6 +1646,20 @@ const waitingHookRenderBackstop = 5 * time.Second
 // every genuine finish for no further protection.
 const paneFinishedConfirmFrames = 2
 
+// paneFinishedConfirmDelay is the minimum time that must separate the first
+// finished reading from the demotion. Counting readings alone is not enough,
+// because a reading is not the same thing as a frame: statusWorkerCycle runs on
+// its 500ms ticker OR on any statusTrigger kick (a hook change on any session,
+// attach exit, reload-all), and tmux.Session.CapturePane serves a 400ms cache
+// verbatim — with fewer than two active sessions seedActiveCaptures does not even
+// re-capture. Two cycles inside that window therefore read the SAME pane, and a
+// bare count would confirm one blink against itself.
+//
+// Matched to tmux's captureCacheTTL so the confirming reading is provably a fresh
+// capture. It costs nothing in practice: the fast pass is 500ms, so a genuine
+// finish still lands on the next pass.
+const paneFinishedConfirmDelay = 400 * time.Millisecond
+
 // conversationActiveWindow bounds how recent the last lead-conversation transcript
 // entry must be for conversationActivePastHook to count the agent as actively
 // working. Sized above the longest observed gap between lead entries during silent
@@ -1719,6 +1738,13 @@ func (s *Session) applyHookFinished(paneStatus Status, convActive bool, log *slo
 	}
 }
 
+// resetPaneFinishedConfirmLocked drops a part-built finished confirmation. Caller
+// holds s.mu.
+func (s *Session) resetPaneFinishedConfirmLocked() {
+	s.paneFinishedFrames = 0
+	s.paneFinishedFirstAt = time.Time{}
+}
+
 // updateStatusFromPane detects status from pane capture when no hook data is available.
 func (s *Session) updateStatusFromPane(oldStatus Status, log *slog.Logger) {
 	log.Debug("no hook data, falling back to pane capture")
@@ -1726,6 +1752,11 @@ func (s *Session) updateStatusFromPane(oldStatus Status, log *slog.Logger) {
 	content, err := s.getCapturer().CapturePane()
 	if err != nil {
 		log.Warn("pane capture failed", "err", err)
+		// A frame we could not read is not a frame that agreed. Drop any
+		// half-built confirmation rather than letting it bridge the gap.
+		s.mu.Lock()
+		s.resetPaneFinishedConfirmLocked()
+		s.mu.Unlock()
 		return // Keep previous status on capture failure.
 	}
 
@@ -1739,11 +1770,11 @@ func (s *Session) updateStatusFromPane(oldStatus Status, log *slog.Logger) {
 	case StatusRunning:
 		s.Status = StatusRunning
 		s.Acknowledged = false
-		s.paneFinishedFrames = 0
+		s.resetPaneFinishedConfirmLocked()
 	case StatusWaiting:
 		s.Status = StatusWaiting
 		s.Acknowledged = false
-		s.paneFinishedFrames = 0
+		s.resetPaneFinishedConfirmLocked()
 	case StatusFinished:
 		// One frame is not enough to demote a running session. Claude repaints the
 		// input box as the user types into it, and on that frame the activity line
@@ -1763,18 +1794,34 @@ func (s *Session) updateStatusFromPane(oldStatus Status, log *slog.Logger) {
 		//
 		// Costs one extra pass (~500ms, since a running session is on the fast
 		// pass) before a genuine finish shows.
-		s.paneFinishedFrames++
-		if oldStatus == StatusRunning && s.paneFinishedFrames < paneFinishedConfirmFrames {
-			log.Debug("pane read finished while running — holding for confirmation",
-				"frames", s.paneFinishedFrames, "need", paneFinishedConfirmFrames)
-			return
+		if oldStatus == StatusRunning {
+			now := time.Now()
+			if s.paneFinishedFrames == 0 {
+				s.paneFinishedFirstAt = now
+			}
+			s.paneFinishedFrames++
+			// Both gates, because neither alone is sufficient: the count rejects a
+			// lone reading, and the delay rejects two readings of one cached frame.
+			if s.paneFinishedFrames < paneFinishedConfirmFrames ||
+				now.Sub(s.paneFinishedFirstAt) < paneFinishedConfirmDelay {
+				log.Debug("pane read finished while running — holding for confirmation",
+					"frames", s.paneFinishedFrames, "need", paneFinishedConfirmFrames,
+					"since", now.Sub(s.paneFinishedFirstAt).Round(time.Millisecond),
+					"needSince", paneFinishedConfirmDelay)
+				return
+			}
 		}
+		s.resetPaneFinishedConfirmLocked()
 		if s.Acknowledged {
 			s.Status = StatusIdle
 		} else {
 			s.Status = StatusFinished
 		}
 	default:
+		// An unclassified pane is the common case, not a quiet vote for finished.
+		// Without this a blink, then minutes of no-match, then another blink would
+		// demote a running session on two frames far apart.
+		s.resetPaneFinishedConfirmLocked()
 		log.Debug("no pattern matched, keeping previous status", "status", s.Status)
 	}
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -4752,24 +4752,41 @@ const hookRepairInterval = 60 * time.Second
 // merely differs from ours — otherwise two instances launched from different
 // worktrees would rewrite each other's settings.json every minute.
 //
-// Only ~/.claude is repaired. Per-account config dirs get settings.json copied
-// from it by claudeaccount.Provision on each session launch, so the repair
-// reaches them the same way the hooks did.
+// Both the active config dir and the literal ~/.claude are repaired, and the
+// second one is not redundant. GetClaudeConfigDir honours $CLAUDE_CONFIG_DIR,
+// which sessionEnv sets to a per-account dir — and fleet is very often launched
+// from inside a fleet session, so the "active" dir is routinely an account dir.
+// claudeaccount.Provision mirrors settings.json out of the real ~/.claude on
+// every session launch, so repairing only the account dir would be copied back
+// over within minutes: the blackout would survive its own fix, in exactly the
+// setup that produces it. Repairing ~/.claude alone is not enough either — a user
+// may have set CLAUDE_CONFIG_DIR themselves, and that dir is the one their
+// sessions read. Each call is a read that writes nothing when healthy, so doing
+// both costs a stat.
 func (h *Home) maybeRepairClaudeHooks() {
 	if !h.lastHookRepairAt.IsZero() && time.Since(h.lastHookRepairAt) < hookRepairInterval {
 		return
 	}
 	h.lastHookRepairAt = time.Now()
 
-	repaired, err := hooks.RepairClaudeHooks(hooks.GetClaudeConfigDir())
-	if err != nil {
-		debuglog.Logger.Error("hook repair failed", "err", err)
-		return
+	dirs := []string{hooks.GetClaudeConfigDir()}
+	if home, err := os.UserHomeDir(); err == nil {
+		if real := filepath.Join(home, ".claude"); real != dirs[0] {
+			dirs = append(dirs, real)
+		}
 	}
-	if repaired {
-		h.hooksRepaired.Store(true)
-		debuglog.Logger.Info("claude hooks re-pointed at the running binary",
-			"command", hooks.GetHookCommand())
+
+	for _, dir := range dirs {
+		repaired, err := hooks.RepairClaudeHooks(dir)
+		if err != nil {
+			debuglog.Logger.Error("hook repair failed", "dir", dir, "err", err)
+			continue
+		}
+		if repaired {
+			h.hooksRepaired.Store(true)
+			debuglog.Logger.Info("claude hooks re-pointed at the running binary",
+				"dir", dir, "command", hooks.GetHookCommand())
+		}
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -235,10 +235,17 @@ type Home struct {
 	viewOffset int
 
 	isAttaching atomic.Bool
-	err         error
-	errTime     time.Time
-	infoMsg     string
-	infoTime    time.Time
+
+	// hooksRepaired latches once maybeRepairClaudeHooks has re-pointed a hook
+	// command that had been deleted. Written on the worker, read by the tip on
+	// the Update tick, hence atomic. Latched rather than sent as a message: the
+	// repair happens at most once in a launch, and worker sends are dropped
+	// during an attach — losing that one send would lose the tip for good.
+	hooksRepaired atomic.Bool
+	err           error
+	errTime       time.Time
+	infoMsg       string
+	infoTime      time.Time
 
 	newDialog             *NewSessionDialog
 	confirmDialog         *ConfirmDialog
@@ -307,6 +314,9 @@ type Home struct {
 	// lastAdoptSweepAt throttles the externally-created-session sweep, mirroring
 	// lastSuspendSweepAt. Worker-goroutine-only, so it needs no lock.
 	lastAdoptSweepAt time.Time
+	// lastHookRepairAt throttles the hook-command existence check, mirroring
+	// lastSuspendSweepAt. Worker-goroutine-only, so it needs no lock.
+	lastHookRepairAt time.Time
 
 	// groupSnooze maps a sidebar group key ("origin:<key>" or a checkout path)
 	// to its umbrella snooze deadline. Read only while building the sidebar
@@ -4721,6 +4731,48 @@ func (h *Home) maybeSuspendIdleSessions(sessions []*session.Session) {
 	}
 }
 
+// hookRepairInterval throttles the hook-command existence check. Slow on purpose:
+// the condition it catches (the injected command's binary deleted out from under
+// a running fleet) changes at most once in a session's life, and the check reads
+// settings.json and stats a path.
+const hookRepairInterval = 60 * time.Second
+
+// maybeRepairClaudeHooks re-points Claude's hooks when the command they name no
+// longer exists on disk.
+//
+// Hooks are injected once, at launch, against the running binary's own path —
+// which in a dev checkout is a worktree's build/fleet. Delete that worktree and
+// every hook in ~/.claude/settings.json silently fails: no status file is ever
+// written, every session falls back to pane capture, and nothing anywhere says
+// so. Measured on a real fleet: 19 hours and 37 live sessions with not one hook
+// firing. Launch-time injection cannot cover it, because the path is clobbered
+// by a *sibling* fleet instance and then deleted while this one keeps running.
+//
+// RepairClaudeHooks writes only when the path is actually missing, never when it
+// merely differs from ours — otherwise two instances launched from different
+// worktrees would rewrite each other's settings.json every minute.
+//
+// Only ~/.claude is repaired. Per-account config dirs get settings.json copied
+// from it by claudeaccount.Provision on each session launch, so the repair
+// reaches them the same way the hooks did.
+func (h *Home) maybeRepairClaudeHooks() {
+	if !h.lastHookRepairAt.IsZero() && time.Since(h.lastHookRepairAt) < hookRepairInterval {
+		return
+	}
+	h.lastHookRepairAt = time.Now()
+
+	repaired, err := hooks.RepairClaudeHooks(hooks.GetClaudeConfigDir())
+	if err != nil {
+		debuglog.Logger.Error("hook repair failed", "err", err)
+		return
+	}
+	if repaired {
+		h.hooksRepaired.Store(true)
+		debuglog.Logger.Info("claude hooks re-pointed at the running binary",
+			"command", hooks.GetHookCommand())
+	}
+}
+
 // adoptSweepInterval throttles the externally-created-session sweep to its own
 // cadence inside the ~2s heavy worker pass. Re-reading the sessions table every
 // heavy cycle would buy nothing: the payoff is a CLI-created session showing up
@@ -6536,6 +6588,11 @@ drainPriority:
 	// why it lives here rather than on the Update loop. Also called on the
 	// empty-fleet early-return path above — the throttle makes that safe.
 	h.maybeAdoptExternalSessions(sessions)
+
+	// 5d. Re-point Claude's hooks if the command they name has been deleted.
+	// Self-throttled; stats a file and may rewrite settings.json, which is why it
+	// lives here rather than on the Update loop.
+	h.maybeRepairClaudeHooks()
 
 	// 5. Git+PR refresh used to run here, inline. It now lives on its own
 	// goroutine (gitWorker) — see the comment there for why sharing this

--- a/internal/ui/tips.go
+++ b/internal/ui/tips.go
@@ -54,6 +54,7 @@ const (
 	// existing user has already dismissed and reset everyone's learned count.
 	// Only the Go identifier changed.
 	tipConnectTicketsID = "connect_linear"
+	tipHooksRepairedID  = "hooks_repaired"
 
 	reloadFailedThreshold = 4
 	cmdPaletteMinSessions = 3
@@ -67,6 +68,23 @@ const (
 
 // tipRegistry is the catalog of contextual tips. Add new tips here.
 var tipRegistry = []Tip{
+	{
+		// Above the TCC tip: a TCC-blocked folder breaks sessions in one place,
+		// a dead hook command breaks status reporting for every session at once,
+		// and unlike TCC it is invisible — the sidebar keeps showing a status,
+		// just one derived from pane scraping alone.
+		ID:       tipHooksRepairedID,
+		Policy:   tipRecurring,
+		Priority: 130,
+		active: func(h *Home) bool {
+			return h.hooksRepaired.Load() && h.countSessionsMissingHooks() > 0
+		},
+		text: func(h *Home) string {
+			return fmt.Sprintf("Claude's hooks pointed at a deleted fleet binary, so status came from screen scraping alone. "+
+				"Repaired — but %d running session(s) won't report status until you restart them (`r`).",
+				h.countSessionsMissingHooks())
+		},
+	},
 	{
 		// Highest priority: a TCC-blocked folder makes every session/shell there
 		// unusable, so it outranks the reload-failed hint.
@@ -175,6 +193,24 @@ func findTip(id string) *Tip {
 // countSessionsByStatus returns how many sessions are currently in st. Runs on
 // the Update goroutine, so reading h.sessions is safe (same contract as
 // rebuildFlatItems).
+// countSessionsMissingHooks counts sessions that should be reporting hook status
+// and are not. Suspended sessions are excluded — clearHookState wipes their hook
+// on purpose — as are Starting ones, which simply haven't fired SessionStart yet.
+// Drives the hooks-repaired tip, so it must stay cheap: in-memory reads only.
+func (h *Home) countSessionsMissingHooks() int {
+	n := 0
+	for _, s := range h.sessions {
+		switch s.GetStatus() {
+		case session.StatusSuspended, session.StatusStarting:
+			continue
+		}
+		if s.GetHookStatus() == "" {
+			n++
+		}
+	}
+	return n
+}
+
 func (h *Home) countSessionsByStatus(st session.Status) int {
 	n := 0
 	for _, s := range h.sessions {

--- a/internal/ui/tips.go
+++ b/internal/ui/tips.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/brizzai/fleet/internal/agent"
 	"github.com/brizzai/fleet/internal/debuglog"
 	"github.com/brizzai/fleet/internal/session"
 	"github.com/brizzai/fleet/internal/ticketing"
@@ -81,7 +82,7 @@ var tipRegistry = []Tip{
 		},
 		text: func(h *Home) string {
 			return fmt.Sprintf("Claude's hooks pointed at a deleted fleet binary, so status came from screen scraping alone. "+
-				"Repaired — but %d running session(s) won't report status until you restart them (`r`).",
+				"Repaired — but %d session(s) won't report status until you restart them (`r`).",
 				h.countSessionsMissingHooks())
 		},
 	},
@@ -197,9 +198,24 @@ func findTip(id string) *Tip {
 // and are not. Suspended sessions are excluded — clearHookState wipes their hook
 // on purpose — as are Starting ones, which simply haven't fired SessionStart yet.
 // Drives the hooks-repaired tip, so it must stay cheap: in-memory reads only.
+//
+// Claude only, because that is all maybeRepairClaudeHooks repairs. Codex and
+// OpenCode bake the same binary path (InjectCodexHooks builds its entries through
+// the shared mergeHookEvent -> GetHookCommand, and InjectOpenCodePlugin embeds
+// FleetBinaryPath in the generated .ts), so one deleted binary silences all three
+// — but a hookless Codex session is pinned to StatusIdle and would land in this
+// count, under a tip promising that `r` restores its status. It would not:
+// ~/.codex/hooks.json still names the dead path. Counting only what the repair
+// actually fixed keeps the tip's promise true; the other two need their own
+// repair, which is deliberately not in scope here.
+//
+// An empty Agent is legacy Claude, the same fallback agentGlyph makes.
 func (h *Home) countSessionsMissingHooks() int {
 	n := 0
 	for _, s := range h.sessions {
+		if s.Agent != agent.Claude && s.Agent != "" {
+			continue
+		}
 		switch s.GetStatus() {
 		case session.StatusSuspended, session.StatusStarting:
 			continue


### PR DESCRIPTION
Diagnosed from a `D` snapshot where a session showed **finished** while `✽ Sock-hopping… (54s · ↓ 2.9k tokens)` was on screen. Two independent faults stacked; the first is fleet-wide and much bigger than the one session.

## 1. Hooks were dead across the whole fleet

`snapshot.json` had an empty `hook` block and the log repeated `no hook data, falling back to pane capture` 48 times. The hook file was never written — and neither was anyone else's:

```
live fleet sessions WITH hook file: 17   (newest write ~19h old)
live fleet sessions WITHOUT hook file: 20
```

Every fleet hook in `~/.claude/settings.json` pointed at `…/brizz-code-base-branch/build/fleet`, a worktree that had since been removed. The hook fires, the command doesn't resolve, nothing is written, and every session silently falls back to pane capture with nothing anywhere reporting it. Routing was fine — `FLEET_INSTANCE_ID` was correctly set.

How it happens: hooks record `FleetBinaryPath()`, which in a dev checkout is a worktree's `build/fleet`. A sibling instance launched from another worktree rewrites that path at launch, the worktree is later deleted, and the long-running instance never re-checks. Homebrew hits the same shape across an upgrade (the versioned Cellar path goes away). The auto-updater is *not* implicated — it renames in place, so its path stays valid.

`RepairClaudeHooks` heals only a path that **doesn't resolve**, never one that merely differs from ours. That distinction is why it exists separately from `InjectClaudeHooks`, which also rewrites a differing path — correct once at launch, ruinous on a timer, since two instances from different worktrees would overwrite each other's `settings.json` every cycle. A path that resolves works whoever wrote it (`hook-handler` writes into one global status-file dir), so *missing* is the only condition worth acting on unprompted. Pinned by `TestRepairClaudeHooksLeavesAResolvablePathAlone`.

Runs throttled (60s) on the worker's heavy pass. A `tipRecurring` fires only after an actual repair and names how many sessions still need restarting, since a running agent keeps the settings it launched with.

## 2. One repaint frame ended a run

With hooks gone, a single frame decided everything:

```
12:38:24.150  matched spinner char  char=✳  line="✳ Sock-hopping… (33s · ↓ 1.6k tokens · thinking with xhigh effort)"
12:38:24.683  matched prompt        line="❯ /ren"  linesFromBottom=4
12:38:24.683  status changed (pane) old=running new=finished detected=finished
              ← 18 seconds of silence →
12:38:42.868  spacejump: landed     targetID=9a5508ce-1787736161
```

The user was typing a slash command while the agent worked. On that repaint the activity line wasn't drawn, so `detectRunning` missed and `detectFinished` matched the prompt. Being finished then dropped the session off the ~500ms fast pass onto the round-robin (5 per 2s over 69 sessions), where the wrong status stood for 18s — and `Space` jumped the user onto a session that was busy.

**The idle-prompt reading is deliberate and stays.** It is the only signal that clears a stale `waiting` hook when the user escapes a permission prompt and starts typing in default mode, where there's no `⏵⏵` mode bar to fall back on (#270). I spiked requiring an empty prompt remainder: all 21 golden fixtures pass, but it breaks `TestScenarioNBSPPromptClearsStaleWaiting`. The same pane shape must clear a stale waiting *and* must not demote a live running, and only the prior state separates them — so the guard belongs at the transition. `detectStatus` is untouched.

`updateStatusFromPane` now needs 2 consecutive finished readings before demoting a running session. Costs one extra pass (~500ms) before a genuine finish shows.

## Tests

- `TestScenarioTypedPromptBlinkDoesNotDemoteRunning` — reproduces the captured frame; fails `expected "running", got "finished"` without the guard.
- `TestScenarioSustainedIdlePromptStillFinishes` — the counterweight: the guard delays a demotion by one pass, never prevents one.
- `TestFleetHookBinary`, plus three `RepairClaudeHooks` tests covering heal / leave-alone / no-settings-file.

`make lint` clean, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbntCtmZonJDvwaQadprEz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Claude hooks now automatically repair themselves when the referenced Fleet binary is missing.
  - Fleet periodically checks for broken hooks without overwriting working configurations.
  - Session status no longer changes to finished because of a single blinking or incomplete frame.
  - Finished sessions require multiple spaced readings for more reliable status detection.

- **User Guidance**
  - Added a notification identifying sessions that should be restarted after hook repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->