### PR TITLE
Let Claude drive the TUI, and fix attach inside tmux

### DIFF
--- a/.claude/skills/drive-fleet/SKILL.md
+++ b/.claude/skills/drive-fleet/SKILL.md
@@ -124,6 +124,13 @@ default. Try `79` and `49` for the stacked and single layouts.
 character grid — `awk '{print length($0)}'`, `cut -c`, and `grep -n` all mean
 what you expect. A PNG cannot answer "is this column aligned".
 
+**A PNG is not authoritative for glyphs.** `freeze`'s font lacks a few of the
+codepoints fleet uses, so `✻` (Claude), `◐` (waiting) and `☾` (snooze) render as
+tofu boxes in an image while being perfectly fine in the terminal. Colors,
+spacing, alignment and layout are faithful; glyph identity is not. Check glyphs
+with `snap`, and never report a boxed glyph as a bug without confirming it in
+the text first.
+
 **Use `-e` for color questions only.** Colors carry meaning in fleet's design
 system (focus > selection > mode), so if the change touched a status color or an
 accent fill, capture ANSI and check the escape codes rather than guessing.

--- a/.claude/skills/drive-fleet/SKILL.md
+++ b/.claude/skills/drive-fleet/SKILL.md
@@ -22,7 +22,10 @@ closes that gap: boot a seeded fleet in a sandbox, press keys, read the screen.
 
 The whole surface is `demo/drive.sh`. It drives a throwaway fleet under
 `/private/tmp/fleet-drive` on its own tmux server — never the user's real
-sessions.
+sessions. That holds when you are yourself running inside a tmux pane, which
+you usually are: the script clears `$TMUX` before every tmux call, because
+`$TMUX` names a server and outranks `TMUX_TMPDIR`, and `down` verifies the
+socket it is about to kill lives under the sandbox.
 
 ## Step 1: Bring it up
 

--- a/.claude/skills/drive-fleet/SKILL.md
+++ b/.claude/skills/drive-fleet/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: drive-fleet
+description: >
+  Run fleet in an isolated sandbox and drive it — press keys, capture the screen
+  as text, sweep terminal sizes — so a UI change can be looked at instead of only
+  compiled. Use this whenever you touch anything that renders: a dialog, the
+  sidebar, the preview pane, the drawer, a keybinding, a status glyph, a settings
+  row, spacing, colors, or widths. Trigger on: "add a setting", "new dialog",
+  "change the sidebar", "does this look right", "check the layout", "what does it
+  look like", "screenshot fleet", "run fleet", "try it", "does it fit at 80
+  columns", or any UI work where `make build` passing is not the same as it
+  working.
+allowed-tools: Read, Grep, Glob, Bash
+user-invocable: true
+---
+
+# Drive the fleet TUI
+
+`make build` proves a UI change compiles. It says nothing about whether the
+dialog fits, the column aligns, or the footer is still on screen. This skill
+closes that gap: boot a seeded fleet in a sandbox, press keys, read the screen.
+
+The whole surface is `demo/drive.sh`. It drives a throwaway fleet under
+`/private/tmp/fleet-drive` on its own tmux server — never the user's real
+sessions.
+
+## Step 1: Bring it up
+
+```bash
+demo/drive.sh up            # builds if needed, seeds, launches at 120x40
+demo/drive.sh up 80x24      # or start at a size you want to test
+```
+
+First run takes a few seconds (Go build + `git init` on three repos). After
+that `up` reuses the sandbox. If it is already running, `up` relaunches.
+
+## Step 2: Drive it
+
+```bash
+demo/drive.sh key S                 # key names: S, Down, Enter, Escape, C-k
+demo/drive.sh key Down Down Enter   # several keys in order
+demo/drive.sh type "my branch name" # literal text — never key-name parsed
+demo/drive.sh size 80x24            # resize; the pane really is 24 rows
+```
+
+`key` and `type` are different tools and neither substitutes for the other.
+`key` hands its arguments to tmux's key-name parser, so `Down` means the arrow.
+`type` sends literal characters, so `Down` means the word.
+
+## Step 3: Read the screen
+
+```bash
+demo/drive.sh snap                       # settled plain-text grid
+demo/drive.sh snap -e                    # keep ANSI, to check colors
+demo/drive.sh snap -w 'Appearance'       # settle AND assert, in one call
+demo/drive.sh png /tmp/frame.png         # image of that same frame
+```
+
+Prefer `-w` whenever you know what should appear. Without it you race the
+dialog's first paint; with it, the wait and the assertion are one atomic step
+and a failure is loud instead of a confusing empty grep.
+
+`snap` returns when two consecutive captures match. It is honest about giving
+up: after 4 seconds it prints the frame anyway with a warning on stderr, because
+the only frames that never settle are the loading spinners and aborting over one
+is worse than a caveat.
+
+## What is in the sandbox
+
+Six sessions across four checkouts, built so every visual affordance appears
+exactly once:
+
+```
+▾ api-server 2  ◐ · ● · ●
+  ▾ main  ● · ●
+    ● ✻ Refactor sidebar          running · Claude
+    ● ✻ Fix flaky preview [1]     finished · slot badge
+  ▾ auth *  ◐                     worktree · dirty marker
+    ◐ ✻ Add test coverage         waiting
+    · ◇ Wire codex hooks          idle · Codex
+▾ notes 1
+  ▾ main  ☾ 2d                    group snooze
+    · △ Scratch notes  ☾          suspended · OpenCode
+▾ tools 1  ✕
+  ▾ main  ✕
+    ✕ ✻ Trim stale panes          error
+```
+
+Statuses are pinned by seeding SQLite and giving each row a live, silent tmux
+pane. Which agent holds which status is not arbitrary — only Claude reaches the
+pane-detection path where a quiet pane leaves the seeded status alone. Codex and
+OpenCode force `idle` when no hook file exists, and `suspended` needs no pane at
+all. If you add rows, keep that mapping or the status will be rewritten within
+seconds and you will think you found a bug.
+
+Not seeded: PR badges, tickets, drawer shells.
+
+## Reading a capture well
+
+**Check a dialog against the terminal height, not just its content.** This is
+the failure this harness exists for — a dialog that renders correctly at 40 rows
+and silently loses its footer at 22. Sweep it:
+
+```bash
+demo/drive.sh key S
+for h in 40 30 24 22 20; do
+  demo/drive.sh size 80x$h >/dev/null
+  echo "$h: $(demo/drive.sh snap | grep -c 'esc save')"
+done
+```
+
+A row that drops to 0 is a clip. `size` verifies the pane really is the height
+you asked for, so these numbers can be trusted — the tmux status bar otherwise
+steals a row and every measurement is off by one.
+
+**Layout breakpoints worth probing:** 80 columns is the dual/single-pane
+boundary, so `80x24` is the narrowest two-pane layout, not a comfortable
+default. Try `79` and `49` for the stacked and single layouts.
+
+**Count columns with the text, not the image.** `snap` output is an exact
+character grid — `awk '{print length($0)}'`, `cut -c`, and `grep -n` all mean
+what you expect. A PNG cannot answer "is this column aligned".
+
+**Use `-e` for color questions only.** Colors carry meaning in fleet's design
+system (focus > selection > mode), so if the change touched a status color or an
+accent fill, capture ANSI and check the escape codes rather than guessing.
+
+## Two things not to do
+
+- **Never point this at the user's real fleet.** Every key here is safe because
+  nothing in the sandbox is real. On a live fleet, `d` removes a worktree, `r`
+  kills an agent mid-turn, and `Y` approves a permission prompt on the user's
+  behalf. If they want you to look at their real fleet, ask — do not improvise.
+- **Do not trust a green screenshot too far.** This catches layout: clipping,
+  alignment, wrong glyphs, colors, spacing. It cannot catch the bugs that
+  dominate fleet's history — status races, stale hook ids, keychain limits. A
+  frame that looks right is not a passing test.
+
+## Tear down
+
+```bash
+demo/drive.sh down             # stop; keeps the sandbox for a fast next `up`
+demo/drive.sh down --purge     # also delete /private/tmp/fleet-drive
+demo/drive.sh status           # up/down, size, session count
+```
+
+Leaving it running between edits is fine and is the fast path — `up` after a
+code change rebuilds and relaunches in one command.
+
+## Checklist
+
+- [ ] `make build` passes
+- [ ] `demo/drive.sh up` and the change is **on screen**, not just compiled
+- [ ] Checked at a small size (`80x24`) if it renders in a dialog or panel
+- [ ] Nothing else in the frame moved — `snap` before and after, and diff
+- [ ] `demo/drive.sh down` when finished

