### PR TITLE
fix(report): label issues filed from `!`, for reporters without write access

### DIFF
--- a/.github/workflows/label-reports.yml
+++ b/.github/workflows/label-reports.yml
@@ -22,7 +22,14 @@ jobs:
           # honoured. Without the allowlist anyone could hand themselves
           # `autorelease` — the label merging a release PR keys on — by pasting
           # a comment into an issue.
-          LABEL=$(printf '%s' "$BODY" | sed -n 's/.*<!-- fleet-report-label: \([a-z-]*\) -->.*/\1/p' | head -1)
+          #
+          # tail, not head: fleet appends its marker after the body is fully
+          # built, so it is always the last one. Everything before it is written
+          # by the reporter — a feature request's body is their description
+          # verbatim, and a bug or wrong-status body carries the debug log,
+          # error history and pane excerpt. Any of those quoting the marker
+          # would otherwise outrank the kind they picked in the dialog.
+          LABEL=$(printf '%s' "$BODY" | sed -n 's/.*<!-- fleet-report-label: \([a-z-]*\) -->.*/\1/p' | tail -1)
           case "$LABEL" in
             bug|enhancement) ;;
             *) echo "::notice::ignoring unknown report label '$LABEL'"; exit 0 ;;

--- a/.github/workflows/label-reports.yml
+++ b/.github/workflows/label-reports.yml
@@ -1,0 +1,32 @@
+name: Label Reports
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.body, '<!-- fleet-report-label:')
+    steps:
+      - name: Apply the label the report asked for
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: ${{ github.event.issue.body }}
+        run: |
+          # An issue body is written by whoever opened the issue, so the marker
+          # is a request, not an instruction: only these two labels are ever
+          # honoured. Without the allowlist anyone could hand themselves
+          # `autorelease` — the label merging a release PR keys on — by pasting
+          # a comment into an issue.
+          LABEL=$(printf '%s' "$BODY" | sed -n 's/.*<!-- fleet-report-label: \([a-z-]*\) -->.*/\1/p' | head -1)
+          case "$LABEL" in
+            bug|enhancement) ;;
+            *) echo "::notice::ignoring unknown report label '$LABEL'"; exit 0 ;;
+          esac
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "$LABEL"

--- a/internal/ui/bugreport.go
+++ b/internal/ui/bugreport.go
@@ -343,12 +343,27 @@ func ghAvailable() bool {
 	return err == nil
 }
 
+// labelMarkerFmt embeds the requested label in the issue body, where
+// .github/workflows/label-reports.yml reads it back and applies the label with
+// the repo's own token.
+//
+// The --label flag below is not enough on its own: GitHub accepts labels on
+// issue creation only from users with write access, and silently drops them
+// for everyone else — no error, gh still exits 0, so nothing on this side can
+// tell. fleet is open source and most reporters are outside contributors, so
+// in practice almost every filed issue landed unlabelled. The flag stays for
+// maintainers, whose issues are then labelled at creation rather than a run
+// later; for everyone else the marker is the only path that works.
+const labelMarkerFmt = "\n\n<!-- fleet-report-label: %s -->\n"
+
 // createGitHubIssue files an issue and opens it in the browser. Shared by all
 // three report kinds; only title, body, and label differ between them.
 func (d *BugReportDialog) createGitHubIssue(title, body, label string) tea.Cmd {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return func() tea.Msg { return bugReportOpenErrMsg{err: fmt.Errorf("gh CLI not found")} }
 	}
+
+	body += fmt.Sprintf(labelMarkerFmt, label)
 
 	return func() tea.Msg {
 		debuglog.Logger.Info("bug report: creating GitHub issue via API", "label", label)

--- a/internal/ui/bugreport.go
+++ b/internal/ui/bugreport.go
@@ -300,7 +300,7 @@ func (d *BugReportDialog) submitStatusReport(desc string, expected session.Statu
 	body := buildStatusReportBody(desc, expected, &d.status, d.report)
 	title := fmt.Sprintf("Wrong status: showed %s, expected %s — %s",
 		d.status.shownStatus, expected, ansi.Truncate(sanitizeForIssue(desc), 60, "…"))
-	return d.createGitHubIssue(title, body, "bug")
+	return d.createGitHubIssue(title, body, labelBug)
 }
 
 func (d *BugReportDialog) openGitHubIssue(description string) tea.Cmd {
@@ -310,12 +310,12 @@ func (d *BugReportDialog) openGitHubIssue(description string) tea.Cmd {
 	title := ansi.Truncate(sanitizeForIssue(description), 60, "…")
 
 	var body string
-	label := "bug"
+	label := labelBug
 	if d.kind == kindFeature {
 		// A feature request carries prose and versions only. The error history,
 		// action log, and debug log are reproduction context for a defect; on an
 		// idea they are noise the maintainer has to scroll past.
-		label = "enhancement"
+		label = labelEnhancement
 		body = "## Feature Request\n\n### Problem\n" + sanitizeForIssue(description) + "\n\n" +
 			fmt.Sprintf("### Environment\n- **Version**: %s\n- **OS**: %s (%s)\n",
 				d.report.Version, d.report.OSSummary(), d.report.Arch)
@@ -355,6 +355,18 @@ func ghAvailable() bool {
 // maintainers, whose issues are then labelled at creation rather than a run
 // later; for everyone else the marker is the only path that works.
 const labelMarkerFmt = "\n\n<!-- fleet-report-label: %s -->\n"
+
+// The labels a report can ask for. The workflow allowlists the same set, so a
+// label added here and not there lands unlabelled — the state this whole
+// mechanism exists to fix. reportLabels is what lets the guard test compare the
+// two sets instead of a copy of one of them; a call site spelling its label
+// inline is invisible to it.
+const (
+	labelBug         = "bug"
+	labelEnhancement = "enhancement"
+)
+
+var reportLabels = []string{labelBug, labelEnhancement}
 
 // createGitHubIssue files an issue and opens it in the browser. Shared by all
 // three report kinds; only title, body, and label differ between them.

--- a/internal/ui/bugreport_test.go
+++ b/internal/ui/bugreport_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -257,9 +259,20 @@ func TestLabelMarkerMatchesTheWorkflow(t *testing.T) {
 	}
 	re := regexp.MustCompile(strings.NewReplacer(`\(`, `(`, `\)`, `)`).Replace(bre))
 
-	// Both labels the workflow allowlists. A label fleet emits that the
-	// workflow refuses is dropped just as silently as GitHub dropped it.
-	for _, label := range []string{"bug", "enhancement"} {
+	// fleet appends its marker last, so the workflow has to read the last one.
+	// head takes the first, which is inside reporter-written content — the
+	// debug log, error history or pane excerpt of a bug report, or the whole
+	// body of a feature request. Both labels are allowlisted, so the failure is
+	// silent: the issue is filed under the opposite kind to the one picked.
+	if !strings.Contains(string(wf), "-->.*/\\1/p' | tail -1)") {
+		t.Error("workflow no longer takes the LAST marker — head reads reporter-written content")
+	}
+
+	// Every label fleet actually emits round-trips through the workflow's
+	// pattern. Iterating reportLabels rather than a literal is the point: a
+	// fourth report kind spelling a new label would otherwise be refused by the
+	// workflow, land unlabelled, and leave this test green.
+	for _, label := range reportLabels {
 		marker := fmt.Sprintf(labelMarkerFmt, label)
 		m := re.FindStringSubmatch(marker)
 		if m == nil {
@@ -269,8 +282,24 @@ func TestLabelMarkerMatchesTheWorkflow(t *testing.T) {
 		if m[1] != label {
 			t.Errorf("workflow would extract %q from %q, want %q", m[1], marker, label)
 		}
-		if !strings.Contains(string(wf), label+"|") && !strings.Contains(string(wf), "|"+label) {
-			t.Errorf("workflow allowlist does not accept %q", label)
-		}
+	}
+
+	// The allowlist has to be read out of the `case` arm, not searched for in
+	// the file: a plain Contains over the whole workflow is satisfied by the
+	// explanatory comment above the arm and asserts nothing about the arm
+	// itself. Set equality, so it fails in both directions — a label fleet
+	// emits that the workflow refuses, and a label the workflow honours that
+	// fleet never emits, which is a silent widening of what an issue body can
+	// ask for.
+	arm := regexp.MustCompile(`(?m)^\s*([a-z|-]+)\) ;;$`).FindStringSubmatch(string(wf))
+	if arm == nil {
+		t.Fatalf("no `<labels>) ;;` allowlist arm in the workflow — did the case statement move?")
+	}
+	allowed := strings.Split(arm[1], "|")
+	sort.Strings(allowed)
+	emitted := append([]string(nil), reportLabels...)
+	sort.Strings(emitted)
+	if !slices.Equal(allowed, emitted) {
+		t.Errorf("workflow allowlist %v does not match the labels fleet emits %v", allowed, emitted)
 	}
 }

--- a/internal/ui/bugreport_test.go
+++ b/internal/ui/bugreport_test.go
@@ -1,7 +1,9 @@
 package ui
 
 import (
+	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -229,6 +231,46 @@ func TestAccountEmailsNeverReachAnIssue(t *testing.T) {
 	for _, domain := range []string{"company.com", "acme.co.uk"} {
 		if strings.Contains(body, domain) {
 			t.Errorf("published the domain %s:\n%s", domain, body)
+		}
+	}
+}
+
+// TestLabelMarkerMatchesTheWorkflow pins the one coupling this mechanism has:
+// the marker fleet writes into the issue body and the pattern
+// .github/workflows/label-reports.yml extracts it with live in different files
+// and different languages, so nothing but this test fails when one moves. A
+// marker the workflow cannot read is invisible — the issue is still filed, and
+// still lands unlabelled, which is the state this exists to fix.
+func TestLabelMarkerMatchesTheWorkflow(t *testing.T) {
+	wf, err := os.ReadFile("../../.github/workflows/label-reports.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	// The workflow extracts with sed, whose BRE spells the capture group
+	// `\(...\)`; dropping those backslashes is the whole translation to a Go
+	// regexp. Asserting the BRE is present first is what makes this test fail
+	// when the workflow's pattern is edited rather than silently checking a
+	// string nothing uses.
+	bre := `<!-- fleet-report-label: \([a-z-]*\) -->`
+	if !strings.Contains(string(wf), bre) {
+		t.Fatalf("workflow no longer extracts with %q — update the marker or this test", bre)
+	}
+	re := regexp.MustCompile(strings.NewReplacer(`\(`, `(`, `\)`, `)`).Replace(bre))
+
+	// Both labels the workflow allowlists. A label fleet emits that the
+	// workflow refuses is dropped just as silently as GitHub dropped it.
+	for _, label := range []string{"bug", "enhancement"} {
+		marker := fmt.Sprintf(labelMarkerFmt, label)
+		m := re.FindStringSubmatch(marker)
+		if m == nil {
+			t.Errorf("marker %q is not matched by the workflow pattern", marker)
+			continue
+		}
+		if m[1] != label {
+			t.Errorf("workflow would extract %q from %q, want %q", m[1], marker, label)
+		}
+		if !strings.Contains(string(wf), label+"|") && !strings.Contains(string(wf), "|"+label) {
+			t.Errorf("workflow allowlist does not accept %q", label)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

The report dialog (`!`) has always passed `--label bug` / `--label enhancement` to `gh issue create`. It has almost never worked.

GitHub accepts labels on issue creation **only from users with write access**, and silently drops them for everyone else — no error, `gh` still exits 0, so nothing on our side could tell. fleet is open source and most reporters are outside contributors, so in practice every report they filed landed unlabelled:

| author | repo permission | labels applied |
|---|---|---|
| `hayke102`, `yairsimantov20` | write / admin | yes |
| `1jonahg1`, `tonytimo`, `eylonronen`, … | `pull` or none | **none** |

42 issues were unlabelled. Every one was filed by someone without triage permission.

## Why not client-side

`gh issue edit --add-label` after creation is refused for exactly the same reason. The label has to be applied by something that holds write access — i.e. the repo itself.

## Fix

`createGitHubIssue` appends the requested label to the issue body as an HTML comment:

```
<!-- fleet-report-label: bug -->
```

`.github/workflows/label-reports.yml` reads it back on `issues: opened` and applies it with `GITHUB_TOKEN`.

- The marker goes in at the **one place all three report kinds pass through**, so it carries whatever label that kind asked for — bug, wrong-status and feature all covered by one line.
- `--label` **stays**. A maintainer's issue is still labelled at creation rather than a workflow run later.
- The workflow **allowlists `bug|enhancement`**. An issue body is written by whoever opened the issue, so the marker is a request, not an instruction — without the allowlist anyone could hand themselves `autorelease`, the label a release PR keys on, by pasting a comment into an issue.

## Test

`TestLabelMarkerMatchesTheWorkflow` pins the one coupling this has: the marker is built in Go, extracted by sed in YAML, and nothing else fails when one of them moves. It asserts the workflow still contains the BRE it extracts with, translates it to a Go regexp, and checks every label fleet emits both matches it and survives the allowlist. A marker the workflow can't read is invisible — the issue is still filed, and still lands unlabelled, which is the state this exists to fix.

## Also done (outside this diff)

- **39 existing issues backfilled.** Four were filed on the wrong form (body says `## Bug Report`, content is a feature request) and got `enhancement`: #159, #53, #43, #22. Three test issues left unlabelled: #76, #6, #5.
- **6 issues closed with explanations** — #274, #157, #160, #28 shipped long ago; #219 (expected == shown; the real complaint is the 60s `gh` poll) and #262 (weekly ranking is the deliberate default since #251) answered rather than fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ2cqYhq9DiCoDoTdX9Rf5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bug reports submitted through the app now include classification information that automatically applies either a **bug** or **enhancement** label to the resulting issue.
  - Only supported classifications are applied; unrecognized classifications are safely ignored.
  - When multiple classification markers are present, the latest one determines the issue label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->