--- a/changelog/unreleased/attach-inside-tmux.md
+++ b/changelog/unreleased/attach-inside-tmux.md
@@ -1,0 +1,4 @@
+---
+type: fixed
+---
+**Attach works inside tmux.** If you run fleet from within a tmux session, `⏎` now attaches instead of doing nothing — fleet was passing `$TMUX` through to `tmux attach-session`, which refuses a nested attach and printed its error somewhere you could never see it.

--- a/demo/drive.sh
+++ b/demo/drive.sh
@@ -1,0 +1,488 @@
+#!/bin/bash
+set -euo pipefail
+# fleet drive — run fleet in an isolated sandbox and drive it from the shell.
+# Built so a coding agent can press keys and read the screen while working on
+# the TUI, without touching the user's real sessions.
+#
+# Usage:
+#   demo/drive.sh up [WxH]          Build, seed and launch. Default 120x40.
+#   demo/drive.sh seed              Rebuild the fixture only.
+#   demo/drive.sh key <keys...>     Send keys by name: key Down Down Enter
+#   demo/drive.sh type <text...>    Send literal text.
+#   demo/drive.sh snap [-e] [-w RE] Print the settled screen. -e keeps ANSI.
+#   demo/drive.sh png <file>        Render the current frame to a PNG.
+#   demo/drive.sh size <WxH>        Resize the window.
+#   demo/drive.sh status            One line of state.
+#   demo/drive.sh down [--purge]    Tear down. --purge also removes the sandbox.
+
+# Physically resolved: on macOS /tmp is a symlink to /private/tmp, and
+# `git rev-parse --show-toplevel` returns the real path. An unresolved root
+# here makes pinned_repos and the sessions' repo roots different strings, so
+# every checkout renders twice — once with its sessions, once empty.
+DRIVE_DIR="$(cd /tmp && pwd -P)/fleet-drive"
+SANDBOX="$DRIVE_DIR/home"
+REPOS="$DRIVE_DIR/repos"
+DRIVE_SESSION="fleetdrive"
+FLEET="./build/fleet"
+SNAP_TIMEOUT_MS=4000
+SNAP_POLL=0.12
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$ROOT_DIR"
+
+# Helper: every tmux call goes to a private server. TMUX_TMPDIR is what makes
+# this a sandbox rather than a guest on the user's server — it is the single
+# stop for four separate leaks: migration's session renames, the server-scope
+# option writes in EnsureCopyCommand/EnsureExtendedKeys, a fixture name
+# colliding with a real session, and RefreshSessionCache enumerating the
+# user's real panes every tick.
+tmux_() {
+    TMUX_TMPDIR="$DRIVE_DIR/tmux" tmux "$@"
+}
+
+# Helper: the environment every fleet process in the sandbox must inherit.
+# The three *_CONFIG_DIR overrides are not redundant with HOME — those lookups
+# check the env var first and fall back to HOME only if it is unset, so an
+# ambient one inherited from the caller's shell would punch straight through
+# the sandbox and let InjectClaudeHooks rewrite the real settings.json.
+fleet_env() {
+    echo "-e HOME=$SANDBOX"
+    echo "-e TMUX_TMPDIR=$DRIVE_DIR/tmux"
+    echo "-e CLAUDE_CONFIG_DIR=$SANDBOX/.claude"
+    echo "-e CODEX_HOME=$SANDBOX/.codex"
+    echo "-e OPENCODE_CONFIG_DIR=$SANDBOX/.config/opencode"
+    echo "-e PATH=$SANDBOX/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    echo "-e FLEET_DEMO_PREFIX=$REPOS"
+    echo "-e FLEET_AUTO_UPDATE_DISABLED=1"
+    echo "-e FLEET_TELEMETRY_DISABLED=1"
+    echo "-e DO_NOT_TRACK=1"
+    echo "-e FLEET_FREEZE_ANIM=1"
+    echo "-e TERM=xterm-256color"
+    echo "-e COLORTERM=truecolor"
+}
+
+# Helper: sub-second sleep. Resolved once because probing per call would cost
+# more than the wait. bash 3.2 on macOS rejects `read -t 0.12`, so that is out.
+NAP_KIND=""
+nap() {
+    if [ -z "$NAP_KIND" ]; then
+        if sleep 0.01 2>/dev/null; then NAP_KIND=sleep
+        elif command -v perl >/dev/null 2>&1; then NAP_KIND=perl
+        elif command -v python3 >/dev/null 2>&1; then NAP_KIND=py
+        else
+            echo "drive: need one of sleep, perl, or python3 for sub-second waits." >&2
+            exit 2
+        fi
+    fi
+    case "$NAP_KIND" in
+        sleep) sleep "$1" ;;
+        perl)  perl -e "select(undef,undef,undef,$1)" ;;
+        py)    python3 -c "import time;time.sleep($1)" ;;
+    esac
+}
+
+# Helper: fail early and name the fix, rather than half-building a sandbox.
+require_tools() {
+    command -v tmux >/dev/null 2>&1 || {
+        echo "drive: tmux is not installed. Install it with: brew install tmux" >&2; exit 2; }
+    command -v sqlite3 >/dev/null 2>&1 || {
+        echo "drive: sqlite3 is not installed. macOS ships it at /usr/bin/sqlite3; check your PATH." >&2; exit 2; }
+    command -v git >/dev/null 2>&1 || {
+        echo "drive: git is not installed." >&2; exit 2; }
+}
+
+# Helper: refuse to drive a fleet that is not there, with the command to fix it.
+require_up() {
+    if ! tmux_ has-session -t "$DRIVE_SESSION" 2>/dev/null; then
+        echo "drive: fleet is not running. Run: demo/drive.sh up" >&2
+        exit 3
+    fi
+}
+
+# Helper: build only when needed. version=dev is a second lock on the
+# auto-updater beside FLEET_AUTO_UPDATE_DISABLED — `make build` stamps a real
+# `git describe` version, and a hit there replaces the binary and re-execs
+# itself out from under the change being tested.
+ensure_build() {
+    if [ ! -x "$FLEET" ] || [ -n "$(find cmd internal -name '*.go' -newer "$FLEET" -print -quit 2>/dev/null)" ]; then
+        echo "  Building (version=dev)..."
+        make build VERSION=dev >/dev/null
+    fi
+}
+
+# Helper: the sandbox HOME. Every line here buys one specific thing.
+ensure_sandbox() {
+    mkdir -p "$SANDBOX/.config/fleet" "$SANDBOX/bin" "$DRIVE_DIR/tmux" "$DRIVE_DIR/tmp"
+
+    # Without this marker, the first launch runs migration, which renames
+    # brizzcode_* sessions on whatever tmux server it can reach.
+    touch "$SANDBOX/.config/fleet/.migrated-from-brizz-code"
+
+    # This config is what keeps the first frame from being a dialog and later
+    # frames from changing on their own. The consent and onboarding flags stop
+    # two full-screen takeovers; the release-notes version stops the What's New
+    # shimmer (a ~60ms animation loop); seen_tips stops five tipOnce boxes that
+    # appear and then self-retire after 45s of visible time, changing the frame
+    # with no input at all.
+    cat > "$SANDBOX/.config/fleet/config.json" <<'JSONEOF'
+{
+  "analytics_consent_seen": true,
+  "display_onboarding_seen": true,
+  "telemetry_mode": "off",
+  "release_notes_seen_version": "9999.0.0",
+  "auto_update": false,
+  "auto_name_sessions": false,
+  "tick_interval_sec": 2,
+  "session_suspend_mode": "off",
+  "seen_tips": [
+    "command_palette", "terminal_drawer", "agent_skill", "connect_linear",
+    "sessions_suspended", "reload_failed_sessions", "tcc_blocked_folder",
+    "hooks_repaired"
+  ]
+}
+JSONEOF
+
+    # The hard guarantee behind "no real agents". BuildLaunchCmd emits the bare
+    # words claude/codex/opencode, resolved through the pane's PATH — so with
+    # these first, a stray `r` or a Ctrl+K "Reload All Sessions" from whoever is
+    # driving launches `cat`, not a real agent burning real quota. Everything
+    # else in this script is a promise not to press a key; this is a mechanism.
+    for a in claude codex opencode; do
+        printf '#!/bin/sh\nexec cat\n' > "$SANDBOX/bin/$a"
+        chmod +x "$SANDBOX/bin/$a"
+    done
+}
+
+# Helper: real directories on disk, because sidebar grouping shells out to
+# `git rev-parse --show-toplevel` and `git config --get remote.origin.url`.
+ensure_repos() {
+    mkdir -p "$REPOS"
+    local git_id="-c user.email=drive@example.com -c user.name=drive -c commit.gpgsign=false"
+
+    for r in api-server notes tools; do
+        [ -d "$REPOS/$r/.git" ] && continue
+        mkdir -p "$REPOS/$r"
+        ( cd "$REPOS/$r"
+          git init -q -b main .
+          echo "# $r" > README.md
+          git $git_id add -A
+          git $git_id commit -qm "init" )
+    done
+
+    # example.com, not github.com, on purpose: it groups the checkout and its
+    # worktree under one origin header while making `gh pr view` fail instantly
+    # instead of spending a network round trip. PR badges are out of scope and
+    # this is what keeps them out for free.
+    ( cd "$REPOS/api-server"
+      git remote get-url origin >/dev/null 2>&1 || \
+          git remote add origin git@example.com:acme/api-server.git )
+
+    if [ ! -d "$REPOS/api-server-auth" ]; then
+        ( cd "$REPOS/api-server"
+          git worktree add -q -b feat/auth "$REPOS/api-server-auth" 2>/dev/null || true )
+    fi
+    # The one dirty marker in the fixture.
+    echo "wip $(date +%s)" >> "$REPOS/api-server-auth/README.md" 2>/dev/null || true
+}
+
+# Helper: let the binary write its own schema. `fleet list` specifically, not
+# `add` or `worktree` — those call migration.Run(), which is the tmux-rename
+# path this sandbox exists to avoid. The redirect matters too: debuglog's
+# package default writes to stderr, so session.Open's Info lines would
+# otherwise spray slog over the caller's terminal.
+ensure_db() {
+    HOME="$SANDBOX" "$FLEET" list >/dev/null 2>&1 || true
+}
+
+# The fixture. One line per session: id|title|repo|agent|status|pane
+#
+# Statuses are constrained by how UpdateStatus dispatches on agent, and this is
+# the whole reason the table looks like it does. Only Claude reaches
+# updateStatusFromPane, where a quiet pane makes detectStatus return "" and the
+# default arm keeps whatever status was seeded — so running/waiting/finished/
+# error are Claude-only fixed points. Codex and OpenCode force idle when there
+# is no hook file, so idle is theirs. Suspended short-circuits before any tmux
+# check, so it needs no pane at all and any agent can hold it.
+#
+# Mirrors buildPreviewFixture's vocabulary (2-3 word verb-first titles, every
+# affordance exactly once) and extends it with error, suspended and OpenCode,
+# which that fixture omits on purpose but a layout harness needs.
+fixture_rows() {
+    cat <<'ROWS'
+d0000001|Refactor sidebar|api-server|claude|running|yes
+d0000002|Fix flaky preview|api-server|claude|finished|yes
+d0000003|Add test coverage|api-server-auth|claude|waiting|yes
+d0000004|Wire codex hooks|api-server-auth|codex|idle|yes
+d0000005|Scratch notes|notes|opencode|suspended|no
+d0000006|Trim stale panes|tools|claude|error|yes
+ROWS
+}
+
+# Helper: sanitizeName's rules, so a fixture name round-trips exactly as a real
+# one would — every char outside [A-Za-z0-9-] becomes a hyphen, case preserved.
+slug() {
+    echo "$1" | sed 's/[^A-Za-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//'
+}
+
+# Helper: one quiet pane per live row. `cat` with no stdin blocks forever,
+# paints nothing and generates no window_activity, which is exactly what keeps
+# detectStatus returning "" so the seeded status stands.
+ensure_panes() {
+    local id title repo agent status pane name
+    while IFS='|' read -r id title repo agent status pane; do
+        [ "$pane" = "yes" ] || continue
+        name="fleet_$(slug "$title")_$id"
+        tmux_ has-session -t "$name" 2>/dev/null && continue
+        tmux_ new-session -d -s "$name" -c "$REPOS/$repo" cat
+    done <<EOF
+$(fixture_rows)
+EOF
+}
+
+# Helper: the rows themselves.
+seed_rows() {
+    local now created id title repo agent status pane sid tmuxname i sql
+    now=$(date +%s)
+    created=$((now - 172800))
+    i=2
+
+    sql="PRAGMA busy_timeout=5000;
+DELETE FROM slot_bindings; DELETE FROM snoozed_groups; DELETE FROM sessions;
+DELETE FROM pinned_repos;"
+
+    while IFS='|' read -r id title repo agent status pane; do
+        sid="$id-$created"
+        if [ "$pane" = "yes" ]; then
+            tmuxname="fleet_$(slug "$title")_$id"
+        else
+            tmuxname=""
+        fi
+        # last_accessed lands in the middle of a display bucket, not on its
+        # edge: the preview footer renders relative time, so seeding "now"
+        # would give a frame that flips from "just now" to "1m ago" with no
+        # input. At i*3600+1800 each row reads a stable "Nh ago" for 30 minutes.
+        sql="$sql
+INSERT INTO sessions (id,title,project_path,agent,account,status,tmux_session,
+  created_at,last_accessed,acknowledged,claude_session_id,workspace_name,
+  manually_renamed,first_prompt,title_generated,prompt_count,snoozed_until)
+VALUES ('$sid','$title','$REPOS/$repo','$agent','','$status','$tmuxname',
+  $created,$((now - (i * 3600 + 1800))),0,'','',1,'',1,0,0);"
+        i=$((i + 1))
+    done <<EOF
+$(fixture_rows)
+EOF
+
+    # The one slot badge, and the one group snooze. The snooze goes on the
+    # group holding the suspended row deliberately: a snoozed group renders its
+    # children dim and suspended is already dim, so no affordance is masked.
+    # Snoozing the group with the error row would grey out the error colour.
+    sql="$sql
+INSERT INTO slot_bindings (slot_number, session_id) VALUES (1, 'd0000002-$created');
+INSERT INTO snoozed_groups (group_key, snoozed_until) VALUES ('$REPOS/notes', $((now + 144000)));
+INSERT INTO pinned_repos (repo_path) VALUES ('$REPOS/api-server'),
+  ('$REPOS/api-server-auth'), ('$REPOS/notes'), ('$REPOS/tools');"
+
+    echo "$sql" | sqlite3 "$SANDBOX/.config/fleet/state.db" >/dev/null
+}
+
+launch_tui() {
+    local w="$1" h="$2"
+    local -a envargs=()
+    while IFS= read -r line; do
+        envargs+=(-e "${line#-e }")
+    done < <(fleet_env)
+
+    # remain-on-exit keeps the error text on screen when fleet dies on launch —
+    # otherwise the pane vanishes and the only diagnosis is "it didn't work".
+    tmux_ new-session -d -s "$DRIVE_SESSION" -x "$w" -y "$h" \
+        -c "$ROOT_DIR" "${envargs[@]}" "$FLEET"
+    tmux_ set-option -t "$DRIVE_SESSION" remain-on-exit on >/dev/null 2>&1 || true
+    tmux_ set-option -t "$DRIVE_SESSION" window-size manual >/dev/null 2>&1 || true
+    # Per-session, not -g: the session carries its own explicit value that a
+    # global would not override, and a visible status bar silently costs the
+    # pane a row — which would make every size this script reports a lie.
+    tmux_ set-option -t "$DRIVE_SESSION" status off >/dev/null 2>&1 || true
+}
+
+# Resize so the PANE ends up the requested size, not the window. Those differ
+# by the status bar, and a harness that mislabels its geometry is worse than no
+# harness — every "clips at 80x22" finding would be off by one. Verify rather
+# than assume, and correct once if tmux disagrees.
+do_size() {
+    local size="$1" w h got
+    w="${size%x*}"; h="${size#*x}"
+    tmux_ resize-window -t "$DRIVE_SESSION" -x "$w" -y "$h"
+    nap 0.15
+    got=$(tmux_ display-message -p -t "$DRIVE_SESSION" '#{pane_height}')
+    if [ "$got" != "$h" ] && [ -n "$got" ]; then
+        tmux_ resize-window -t "$DRIVE_SESSION" -x "$w" -y "$((h + h - got))"
+        nap 0.15
+        got=$(tmux_ display-message -p -t "$DRIVE_SESSION" '#{pane_height}')
+    fi
+    if [ "$got" != "$h" ]; then
+        echo "drive: warning: asked for ${w}x${h}, pane is ${w}x${got}." >&2
+    fi
+}
+
+# Helper: the splash uses ▰/▱ for its progress bar, so their absence is a
+# precise "booted" signal — the only other user of those glyphs is the command
+# palette's priority gauge, which cannot be open during boot.
+wait_booted() {
+    local i=0 frame
+    while [ $i -lt 100 ]; do
+        frame=$(tmux_ capture-pane -p -t "$DRIVE_SESSION" 2>/dev/null || echo "")
+        case "$frame" in
+            *▰*|*▱*) ;;
+            *Sessions*|*"No Sessions"*) return 0 ;;
+        esac
+        nap 0.2
+        i=$((i + 1))
+    done
+    echo "drive: fleet did not reach a booted frame in 20s." >&2
+    echo "--- last frame ---" >&2
+    tmux_ capture-pane -p -t "$DRIVE_SESSION" 2>&1 | sed 's/^/  /' >&2
+    echo "--- debug.log tail ---" >&2
+    tail -20 "$SANDBOX/.config/fleet/debug.log" 2>/dev/null | sed 's/^/  /' >&2
+    exit 3
+}
+
+# Two consecutive identical captures, polled at 120ms. The interval is not
+# 100ms on purpose: fleet's tick cadences are 100ms (spinners), 80ms (splash)
+# and 60ms (shimmer), and a 100ms sampler aliases onto the spinner exactly —
+# it would report a spinning dialog as settled. 120ms shares no small-integer
+# ratio with any of them.
+wait_stable() {
+    local ansi="$1" want="$2"
+    local prev="" cur="" elapsed=0 capargs="-p"
+    [ "$ansi" = "yes" ] && capargs="-p -e"
+
+    while [ $elapsed -lt $SNAP_TIMEOUT_MS ]; do
+        # shellcheck disable=SC2086
+        cur=$(tmux_ capture-pane $capargs -t "$DRIVE_SESSION" 2>/dev/null) || {
+            echo "drive: fleet is not running. Run: demo/drive.sh up" >&2; exit 3; }
+        if [ "$cur" = "$prev" ]; then
+            if [ -z "$want" ] || printf '%s' "$cur" | grep -qE "$want"; then
+                printf '%s\n' "$cur"
+                return 0
+            fi
+        fi
+        prev="$cur"
+        nap $SNAP_POLL
+        elapsed=$((elapsed + 120))
+    done
+
+    if [ -n "$want" ]; then
+        echo "drive: frame never matched /$want/ within $((SNAP_TIMEOUT_MS/1000))s." >&2
+        printf '%s\n' "$cur" >&2
+        exit 3
+    fi
+    # An unsettled frame is not an error. The only frames that legitimately
+    # never settle are the loading spinners, and aborting a `set -e` caller
+    # over one is worse than handing back the frame with a caveat.
+    echo "drive: warning: frame unsettled after $((SNAP_TIMEOUT_MS/1000))s — a spinner is probably running." >&2
+    printf '%s\n' "$cur"
+}
+
+do_seed() {
+    ensure_sandbox
+    ensure_repos
+    ensure_db
+    ensure_panes
+    seed_rows
+}
+
+do_up() {
+    local size="${1:-120x40}" w h
+    w="${size%x*}"; h="${size#*x}"
+    require_tools
+    echo "=== fleet drive ==="
+    ensure_build
+    echo "  [1/3] Seeding sandbox at $DRIVE_DIR..."
+    do_seed
+    echo "  [2/3] Launching fleet (${w}x${h})..."
+    tmux_ kill-session -t "$DRIVE_SESSION" 2>/dev/null || true
+    launch_tui "$w" "$h"
+    echo "  [3/3] Waiting for boot..."
+    wait_booted
+    echo ""
+    echo "=== ready ==="
+    echo "  ${w}x${h}, 6 sessions across 4 checkouts under $REPOS"
+    echo ""
+    echo "  demo/drive.sh key S          # open settings"
+    echo "  demo/drive.sh snap           # capture the screen as text"
+    echo "  demo/drive.sh size 80x24     # probe a layout breakpoint"
+    echo "  demo/drive.sh down           # tear it all down"
+}
+
+do_snap() {
+    local ansi="no" want=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -e) ansi="yes"; shift ;;
+            -w) want="${2:-}"; shift 2 ;;
+            *)  echo "drive: unknown snap option: $1" >&2; exit 1 ;;
+        esac
+    done
+    require_up
+    wait_stable "$ansi" "$want"
+}
+
+do_png() {
+    local out="${1:-}"
+    [ -n "$out" ] || { echo "drive: png needs an output path. Run: demo/drive.sh png /tmp/frame.png" >&2; exit 1; }
+    command -v freeze >/dev/null 2>&1 || {
+        echo "drive: png needs charmbracelet/freeze. Install it with:" >&2
+        echo "  brew install charmbracelet/tap/freeze" >&2
+        exit 2; }
+    require_up
+    local raw="$DRIVE_DIR/tmp/frame.ansi"
+    wait_stable "yes" "" > "$raw"
+    freeze --language ansi -o "$out" "$raw" >/dev/null
+    echo "$out"
+}
+
+do_status() {
+    if tmux_ has-session -t "$DRIVE_SESSION" 2>/dev/null; then
+        local size rows
+        size=$(tmux_ display-message -p -t "$DRIVE_SESSION" '#{window_width}x#{window_height}')
+        rows=$(sqlite3 "$SANDBOX/.config/fleet/state.db" "SELECT COUNT(*) FROM sessions;" 2>/dev/null || echo "?")
+        echo "up  $size  $rows sessions  $DRIVE_DIR"
+    else
+        echo "down  $DRIVE_DIR"
+    fi
+}
+
+do_down() {
+    # One command, and only safe because the server is private: kill-server on
+    # a shared server would take the user's real sessions with it.
+    tmux_ kill-server 2>/dev/null || true
+    if [ "${1:-}" = "--purge" ]; then
+        rm -rf "$DRIVE_DIR"
+        echo "Torn down and purged $DRIVE_DIR."
+    else
+        echo "Torn down. Sandbox kept at $DRIVE_DIR (--purge to remove)."
+    fi
+}
+
+main() {
+    local verb="${1:-}"
+    [ $# -gt 0 ] && shift
+    case "$verb" in
+        up)     do_up "$@" ;;
+        seed)   require_tools; do_seed; echo "Reseeded $DRIVE_DIR." ;;
+        key)    require_up; tmux_ send-keys -t "$DRIVE_SESSION" "$@" ;;
+        type)   require_up; tmux_ send-keys -t "$DRIVE_SESSION" -l -- "$*" ;;
+        snap)   do_snap "$@" ;;
+        png)    do_png "$@" ;;
+        size)   require_up; do_size "$1" ;;
+        status) do_status ;;
+        down)   do_down "$@" ;;
+        *)
+            sed -n '3,17p' "$0" | sed 's/^# \{0,1\}//'
+            [ -n "$verb" ] && exit 1 || exit 0
+            ;;
+    esac
+}
+
+main "$@"

--- a/demo/drive.sh
+++ b/demo/drive.sh
@@ -123,6 +123,19 @@ ensure_build() {
 
 # Helper: the sandbox HOME. Every line here buys one specific thing.
 ensure_sandbox() {
+    # $DRIVE_DIR lives under /tmp, which is world-writable, so another process
+    # can pre-create it. A symlink there would point the whole sandbox — and
+    # the kill-server target below — somewhere else while every textual path
+    # check still passed. Refuse rather than follow it.
+    if [ -L "$DRIVE_DIR" ] || [ -L "$DRIVE_DIR/tmux" ]; then
+        echo "drive: $DRIVE_DIR is a symlink; refusing to use it." >&2
+        echo "drive: remove it and re-run, or set DRIVE_DIR elsewhere." >&2
+        exit 2
+    fi
+    mkdir -p -m 700 "$DRIVE_DIR"
+    # -m only applies on creation, so a directory someone else made first would
+    # keep its own mode. Set it either way.
+    chmod 700 "$DRIVE_DIR" 2>/dev/null || true
     mkdir -p "$SANDBOX/.config/fleet" "$SANDBOX/bin" "$DRIVE_DIR/tmux" "$DRIVE_DIR/tmp"
 
     # Without this marker, the first launch runs migration, which renames
@@ -473,8 +486,18 @@ do_down() {
     # came out right. An earlier version asserted this isolation in a comment
     # and was wrong for exactly one reason ($TMUX outranking TMUX_TMPDIR); a
     # comment cannot fail a run, and this can.
-    local sock
+    local sock sockdir
     sock=$(tmux_ display-message -p '#{socket_path}' 2>/dev/null || true)
+    # Compare resolved paths, not strings. tmux reports the socket path it was
+    # given, symlinks intact, so a symlinked component would let a socket that
+    # textually sits under $DRIVE_DIR actually live on the user's real server —
+    # and this check would then authorise precisely what it exists to prevent.
+    if [ -n "$sock" ]; then
+        sockdir=$(cd "$(dirname "$sock")" 2>/dev/null && pwd -P) || sockdir=""
+        if [ -n "$sockdir" ]; then
+            sock="$sockdir/$(basename "$sock")"
+        fi
+    fi
     case "$sock" in
         "$DRIVE_DIR"/*)
             tmux_ kill-server 2>/dev/null || true

--- a/demo/drive.sh
+++ b/demo/drive.sh
@@ -38,7 +38,17 @@ cd "$ROOT_DIR"
 # colliding with a real session, and RefreshSessionCache enumerating the
 # user's real panes every tick.
 tmux_() {
-    TMUX_TMPDIR="$DRIVE_DIR/tmux" tmux "$@"
+    # `env -u TMUX -u TMUX_PANE` is load-bearing, not tidiness. $TMUX names a
+    # socket and tmux prefers it over TMUX_TMPDIR — verified: with TMUX_TMPDIR
+    # pointing at an empty directory and $TMUX set, `tmux ls` still answered
+    # from the $TMUX server. So without this, TMUX_TMPDIR is inert and every
+    # command here lands on the caller's server: `down` would kill-server the
+    # user's real tmux, and the fixture panes would be created among their real
+    # sessions for their running fleet to adopt.
+    #
+    # This is the normal case, not an edge one: agent sessions run inside tmux
+    # panes, so anything driving this script has $TMUX set.
+    env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$DRIVE_DIR/tmux" tmux "$@"
 }
 
 # Helper: the environment every fleet process in the sandbox must inherit.
@@ -454,9 +464,26 @@ do_status() {
 }
 
 do_down() {
-    # One command, and only safe because the server is private: kill-server on
-    # a shared server would take the user's real sessions with it.
-    tmux_ kill-server 2>/dev/null || true
+    # kill-server is irreversible and takes every session on whichever server it
+    # reaches, so verify the target rather than trusting that the environment
+    # came out right. An earlier version asserted this isolation in a comment
+    # and was wrong for exactly one reason ($TMUX outranking TMUX_TMPDIR); a
+    # comment cannot fail a run, and this can.
+    local sock
+    sock=$(tmux_ display-message -p '#{socket_path}' 2>/dev/null || true)
+    case "$sock" in
+        "$DRIVE_DIR"/*)
+            tmux_ kill-server 2>/dev/null || true
+            ;;
+        "")
+            : # No server to kill; `down` stays idempotent.
+            ;;
+        *)
+            echo "drive: refusing to kill-server — socket is $sock, outside $DRIVE_DIR." >&2
+            echo "drive: that socket is not this sandbox's. Nothing was killed." >&2
+            exit 3
+            ;;
+    esac
     if [ "${1:-}" = "--purge" ]; then
         rm -rf "$DRIVE_DIR"
         echo "Torn down and purged $DRIVE_DIR."

--- a/demo/drive.sh
+++ b/demo/drive.sh
@@ -448,6 +448,10 @@ do_png() {
     require_up
     local raw="$DRIVE_DIR/tmp/frame.ansi"
     wait_stable "yes" "" > "$raw"
+    # Default font only. --font.family with a system font name (Menlo, SF Mono,
+    # Andale Mono were all tried) exits 0 and writes a near-blank image — three
+    # different names produced byte-identical 170KB files against 717KB for the
+    # default. A silent wrong answer is worse than the missing glyphs below.
     freeze --language ansi -o "$out" "$raw" >/dev/null
     echo "$out"
 }

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -48,6 +49,27 @@ func findCtrlQ(buf []byte) (int, int) {
 	return idx, length
 }
 
+// clientEnv returns the parent environment with tmux's own client variables
+// stripped. A tmux client refuses to attach to a session on the server it is
+// already inside — "sessions should be nested with care, unset $TMUX to force"
+// — so a fleet launched from within tmux would hand that variable to every
+// attach and Enter would do nothing at all. The error goes to the child's
+// stderr, which here is the PTY we immediately put into raw mode, so it never
+// reaches the TUI or the log: a silent dead key on fleet's primary action.
+// Unsetting is exactly what tmux's message asks for. TMUX_PANE goes with it —
+// it names a pane on the outer server and means nothing to the new client.
+func clientEnv() []string {
+	env := os.Environ()
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "TMUX=") || strings.HasPrefix(kv, "TMUX_PANE=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
 // Attach attaches to the tmux session with full PTY support.
 // Ctrl+Q detaches and returns to the caller. Ctrl+b d also works (tmux native).
 func (s *Session) Attach(ctx context.Context) error {
@@ -60,6 +82,7 @@ func (s *Session) Attach(ctx context.Context) error {
 
 	// Start tmux attach with PTY.
 	cmd := exec.CommandContext(ctx, "tmux", "attach-session", "-t", s.Name)
+	cmd.Env = clientEnv()
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to start pty: %w", err)

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -58,6 +58,35 @@ func findCtrlQ(buf []byte) (int, int) {
 // reaches the TUI or the log: a silent dead key on fleet's primary action.
 // Unsetting is exactly what tmux's message asks for. TMUX_PANE goes with it —
 // it names a pane on the outer server and means nothing to the new client.
+// socketFromEnv reads the server socket path out of $TMUX, whose value is
+// "<socket>,<pid>,<session>". Empty when fleet is not running inside tmux.
+func socketFromEnv() string {
+	v := os.Getenv("TMUX")
+	if i := strings.IndexByte(v, ','); i >= 0 {
+		v = v[:i]
+	}
+	return v
+}
+
+// attachArgs builds the tmux argv for attaching to name.
+//
+// $TMUX carries two things at once: which server to talk to, and the fact that
+// we are nested inside it. Only the second is a problem, so they have to be
+// separated — keep the server by naming its socket with -S, and drop the
+// nesting marker from the environment (see clientEnv).
+//
+// Dropping $TMUX on its own is not enough and is its own bug: tmux would fall
+// back to the *default* socket, while Exists() just confirmed the session on
+// the inherited one. For anyone running fleet under a named socket
+// (`tmux -L work`) every session lives there, so the attach would look for it
+// on a server that has never heard of it.
+func attachArgs(name string) []string {
+	if sock := socketFromEnv(); sock != "" {
+		return []string{"-S", sock, "attach-session", "-t", name}
+	}
+	return []string{"attach-session", "-t", name}
+}
+
 func clientEnv() []string {
 	env := os.Environ()
 	out := make([]string, 0, len(env))
@@ -81,7 +110,7 @@ func (s *Session) Attach(ctx context.Context) error {
 	defer cancel()
 
 	// Start tmux attach with PTY.
-	cmd := exec.CommandContext(ctx, "tmux", "attach-session", "-t", s.Name)
+	cmd := exec.CommandContext(ctx, "tmux", attachArgs(s.Name)...)
 	cmd.Env = clientEnv()
 	ptmx, err := pty.Start(cmd)
 	if err != nil {

--- a/internal/tmux/pty_test.go
+++ b/internal/tmux/pty_test.go
@@ -64,3 +64,55 @@ func TestClientEnvDropsTmuxVars(t *testing.T) {
 		t.Error("clientEnv() dropped an unrelated variable; it must only strip the tmux ones")
 	}
 }
+
+// $TMUX names the server AND marks the nesting. clientEnv drops the marker, so
+// the socket has to be carried some other way or the attach silently retargets
+// the default server — where Exists() never looked and the session is not.
+func TestAttachArgsKeepsTheInheritedSocket(t *testing.T) {
+	t.Run("inside tmux, -S names the inherited socket", func(t *testing.T) {
+		t.Setenv("TMUX", "/private/tmp/tmux-501/work,62039,14")
+		got := attachArgs("fleet_demo_abc")
+		want := []string{"-S", "/private/tmp/tmux-501/work", "attach-session", "-t", "fleet_demo_abc"}
+		if strings.Join(got, " ") != strings.Join(want, " ") {
+			t.Errorf("attachArgs() = %v, want %v", got, want)
+		}
+		// tmux parses server options before the command, so a -S appended after
+		// attach-session would be read as an argument to it and ignored.
+		if got[0] != "-S" {
+			t.Errorf("-S must precede the command; got %v", got)
+		}
+	})
+
+	t.Run("outside tmux, no -S at all", func(t *testing.T) {
+		t.Setenv("TMUX", "")
+		got := attachArgs("fleet_demo_abc")
+		for _, a := range got {
+			if a == "-S" {
+				t.Fatalf("attachArgs() added -S with no $TMUX: %v", got)
+			}
+		}
+	})
+}
+
+func TestSocketFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		tmux string
+		want string
+	}{
+		{"standard three-field value", "/tmp/tmux-501/default,123,0", "/tmp/tmux-501/default"},
+		{"named socket", "/tmp/tmux-501/work,1,2", "/tmp/tmux-501/work"},
+		{"unset", "", ""},
+		// tmux has used a bare socket path historically; take the whole value
+		// rather than returning nothing and silently retargeting the default.
+		{"no comma", "/tmp/tmux-501/default", "/tmp/tmux-501/default"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TMUX", tt.tmux)
+			if got := socketFromEnv(); got != tt.want {
+				t.Errorf("socketFromEnv() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/pty_test.go
+++ b/internal/tmux/pty_test.go
@@ -2,7 +2,10 @@
 
 package tmux
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestFindCtrlQ(t *testing.T) {
 	tests := []struct {
@@ -31,5 +34,33 @@ func TestFindCtrlQ(t *testing.T) {
 					tt.in, gotIdx, gotLength, tt.wantIdx, tt.wantLength)
 			}
 		})
+	}
+}
+
+// A tmux client refuses to attach to a session on the server it is already
+// inside, so an attach launched from a fleet running under tmux must not carry
+// $TMUX. The failure is silent — the error lands on the PTY, not the TUI — so
+// nothing but this test stands between a regression and a dead Enter key.
+func TestClientEnvDropsTmuxVars(t *testing.T) {
+	t.Setenv("TMUX", "/private/tmp/tmux-501/default,12345,0")
+	t.Setenv("TMUX_PANE", "%7")
+	t.Setenv("FLEET_KEEP_ME", "yes")
+
+	var sawKeeper bool
+	for _, kv := range clientEnv() {
+		switch {
+		case strings.HasPrefix(kv, "TMUX="):
+			t.Errorf("clientEnv() kept %q; tmux refuses a nested attach while it is set", kv)
+		case strings.HasPrefix(kv, "TMUX_PANE="):
+			t.Errorf("clientEnv() kept %q; it names a pane on the outer server", kv)
+		case kv == "FLEET_KEEP_ME=yes":
+			sawKeeper = true
+		}
+	}
+
+	// Guard against the opposite bug: an over-eager filter that drops
+	// everything would pass every assertion above while breaking the attach.
+	if !sawKeeper {
+		t.Error("clientEnv() dropped an unrelated variable; it must only strip the tmux ones")
 	}
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -210,6 +210,9 @@ type (
 )
 
 func spinnerTickCmd() tea.Msg {
+	if FreezeAnim {
+		return nil
+	}
 	time.Sleep(100 * time.Millisecond)
 	return spinnerTickMsg{}
 }
@@ -218,6 +221,9 @@ func spinnerTickCmd() tea.Msg {
 // while the badge is visible (see the whatsNewTickMsg handler), so it burns no
 // CPU when the badge is hidden.
 func whatsNewTickCmd() tea.Cmd {
+	if FreezeAnim {
+		return nil
+	}
 	return tea.Tick(whatsNewTickInterval, func(time.Time) tea.Msg { return whatsNewTickMsg{} })
 }
 
@@ -3168,6 +3174,9 @@ func (h *Home) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 // matching splashTick). Self-rescheduled by Update while `quitting`, until the
 // teardown command emits tea.Quit and the program exits.
 func (h *Home) shutdownTick() tea.Cmd {
+	if FreezeAnim {
+		return nil
+	}
 	return tea.Tick(80*time.Millisecond, func(t time.Time) tea.Msg {
 		return shutdownFrameMsg(t)
 	})
@@ -6219,6 +6228,9 @@ func (h *Home) bootProgress() float64 {
 
 // splashTick schedules the next splash-spinner advance (~80ms cadence).
 func (h *Home) splashTick() tea.Cmd {
+	if FreezeAnim {
+		return nil
+	}
 	return tea.Tick(80*time.Millisecond, func(t time.Time) tea.Msg {
 		return splashFrameMsg(t)
 	})

--- a/internal/ui/drawer.go
+++ b/internal/ui/drawer.go
@@ -109,6 +109,13 @@ func (h *Home) drawerAnimTick() tea.Cmd {
 
 // drawerStep advances the slide one frame; returns true while still animating.
 func (h *Home) drawerStep() bool {
+	// Unlike the other animations, this one cannot simply stop: drawerProgress
+	// feeds the panel's height, so a suppressed tick would strand the drawer
+	// half-open forever. Jump to the end state instead.
+	if FreezeAnim {
+		h.drawerProgress = h.drawerTarget
+		return false
+	}
 	switch {
 	case h.drawerProgress < h.drawerTarget:
 		h.drawerProgress += drawerSlideStep

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"image/color"
+	"os"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -423,6 +424,34 @@ var (
 	ChevronStyle       = "triangle"               // "triangle" (▾▸) or "plusminus" (−+)
 	SidebarDensity     = "normal"                 // "normal" (gap between groups) or "compact"
 )
+
+// FreezeAnim stops every self-rescheduling animation, so two screen captures
+// taken a moment apart are byte-identical. Set FLEET_FREEZE_ANIM=1.
+//
+// This exists for automated screen capture (see demo/drive.sh), where the
+// settle test is "two consecutive frames match" — a test a 60ms shimmer or a
+// 100ms spinner never passes, leaving the harness to fall back on a blind
+// sleep and photograph a half-drawn frame.
+//
+// It lives here rather than on Home because several render entry points are
+// package-level funcs with no Home to read (RenderSidebar, RenderSplash,
+// renderWhatsNewBadge), and a harness driving those directly would see an
+// unset flag. Deliberately not in ApplyDisplayConfig either: that re-runs on
+// every Appearance change and takes a *config.Config, which would imply this
+// is a user setting. It is not — it is a testing seam.
+var FreezeAnim = envIsTruthy("FLEET_FREEZE_ANIM")
+
+// envIsTruthy mirrors the helper in internal/tmux. Copied rather than exported
+// from there: internal/ui already imports internal/tmux, but exporting a
+// general-purpose env helper *from* the tmux package for the UI's benefit
+// inverts what that dependency is supposed to mean.
+func envIsTruthy(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "", "0", "false", "no", "off":
+		return false
+	}
+	return true
+}
 
 // ApplyDisplayConfig syncs all sidebar display flags from config. Must be called
 // on the main goroutine (Bubble Tea Update/View), like ApplyPalette.


### PR DESCRIPTION
## Why

`make build` passing is not the same as a UI change working. Every layout bug so far has cost a full round trip through a human looking at the screen — the worktree dialog that pushed its footer off at 80×24, the base-branch field that jumped four rows mid-word, the priority gauge that rendered `▰▰▰BRZ-1` with no separator.

This adds a harness that lets an agent boot fleet, press keys, and read the screen.

## Two bugs it found

**`Enter` is a dead key inside tmux.** `Session.Attach` built its command without touching `cmd.Env`, so the child inherited `$TMUX` and tmux refused with `sessions should be nested with care`. The error went to the PTY we put into raw mode a few lines later, so it never reached the TUI or the log. Anyone running fleet from inside tmux pressed Enter and nothing happened, with nothing explaining why.

**The Settings dialog has one row of headroom.** It is 23 rows tall; a standard terminal is 24. One more Appearance setting fills it exactly, two clip it — it loses its bottom border at 22 rows and its `esc save` footer at 20.

## What's here

`demo/drive.sh` — `up / seed / key / type / snap / png / size / status / down`. Seeds six sessions across four checkouts covering every status, all three agent glyphs, a slot badge, a dirty marker, worktree and origin grouping, and a group snooze.

`.claude/skills/drive-fleet/SKILL.md` — so a future session reaches for it on ordinary UI work, not only when someone says "drive fleet".

`FLEET_FREEZE_ANIM` — stops the four self-rescheduling animations so two captures are byte-identical. The drawer *snaps* to its target rather than stopping: its progress feeds the panel height, so a suppressed tick would strand it half-open forever.

## Isolation is structural, not a promise

- Its own tmux server via `TMUX_TMPDIR` — the single stop for migration's session renames, the server-scope writes in `EnsureCopyCommand`/`EnsureExtendedKeys`, a fixture name colliding with a real session, and `RefreshSessionCache` enumerating real panes.
- `claude`/`codex`/`opencode` shimmed to `cat` on the sandbox PATH, so a stray `r` launches nothing that costs real quota.
- `HOME` plus explicit `CLAUDE_CONFIG_DIR`/`CODEX_HOME`/`OPENCODE_CONFIG_DIR`, since those are read *before* the HOME fallback and an ambient one would let `InjectClaudeHooks` rewrite the real `settings.json`.

## Notes for review

- **Statuses are pinned by SQLite plus a live silent pane.** Which agent holds which status is forced by `UpdateStatus`, not chosen: only Claude reaches the pane path where a quiet pane leaves the seed alone; Codex and OpenCode force `idle` without a hook file; `suspended` needs no pane at all. Changing the fixture without honouring that will look like a bug.
- **A render-only clock was considered and dropped.** Seeding the config and picking fixture timestamps that sit mid-bucket makes captures stable without touching thirteen render sites.
- **`size` verifies the pane height it hands you.** The tmux status bar silently costs a row, which made an earlier measurement of this same Settings bug off by one. A harness that mislabels its geometry is worse than none.
- PNG output needs `brew install charmbracelet/tap/freeze`; without it `png` exits 2 with the install line rather than half-working.

## Verification

- `go test ./internal/tmux/ ./internal/ui/` passes; `go vet` clean.
- Three captures a second apart are byte-identical, including with a spinner dialog open — the case a naive settle loop never survives.
- The Settings sweep reproduces through the script with verified geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MkrvFayY2ZYCfLNW4vJaq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed attaching to Fleet from within an existing tmux session when pressing Enter.
  - Prevented nested tmux session errors from being hidden, making attachment behave as expected.

- **Improvements**
  - Added an option to freeze interface animations, producing stable, consistent screen captures when enabled.
  - Added a sandboxed harness for reliably launching, inspecting, and testing Fleet’s terminal interface without affecting the active tmux environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->