### PR TITLE
feat(ui): frost mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,8 @@ internal/ui/command_palette.go   # Command palette dialog (Ctrl+K) — fuzzy sea
 internal/ui/drawer.go            # Terminal drawer (` key): render, slide animation, focus/key handling, shell lifecycle + live-stream wiring (syncShellStream → OutputReader + vterm)
 internal/tmux/control_output.go  # Control-mode %output reader (live shell streaming) + octal decoder
 internal/vterm/vterm.go          # Insulated charmbracelet/x/vt wrapper (drawer live rendering; strips ESC k titles)
+internal/frost/                  # Frost mode: freeze a rendered frame into a styled cell grid (x/vt replay) and run cell effects over it
+internal/ui/frost.go             # Frost mode trigger + tick loop
 internal/chrome/protocol.go      # Command/Response types, action constants, socket path
 internal/chrome/native_host.go   # Native messaging host with Unix socket bridge
 internal/chrome/client.go        # TUI-side client (connects to socket, sends commands)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.0
 	charm.land/bubbletea/v2 v2.0.7
 	charm.land/lipgloss/v2 v2.0.4
+	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/vt v0.0.0-20260622092256-25656177ba8e
 	github.com/creack/pty v1.1.24
@@ -21,7 +22,6 @@ require (
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 // indirect
 	github.com/charmbracelet/x/exp/ordered v0.1.0 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect

--- a/internal/analytics/events.go
+++ b/internal/analytics/events.go
@@ -48,10 +48,10 @@ const (
 	// Navigation / filtering.
 	EventFilterUsed = "filter_used"
 	EventSpaceJump  = "space_jump"
+	EventHeaderJump = "header_jump"
 
 	// Frost mode was started from the sidebar.
-	EventFrostMode  = "frost_mode"
-	EventHeaderJump = "header_jump"
+	EventFrostMode = "frost_mode"
 
 	// RTS slot bindings.
 	EventSlotBindingSet = "slot_binding_set"

--- a/internal/analytics/events.go
+++ b/internal/analytics/events.go
@@ -48,6 +48,9 @@ const (
 	// Navigation / filtering.
 	EventFilterUsed = "filter_used"
 	EventSpaceJump  = "space_jump"
+
+	// Frost mode was started from the sidebar.
+	EventFrostMode  = "frost_mode"
 	EventHeaderJump = "header_jump"
 
 	// RTS slot bindings.

--- a/internal/frost/assets.go
+++ b/internal/frost/assets.go
@@ -169,7 +169,7 @@ var (
 
 // pack is the glyph data: a gzip-compressed JSON array of strings, in the
 // order init reads them.
-const pack = "H4sIAAAAAAACE7VRvW4TQRB+lcFNmsgPQGNFQIFAVFAhivXd+G51zu4xu47lzoqQlYIiTuzlLzgdBRIJPW+zT8Lsz1m2iEBCcPdpbr6Zb2dn5l72AMC7c+8+eXfWIfgc7x1CL2Q/e3e1k91iniXeXd+V3sWHLPzo3eb3Ngs3f9QGIffQ4X3ibyIJNvFNB5f42w6Zf02fd7FLF2c92xZbencRbXIu9+lyK1p2ZP3Nr+b/HuubWH11CunxVz/gwdOjFw8fwfOjZ08iT4nV6b7yzmdf5RfnfnEBUJI8wRRY+sUlgJDHv6pNKwpWjSSxRVMADEXR/NXNeII0s7VUFUgDAqygCu2Oav39/2zzNlQfoz0wQDgShdUE3Ifph7jWbXJsLSxohTAVBqaaGm40Jh6DqfVkXELoNk5vdRTkYzwMYyQVxoCff4l1p5ENZylakLSyEGOopU2BsZiUyEtQzeBefgeDkEFhLBJgVYHBgvjSWpYlKjATakmadAhygUYrcSzDuVYYw22V9wNRus0XayIsbJ8nRsKDsPhctcEZu68nqPgPaxUEYGSJQ0F9QFnVFlpCY9AcgtLAC+S2eFevfgIP8BCKRQQAAA=="
+const pack = "H4sIAAAAAAACE7VRvW4TQRB+lQ83aaw8AI0VAQUCUUEVpVjfje9W5+weu3ux3FkRslJQxIl9/AWno0Aioedt9knYv7NsJQoSgr3R3Hwz387fHvYA2Pbctl9se9aJt52/10fPR7/a9morupFZotj2+r7wtnxKxM+2XT+sE3H9R64nuh46+RjxuwC8jnjdSRvx+04S/h5/H0KXbZj1bJNsYduLoKNxuQsXG9KiA6sfdjn797K6CdmXp4jHXv3Ck5cHb54+w+uDVy8CjoHl6S7z3rPLsvNzO78AcsVPKDoWdn4JMH58l61rljnWiCunSWfAkGXVX1WmE1JTU3JRgGswGKYKMlus1c//s81bn31MZk9D0YhlRiq4PvS+90tZR8OUzEAKwoRpTKSqXKMh8By6lM04h+82TG9kIKRrbhgnIy4oOOzsW8g7CWg4jd5MccMzNkbJTXSMWZOTW4KoBo/SNxj4CDFtSIGKApoy5YqWPM9JQDeqVlzHS0gJKinYMQ8VVR98hKlsUAk5cSMSaqa1azV/7AlC1pR6JkV7/g1SgYqmznzbkHCPLUW4qnlOQ6b2QbwoDWpFWpPuQ0i4XboO3dqOfgOrFdDxUAQAAA=="
 
 func init() {
 	raw, err := base64.StdEncoding.DecodeString(pack)
@@ -213,13 +213,14 @@ func init() {
 }
 
 // GateText is the copy for the prompt that fronts frost mode elsewhere in the
-// app: how the entry is found, what it asks, and what it says either way.
+// app: how the entry is found, the hint it always shows, what it asks for,
+// and what it says to a wrong answer. The right answer starts a run.
 type GateText struct {
 	Label    string // the entry's name
 	Keywords string // extra search terms that surface it
 	Prompt   string // what it asks for
 	Wrong    string // said to a wrong answer
-	Hint     string // said to the right one
+	Hint     string // the other way in, always shown
 }
 
 var gate GateText

--- a/internal/frost/assets.go
+++ b/internal/frost/assets.go
@@ -47,6 +47,9 @@ const (
 	quipBuried
 	quipSelfHit
 	quipBye
+	quipCrit
+
+	quipCount
 )
 
 // armCell is one glyph of an arm sprite relative to its pivot: dx grows away
@@ -61,11 +64,11 @@ type arm struct {
 	tip   [2]int // where a probe leaves
 }
 
-// burstCell is one glyph of an impact frame relative to the impact cell.
+// burstCell is one glyph of an impact frame relative to the impact cell; the
+// frame's colour comes from the burst palette it is drawn with.
 type burstCell struct {
 	dx, dy int
 	g      string
-	style  uv.Style
 }
 
 var armGeom = [4]struct {
@@ -137,6 +140,8 @@ var (
 	trackStyle  = rgb(92, 99, 112)
 	armStyle    = rgb(184, 190, 200)
 	probeStyle  = rgb(249, 226, 175)
+	critStyle   = rgb(140, 195, 255) // a crit: the ball's rim, burst body
+	critGlow    = rgb(232, 244, 255) // a crit: the ball's core, trail, burst flash
 	flashStyle  = rgb(249, 226, 175)
 	fireStyle   = rgb(250, 179, 135)
 	emberStyle  = rgb(120, 124, 140)
@@ -154,11 +159,15 @@ var (
 	bubbleStyle    = uv.Style{Fg: color.RGBA{R: 230, G: 232, B: 240, A: 255}, Bg: cardBg}
 )
 
-var burstStyles = [4]uv.Style{flashStyle, flashStyle, fireStyle, emberStyle}
+// Burst palettes, one style per animation frame.
+var (
+	burstStyles     = [4]uv.Style{flashStyle, flashStyle, fireStyle, emberStyle}
+	critBurstStyles = [4]uv.Style{critGlow, critGlow, critStyle, emberStyle}
+)
 
 // pack is the glyph data: a gzip-compressed JSON array of strings, in the
 // order init reads them.
-const pack = "H4sIAAAAAAACE7WQvU7DMBDHX+WUhQXxDhUwIBATTIjBTZ02aqkr2zTqVlWo6sDQ9MN8lbAxIBXYeZt7EuxzErWiAgmB9dfl/ne/XM45CwAAzRjNA5pRIZfberANges+olmsdEv1cwTN06b2qu5y8B5N9n3MwexH1oF2h0K33l+RcdH7rJDx/rpQ7l/844a2NHTXUTksRTOh6JPpuk1LKC3MfImz/t9r/krTZwPwBxcfsHtUOd3bh5PK8SF535gN1smNZ53C4RiHE4CajLvcF1IcTgFYfPGVVh0WWiqKpY1chQBVFjZ/9WXe5bKnG3G7DrECBprJOtcr1Pz9f/7mm5ve4npLgeQRC7WQYPdQO64uRMcnusE0iDaHhClIhGzaRalxAKohLls1cNvS7bUgIH/NXsYqitucCth/prkJuWrPVs8/ATkhujx3AwAA"
+const pack = "H4sIAAAAAAACE7WQuU7DQBCGX2XkhgblHSKgQCAqqBDFxtnEqxhvtLvESmdFKEpBEedYrhA6CiSOnreZJ2EPO3JEBBKC1a/x/DOfx7M+DQAA9Rj1PepRKZuberANge0+oF5UuitlBYL6cVO7qtsCvEO9/D4W4PJH1oJmh1I33l86Y6P3y1La+6tShX/2j2u3pXZ3Ha2G5agnLvpkum7zFZSXZv6Cs+zvNX9102cD8AcXH7BzWD/Z3YPj+tGB874xG6yTG886hcMxDicATcF61BdyHE4BCDv/SssuCQ3VYsJEKkOABgk7v/oy7VHRVxFL2sAkEFBEtKmqUPP3//mbb3Z6TNWWBEFbJFRcgNlD1myd865PVEQU8IRCSiSkXHTMoq6xDzLiF3ET7Lbu9oo7oHjNXMaoxRLqCpg9ubmpc42+r4aCKRaSGCKmasHZJ+4QVSSIAwAA"
 
 func init() {
 	raw, err := base64.StdEncoding.DecodeString(pack)
@@ -191,7 +200,7 @@ func init() {
 	for i := range bursts {
 		rs := []rune(s[at+i])
 		for j, p := range burstGeom[i] {
-			bursts[i] = append(bursts[i], burstCell{p[0], p[1], string(rs[j]), burstStyles[i]})
+			bursts[i] = append(bursts[i], burstCell{p[0], p[1], string(rs[j])})
 		}
 	}
 	at += len(bursts)

--- a/internal/frost/assets.go
+++ b/internal/frost/assets.go
@@ -1,0 +1,200 @@
+// Package frost freezes a rendered frame into a grid of styled cells and runs
+// cell-level effects over it: a small side-view sim with one driveable actor,
+// ballistic probes, impact damage and debris that settles under gravity. It is
+// a pure simulation — no Bubble Tea, no tmux — so the UI only freezes a frame,
+// forwards keys and ticks, and asks for the next frame to draw.
+package frost
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"image/color"
+	"io"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// Sprite geometry. The glyph strings are unpacked from pack at init; the
+// tables here only carry positions.
+const (
+	SpriteW = 13
+	SpriteH = 4
+
+	pivotRow = 2 // the arm pivots off this sprite row
+)
+
+var (
+	spriteRows [SpriteH]string // the actor, facing right
+	altBase    string          // bottom row shifted one cell; alternated while moving
+	arms       [4]arm          // one sprite per elevation bucket
+	bursts     [4][]burstCell  // impact animation frames
+	card       []string        // the card stamped into the frozen frame
+	quips      []string        // what the actor says, by event (see quip*)
+)
+
+// cardRows is how many pack strings the card takes; the rest are quips.
+const cardRows = 8
+
+// Quip indexes into quips.
+const (
+	quipStart = iota
+	quipFirstHit
+	quipSessionHit
+	quipRazed100
+	quipRazed300
+	quipBuried
+	quipSelfHit
+	quipBye
+)
+
+// armCell is one glyph of an arm sprite relative to its pivot: dx grows away
+// from the base in the facing direction, dy < 0 is up.
+type armCell struct {
+	dx, dy int
+	g      rune
+}
+
+type arm struct {
+	cells []armCell
+	tip   [2]int // where a probe leaves
+}
+
+// burstCell is one glyph of an impact frame relative to the impact cell.
+type burstCell struct {
+	dx, dy int
+	g      string
+	style  uv.Style
+}
+
+var armGeom = [4]struct {
+	at  [][2]int
+	tip [2]int
+}{
+	{[][2]int{{0, 0}, {1, 0}, {2, 0}, {3, 0}}, [2]int{4, 0}},
+	{[][2]int{{0, 0}, {1, 0}, {2, -1}, {3, -1}}, [2]int{4, -2}},
+	{[][2]int{{0, 0}, {1, -1}, {2, -2}, {3, -3}}, [2]int{3, -4}},
+	{[][2]int{{0, 0}, {0, -1}, {0, -2}, {0, -3}}, [2]int{0, -4}},
+}
+
+var burstGeom = [4][][2]int{
+	{{0, 0}},
+	{{-1, 0}, {0, 0}, {1, 0}, {-1, 1}, {0, 1}, {1, 1}},
+	{{-1, -1}, {0, -1}, {1, -1}, {-2, 0}, {-1, 0}, {0, 0}, {1, 0}, {2, 0}, {-1, 1}, {0, 1}, {1, 1}},
+	{{-2, -1}, {2, -1}, {0, 1}},
+}
+
+// armBucket picks the arm sprite for an elevation in degrees (0 = level).
+func armBucket(angle int) int {
+	switch {
+	case angle < 15:
+		return 0
+	case angle < 45:
+		return 1
+	case angle < 75:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// mirror maps each quadrant/box glyph to its horizontal reflection. Anything
+// absent is symmetric.
+var mirror = map[rune]rune{
+	'▐': '▌', '▌': '▐',
+	'▛': '▜', '▜': '▛',
+	'▝': '▘', '▘': '▝',
+	'▗': '▖', '▖': '▗',
+	'▟': '▙', '▙': '▟',
+	'▚': '▞', '▞': '▚',
+	'╱': '╲', '╲': '╱',
+	'▸': '◂', '◂': '▸',
+}
+
+func mirrorRune(r rune) rune {
+	if m, ok := mirror[r]; ok {
+		return m
+	}
+	return r
+}
+
+// mirrorRow reflects a sprite row: reverse the cells, then reflect each glyph.
+func mirrorRow(s string) string {
+	rs := []rune(s)
+	out := make([]rune, len(rs))
+	for i, r := range rs {
+		out[len(rs)-1-i] = mirrorRune(r)
+	}
+	return string(out)
+}
+
+func rgb(r, g, b uint8) uv.Style { return uv.Style{Fg: color.RGBA{R: r, G: g, B: b, A: 255}} }
+
+var (
+	actorStyle  = rgb(217, 119, 87)
+	baseStyle   = rgb(138, 143, 152)
+	trackStyle  = rgb(92, 99, 112)
+	armStyle    = rgb(184, 190, 200)
+	probeStyle  = rgb(249, 226, 175)
+	flashStyle  = rgb(249, 226, 175)
+	fireStyle   = rgb(250, 179, 135)
+	emberStyle  = rgb(120, 124, 140)
+	traceStyle  = rgb(168, 152, 112)
+	statusStyle = rgb(120, 124, 140)
+
+	// The card is filled so it reads over whatever the frozen frame has
+	// behind it; the fill also makes its blank cells solid. Neutral gray on
+	// purpose: a terminal without truecolor snaps a dark blue-gray to the
+	// nearest of 256 colors, which is navy; a gray stays on the gray ramp.
+	cardBg         = color.RGBA{R: 48, G: 48, B: 48, A: 255}
+	cardStyle      = uv.Style{Fg: color.RGBA{R: 200, G: 204, B: 216, A: 255}, Bg: cardBg}
+	cardTitleStyle = uv.Style{Fg: color.RGBA{R: 217, G: 119, B: 87, A: 255}, Bg: cardBg}
+	cardEdgeStyle  = uv.Style{Fg: color.RGBA{R: 110, G: 114, B: 130, A: 255}, Bg: cardBg}
+	bubbleStyle    = uv.Style{Fg: color.RGBA{R: 230, G: 232, B: 240, A: 255}, Bg: cardBg}
+)
+
+var burstStyles = [4]uv.Style{flashStyle, flashStyle, fireStyle, emberStyle}
+
+// pack is the glyph data: a gzip-compressed JSON array of strings, in the
+// order init reads them.
+const pack = "H4sIAAAAAAACE7WQvU7DMBDHX+WUhQXxDhUwIBATTIjBTZ02aqkr2zTqVlWo6sDQ9MN8lbAxIBXYeZt7EuxzErWiAgmB9dfl/ne/XM45CwAAzRjNA5pRIZfberANges+olmsdEv1cwTN06b2qu5y8B5N9n3MwexH1oF2h0K33l+RcdH7rJDx/rpQ7l/844a2NHTXUTksRTOh6JPpuk1LKC3MfImz/t9r/krTZwPwBxcfsHtUOd3bh5PK8SF535gN1smNZ53C4RiHE4CajLvcF1IcTgFYfPGVVh0WWiqKpY1chQBVFjZ/9WXe5bKnG3G7DrECBprJOtcr1Pz9f/7mm5ve4npLgeQRC7WQYPdQO64uRMcnusE0iDaHhClIhGzaRalxAKohLls1cNvS7bUgIH/NXsYqitucCth/prkJuWrPVs8/ATkhujx3AwAA"
+
+func init() {
+	raw, err := base64.StdEncoding.DecodeString(pack)
+	if err != nil {
+		panic(err)
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		panic(err)
+	}
+	data, err := io.ReadAll(zr)
+	if err != nil {
+		panic(err)
+	}
+	var s []string
+	if err := json.Unmarshal(data, &s); err != nil {
+		panic(err)
+	}
+	copy(spriteRows[:], s[0:SpriteH])
+	altBase = s[SpriteH]
+	at := SpriteH + 1
+	for i := range arms {
+		rs := []rune(s[at+i])
+		for j, p := range armGeom[i].at {
+			arms[i].cells = append(arms[i].cells, armCell{p[0], p[1], rs[j]})
+		}
+		arms[i].tip = armGeom[i].tip
+	}
+	at += len(arms)
+	for i := range bursts {
+		rs := []rune(s[at+i])
+		for j, p := range burstGeom[i] {
+			bursts[i] = append(bursts[i], burstCell{p[0], p[1], string(rs[j]), burstStyles[i]})
+		}
+	}
+	at += len(bursts)
+	card = s[at : at+cardRows]
+	quips = s[at+cardRows:]
+}

--- a/internal/frost/assets.go
+++ b/internal/frost/assets.go
@@ -10,8 +10,10 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"encoding/json"
+	"hash/fnv"
 	"image/color"
 	"io"
+	"strings"
 
 	uv "github.com/charmbracelet/ultraviolet"
 )
@@ -167,7 +169,7 @@ var (
 
 // pack is the glyph data: a gzip-compressed JSON array of strings, in the
 // order init reads them.
-const pack = "H4sIAAAAAAACE7WQuU7DQBCGX2XkhgblHSKgQCAqqBDFxtnEqxhvtLvESmdFKEpBEedYrhA6CiSOnreZJ2EPO3JEBBKC1a/x/DOfx7M+DQAA9Rj1PepRKZuberANge0+oF5UuitlBYL6cVO7qtsCvEO9/D4W4PJH1oJmh1I33l86Y6P3y1La+6tShX/2j2u3pXZ3Ha2G5agnLvpkum7zFZSXZv6Cs+zvNX9102cD8AcXH7BzWD/Z3YPj+tGB874xG6yTG886hcMxDicATcF61BdyHE4BCDv/SssuCQ3VYsJEKkOABgk7v/oy7VHRVxFL2sAkEFBEtKmqUPP3//mbb3Z6TNWWBEFbJFRcgNlD1myd865PVEQU8IRCSiSkXHTMoq6xDzLiF3ET7Lbu9oo7oHjNXMaoxRLqCpg9ubmpc42+r4aCKRaSGCKmasHZJ+4QVSSIAwAA"
+const pack = "H4sIAAAAAAACE7VRvW4TQRB+lcFNmsgPQGNFQIFAVFAhivXd+G51zu4xu47lzoqQlYIiTuzlLzgdBRIJPW+zT8Lsz1m2iEBCcPdpbr6Zb2dn5l72AMC7c+8+eXfWIfgc7x1CL2Q/e3e1k91iniXeXd+V3sWHLPzo3eb3Ngs3f9QGIffQ4X3ibyIJNvFNB5f42w6Zf02fd7FLF2c92xZbencRbXIu9+lyK1p2ZP3Nr+b/HuubWH11CunxVz/gwdOjFw8fwfOjZ08iT4nV6b7yzmdf5RfnfnEBUJI8wRRY+sUlgJDHv6pNKwpWjSSxRVMADEXR/NXNeII0s7VUFUgDAqygCu2Oav39/2zzNlQfoz0wQDgShdUE3Ifph7jWbXJsLSxohTAVBqaaGm40Jh6DqfVkXELoNk5vdRTkYzwMYyQVxoCff4l1p5ENZylakLSyEGOopU2BsZiUyEtQzeBefgeDkEFhLBJgVYHBgvjSWpYlKjATakmadAhygUYrcSzDuVYYw22V9wNRus0XayIsbJ8nRsKDsPhctcEZu68nqPgPaxUEYGSJQ0F9QFnVFlpCY9AcgtLAC+S2eFevfgIP8BCKRQQAAA=="
 
 func init() {
 	raw, err := base64.StdEncoding.DecodeString(pack)
@@ -205,5 +207,33 @@ func init() {
 	}
 	at += len(bursts)
 	card = s[at : at+cardRows]
-	quips = s[at+cardRows:]
+	at += cardRows
+	quips = s[at : at+quipCount]
+	gate = GateText{Label: s[at+quipCount], Keywords: s[at+quipCount+1], Prompt: s[at+quipCount+2], Wrong: s[at+quipCount+3], Hint: s[at+quipCount+4]}
+}
+
+// GateText is the copy for the prompt that fronts frost mode elsewhere in the
+// app: how the entry is found, what it asks, and what it says either way.
+type GateText struct {
+	Label    string // the entry's name
+	Keywords string // extra search terms that surface it
+	Prompt   string // what it asks for
+	Wrong    string // said to a wrong answer
+	Hint     string // said to the right one
+}
+
+var gate GateText
+
+// Gate returns the prompt's copy.
+func Gate() GateText { return gate }
+
+// gateKey is the hash of the answer the prompt accepts.
+var gateKey uint64 = 0x59f74680b7643863
+
+// Unlock reports whether answer is the one the prompt accepts. Case and
+// surrounding space do not count.
+func Unlock(answer string) bool {
+	f := fnv.New64a()
+	_, _ = f.Write([]byte(strings.ToLower(strings.TrimSpace(answer))))
+	return f.Sum64() == gateKey
 }

--- a/internal/frost/scene.go
+++ b/internal/frost/scene.go
@@ -13,23 +13,28 @@ import (
 // rate below is per tick. Rows are twice as tall as columns are wide, so a
 // vertical velocity is halved to look like the same speed on screen.
 const (
-	probeGravity  = 0.045 // rows per tick²
-	debrisGravity = 0.08
-	driveSpeed    = 0.9 // columns per tick while a drive key is held
-	driveTicks    = 3   // ticks of motion one key event adds (key repeat keeps it topped up)
-	driveMax      = 12  // cap on banked motion, so a burst of presses is not a long slide
-	angleStep     = 5   // degrees per ↑/↓
-	emitCooldown  = 4
-	flashTicks    = 2
-	shakeTicks    = 2
-	burstFrame    = 2 // ticks per impact frame
-	maxDebris     = 600
-	probeSubsteps = 6
-	traceDots     = 40
-	recoilTicks   = 2
-	bubbleTicks   = 40 // how long a line of speech stays up
-	collapseRows  = 3  // rows released per tick when the frame comes down
-	collapseCap   = 80 // ticks before a collapse ends whether or not debris has settled
+	probeGravity   = 0.045 // rows per tick²
+	debrisGravity  = 0.08
+	driveSpeed     = 0.9 // columns per tick while a drive key is held
+	driveTicks     = 3   // ticks of motion one key event adds (key repeat keeps it topped up)
+	driveMax       = 12  // cap on banked motion, so a burst of presses is not a long slide
+	angleStep      = 5   // degrees per ↑/↓
+	emitCooldown   = 4
+	critOdds       = 8  // one emit in critOdds is a crit: twice the footprint, cleared outright
+	critCooldown   = 16 // a crit holds the next shot longer, so there is time to watch it
+	critGap        = 3  // plain shots that must go between one crit and the next
+	flashTicks     = 2
+	shakeTicks     = 2
+	critShake      = 4
+	burstFrame     = 2 // ticks per impact frame
+	maxDebris      = 600
+	probeSubsteps  = 6
+	traceDots      = 40
+	recoilTicks    = 2
+	bubbleTicks    = 40 // how long a line of speech stays up
+	collapseRows   = 3  // rows released per tick when the frame comes down
+	collapseCap    = 80 // ticks before a collapse counts as settled whether or not debris has
+	collapseLinger = 30 // ticks the settled debris stays on screen before the run ends
 )
 
 // Actor is the driveable unit.
@@ -45,13 +50,30 @@ type Actor struct {
 }
 
 // Probe is a projectile in flight. Positions are in cells; y is fractional rows.
-type Probe struct{ x, y, vx, vy float64 }
+// A crit carries its last few positions so it can draw a trail.
+type Probe struct {
+	x, y, vx, vy float64
+	crit         bool
+	past         [3][2]float64
+}
 
-// Burst is an impact animation at a cell.
+// Burst is an impact animation at a cell. A big one is the same animation
+// stamped in a cluster that blooms outward: each outer copy runs a frame or
+// two behind the centre.
 type Burst struct {
 	x, y int
 	age  int
+	big  bool
 }
+
+// bigBurstStamps are a big burst's outer copies around the centre stamp, with
+// the frames each runs behind. Rows are tall, so the cluster is wide.
+var bigBurstStamps = [...]struct{ dx, dy, lag int }{
+	{-3, 0, 1}, {3, 0, 1}, {-2, -1, 1}, {2, -1, 1},
+	{-6, 0, 2}, {6, 0, 2},
+}
+
+const bigBurstLag = 2 // frames the outermost copies run behind
 
 // Debris is a glyph knocked loose and falling.
 type Debris struct {
@@ -68,17 +90,18 @@ type Scene struct {
 	frame    *Grid   // scratch buffer each Render composes into
 	damage   []uint8 // per cell: 0 intact, 1 cracked, 2 gone
 
-	Actor    Actor
-	probes   []Probe
-	bursts   []Burst
-	falling  []Debris
-	heap     [][]Cell // per column, bottom-up: debris that has landed
-	flash    int
-	shake    int
-	tick     int
-	power    float64
-	rng      *rand.Rand
-	showKeys bool
+	Actor     Actor
+	sinceCrit int // shots since the last crit; a crit needs critGap of them
+	probes    []Probe
+	bursts    []Burst
+	falling   []Debris
+	heap      [][]Cell // per column, bottom-up: debris that has landed
+	flash     int
+	shake     int
+	tick      int
+	power     float64
+	rng       *rand.Rand
+	showKeys  bool
 
 	entering bool // driving in from off-screen; input is ignored until parked
 	razed    int  // frame cells cleared by impacts
@@ -86,13 +109,15 @@ type Scene struct {
 	// Speech: one line at a time, each event line said once.
 	bubble     string
 	bubbleLeft int
-	said       [8]bool
+	said       [quipCount]bool
 
-	// Leaving: the frame is released row by row into debris, and the run
-	// ends once it has settled (or collapseCap ticks have passed).
+	// Leaving: the frame is released row by row into debris; once it has
+	// settled (or collapseCap ticks have passed) the debris lingers for
+	// collapseLinger ticks, and then the run ends.
 	collapsing  bool
 	collapseRow int
 	collapseAge int
+	settled     int // ticks spent lingering on the settled debris
 	done        bool
 }
 
@@ -112,6 +137,7 @@ func New(screen *Grid, seed uint64) *Scene {
 		heap:     make([][]Cell, screen.W),
 		rng:      rand.New(rand.NewPCG(seed, seed^0x9e3779b97f4a7c15)),
 	}
+	s.sinceCrit = critGap // the first shot may crit
 	s.stampCard()
 	s.pristine.CopyFrom(screen)
 	byWidth := math.Sqrt(1.4 * float64(s.W) * probeGravity)
@@ -281,7 +307,10 @@ func (s *Scene) stepCollapse() {
 		}
 	}
 	if (s.collapseRow >= s.H && len(s.falling) == 0) || s.collapseAge >= collapseCap {
-		s.done = true
+		s.settled++
+		if s.settled > collapseLinger {
+			s.done = true
+		}
 	}
 }
 
@@ -329,15 +358,29 @@ func (s *Scene) nozzle() (x, y int) {
 	return px + s.Actor.Facing*tip[0], py + tip[1]
 }
 
-// emit launches a probe from the nozzle; the arm dips for a moment.
+// emit launches a probe from the nozzle; the arm dips for a moment. One
+// emit in critOdds rolls a crit, once critGap plain shots have gone since
+// the last one.
 func (s *Scene) emit() {
 	if s.Actor.cooldown > 0 {
 		return
 	}
+	s.fire(s.sinceCrit >= critGap && s.rng.IntN(critOdds) == 0)
+}
+
+// fire launches a probe, crit or not, without rolling.
+func (s *Scene) fire(crit bool) {
 	s.Actor.cooldown = emitCooldown
+	s.sinceCrit++
+	if crit {
+		s.Actor.cooldown = critCooldown
+		s.sinceCrit = 0
+	}
 	s.flash = flashTicks
 	nx, ny := s.nozzle()
-	s.probes = append(s.probes, s.launch(float64(nx), float64(ny)))
+	p := s.launch(float64(nx), float64(ny))
+	p.crit = crit
+	s.probes = append(s.probes, p)
 	s.Actor.recoil = recoilTicks
 }
 
@@ -345,10 +388,11 @@ func (s *Scene) emit() {
 func (s *Scene) launch(x, y float64) Probe {
 	rad := float64(s.Actor.Angle) * math.Pi / 180
 	return Probe{
-		x:  x,
-		y:  y,
-		vx: float64(s.Actor.Facing) * s.power * math.Cos(rad),
-		vy: -s.power * math.Sin(rad) / 2,
+		x:    x,
+		y:    y,
+		vx:   float64(s.Actor.Facing) * s.power * math.Cos(rad),
+		vy:   -s.power * math.Sin(rad) / 2,
+		past: [3][2]float64{{x, y}, {x, y}, {x, y}},
 	}
 }
 
@@ -388,6 +432,7 @@ func (s *Scene) stepProbes() {
 	kept := s.probes[:0]
 	for i := range s.probes {
 		p := s.probes[i]
+		p.past[2], p.past[1], p.past[0] = p.past[1], p.past[0], [2]float64{p.x, p.y}
 		var hit, gone bool
 		var hx, hy int
 		for sub := 0; sub < probeSubsteps && !hit && !gone; sub++ {
@@ -395,7 +440,7 @@ func (s *Scene) stepProbes() {
 		}
 		switch {
 		case hit:
-			s.impact(hx, hy)
+			s.impact(hx, hy, p.crit)
 		case gone:
 		default:
 			kept = append(kept, p)
@@ -408,16 +453,22 @@ func (s *Scene) stepProbes() {
 // are tall). The core — the impact cell and two neighbours either side on its
 // row — is cleared outright; the ring cracks on the first hit and clears on
 // the next, so text visibly breaks before it disappears. Landed debris in the
-// footprint is thrown back into the air.
-func (s *Scene) impact(cx, cy int) {
-	s.bursts = append(s.bursts, Burst{x: cx, y: cy})
+// footprint is thrown back into the air. A crit doubles the footprint and
+// clears all of it outright, with a bigger burst and a longer shake.
+func (s *Scene) impact(cx, cy int, crit bool) {
+	s.bursts = append(s.bursts, Burst{x: cx, y: cy, big: crit})
 	s.shake = shakeTicks
+	rx, ry, reach := 3, 1, 10
+	if crit {
+		s.shake = critShake
+		rx, ry, reach = 6, 2, 40
+	}
 	if x0, x1 := s.baseSpan(); cx >= x0 && cx <= x1 && cy >= s.top() {
 		s.say(quipSelfHit)
 	}
-	for dy := -1; dy <= 1; dy++ {
-		for dx := -3; dx <= 3; dx++ {
-			if dx*dx+4*dy*dy > 10 {
+	for dy := -ry; dy <= ry; dy++ {
+		for dx := -rx; dx <= rx; dx++ {
+			if dx*dx+4*dy*dy > reach {
 				continue
 			}
 			x, y := cx+dx, cy+dy
@@ -432,7 +483,7 @@ func (s *Scene) impact(cx, cy int) {
 			if s.damage[i] == 2 || !s.world.Solid(x, y) {
 				continue
 			}
-			core := dy == 0 && dx >= -2 && dx <= 2
+			core := crit || (dy == 0 && dx >= -2 && dx <= 2)
 			if s.damage[i] == 0 && !core {
 				c := s.world.At(x, y)
 				s.world.Set(x, y, Cell{Content: "▒", Width: 1, Style: c.Style})
@@ -454,6 +505,9 @@ func (s *Scene) impact(cx, cy int) {
 		s.say(quipRazed300)
 	} else if s.razed >= 100 {
 		s.say(quipRazed100)
+	}
+	if crit {
+		s.say(quipCrit)
 	}
 }
 
@@ -497,7 +551,11 @@ func (s *Scene) stepBursts() {
 	kept := s.bursts[:0]
 	for _, b := range s.bursts {
 		b.age++
-		if b.age < len(bursts)*burstFrame {
+		life := len(bursts) * burstFrame
+		if b.big {
+			life += bigBurstLag * burstFrame // until the outermost copies finish
+		}
+		if b.age < life {
 			kept = append(kept, b)
 		}
 	}
@@ -631,11 +689,31 @@ func (s *Scene) Render() string {
 		s.drawBubble(f)
 	}
 	for _, p := range s.probes {
-		f.Set(int(math.Round(p.x)), int(math.Round(p.y)), Cell{Content: "●", Width: 1, Style: probeStyle})
+		if !p.crit {
+			f.Set(int(math.Round(p.x)), int(math.Round(p.y)), Cell{Content: "●", Width: 1, Style: probeStyle})
+			continue
+		}
+		for i, q := range p.past {
+			g := "·"
+			if i == 0 {
+				g = "✦"
+			}
+			f.Set(int(math.Round(q[0])), int(math.Round(q[1])), Cell{Content: g, Width: 1, Style: critGlow})
+		}
+		// A three-cell ball: half-circle rims around a bright core.
+		x, y := int(math.Round(p.x)), int(math.Round(p.y))
+		f.Set(x-1, y, Cell{Content: "◖", Width: 1, Style: critStyle})
+		f.Set(x, y, Cell{Content: "◉", Width: 1, Style: critGlow})
+		f.Set(x+1, y, Cell{Content: "◗", Width: 1, Style: critStyle})
 	}
 	for _, b := range s.bursts {
-		for _, c := range bursts[b.age/burstFrame] {
-			f.Set(b.x+c.dx, b.y+c.dy, Cell{Content: c.g, Width: 1, Style: c.style})
+		if !b.big {
+			s.drawBurst(f, b.x, b.y, b.age, burstStyles)
+			continue
+		}
+		s.drawBurst(f, b.x, b.y, b.age, critBurstStyles)
+		for _, o := range bigBurstStamps {
+			s.drawBurst(f, b.x+o.dx, b.y+o.dy, b.age-o.lag*burstFrame, critBurstStyles)
 		}
 	}
 	if s.flash > 0 {
@@ -725,6 +803,18 @@ func (s *Scene) drawBubble(f *Grid) {
 // drawStatus writes the elevation (and, on `?`, the keys — for after the
 // card is gone) into the top right corner. Right-aligned because the frozen
 // header's breadcrumb is on the left and is a target like anything else.
+// drawBurst stamps one frame of the impact animation at (x, y) in the given
+// palette; an age out of range draws nothing.
+func (s *Scene) drawBurst(f *Grid, x, y, age int, styles [4]uv.Style) {
+	if age < 0 || age >= len(bursts)*burstFrame {
+		return
+	}
+	frame := age / burstFrame
+	for _, c := range bursts[frame] {
+		f.Set(x+c.dx, y+c.dy, Cell{Content: c.g, Width: 1, Style: styles[frame]})
+	}
+}
+
 func (s *Scene) drawStatus(f *Grid) {
 	text := fmt.Sprintf(" ∠ %2d° ", s.Actor.Angle)
 	if s.showKeys {

--- a/internal/frost/scene.go
+++ b/internal/frost/scene.go
@@ -328,8 +328,7 @@ func (s *Scene) nozzle() (x, y int) {
 	return px + s.Actor.Facing*tip[0], py + tip[1]
 }
 
-// emit launches a probe from the nozzle. The actor kicks back a column and
-// the arm dips for a moment.
+// emit launches a probe from the nozzle; the arm dips for a moment.
 func (s *Scene) emit() {
 	if s.Actor.cooldown > 0 {
 		return
@@ -339,8 +338,6 @@ func (s *Scene) emit() {
 	nx, ny := s.nozzle()
 	s.probes = append(s.probes, s.launch(float64(nx), float64(ny)))
 	s.Actor.recoil = recoilTicks
-	lo, hi := s.xRange()
-	s.Actor.X = min(max(s.Actor.X-float64(s.Actor.Facing), lo), hi)
 }
 
 // launch builds a probe leaving (x, y) at the actor's current elevation.

--- a/internal/frost/scene.go
+++ b/internal/frost/scene.go
@@ -6,6 +6,7 @@ import (
 	"math/rand/v2"
 
 	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // Tuning. The sim runs at a fixed tick (the UI schedules the interval); every
@@ -168,7 +169,7 @@ func (s *Scene) stampCard() {
 // instead; a second one during it ends the run at once.
 func (s *Scene) Key(k string) (exit bool) {
 	switch k {
-	case "esc", "q", "ctrl+c":
+	case "esc", "q":
 		if s.collapsing {
 			return true
 		}
@@ -466,8 +467,10 @@ func (s *Scene) fling(x, y int, c Cell, dx int) {
 	if len(s.falling) >= cap || c.Width == 0 {
 		return
 	}
-	if c.Content == "" || c.Content == " " {
-		c.Content = "▪" // a filled space sheds a chip, not an invisible one
+	if c.Content == "" || c.Content == " " || ansi.StringWidth(c.Content) != 1 {
+		// A filled space sheds a chip, not an invisible one; so does a glyph
+		// wider than the one column a heap cell has.
+		c.Content = "▪"
 	}
 	c.Width = 1
 	away := float64(dx) * 0.12
@@ -504,8 +507,10 @@ func (s *Scene) stepBursts() {
 // stepDebris drops falling glyphs through the (background) text until they
 // meet the floor or a heap, then stacks them.
 func (s *Scene) stepDebris() {
+	surface := func(col int) float64 { return float64(s.H - 1 - len(s.heap[col])) }
 	kept := s.falling[:0]
 	for _, d := range s.falling {
+		from := int(math.Round(d.x))
 		d.vy += debrisGravity
 		d.vx *= 0.9
 		d.x += d.vx
@@ -514,8 +519,15 @@ func (s *Scene) stepDebris() {
 		if col < 0 || col >= s.W {
 			continue
 		}
-		landing := float64(s.H - 1 - len(s.heap[col]))
-		if d.y >= landing {
+		// Drifting into a column whose mound already stands above the chip is
+		// hitting the mound's side, not landing on it: the chip stays in the
+		// column it came from instead of being stacked rows higher in one tick.
+		if col != from && d.y > surface(col)+1 {
+			col = from
+			d.x = float64(from)
+			d.vx = 0
+		}
+		if d.y >= surface(col) {
 			if len(s.heap[col]) < s.H {
 				s.heap[col] = append(s.heap[col], d.cell)
 			}

--- a/internal/frost/scene.go
+++ b/internal/frost/scene.go
@@ -1,0 +1,729 @@
+package frost
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// Tuning. The sim runs at a fixed tick (the UI schedules the interval); every
+// rate below is per tick. Rows are twice as tall as columns are wide, so a
+// vertical velocity is halved to look like the same speed on screen.
+const (
+	probeGravity  = 0.045 // rows per tick²
+	debrisGravity = 0.08
+	driveSpeed    = 0.9 // columns per tick while a drive key is held
+	driveTicks    = 3   // ticks of motion one key event adds (key repeat keeps it topped up)
+	driveMax      = 12  // cap on banked motion, so a burst of presses is not a long slide
+	angleStep     = 5   // degrees per ↑/↓
+	emitCooldown  = 4
+	flashTicks    = 2
+	shakeTicks    = 2
+	burstFrame    = 2 // ticks per impact frame
+	maxDebris     = 600
+	probeSubsteps = 6
+	traceDots     = 40
+	recoilTicks   = 2
+	bubbleTicks   = 40 // how long a line of speech stays up
+	collapseRows  = 3  // rows released per tick when the frame comes down
+	collapseCap   = 80 // ticks before a collapse ends whether or not debris has settled
+)
+
+// Actor is the driveable unit.
+type Actor struct {
+	X          float64 // sprite origin column (may sit a little off-screen while facing left)
+	Facing     int     // +1 right, -1 left
+	Angle      int     // arm elevation in degrees, 0 = level, 90 = straight up
+	driveLeft  int     // ticks of drive momentum left
+	vx         float64
+	trackPhase int
+	cooldown   int
+	recoil     int // ticks the arm dips after emitting
+}
+
+// Probe is a projectile in flight. Positions are in cells; y is fractional rows.
+type Probe struct{ x, y, vx, vy float64 }
+
+// Burst is an impact animation at a cell.
+type Burst struct {
+	x, y int
+	age  int
+}
+
+// Debris is a glyph knocked loose and falling.
+type Debris struct {
+	x, y, vx, vy float64
+	cell         Cell
+}
+
+// Scene is one run over a frozen frame.
+type Scene struct {
+	W, H int
+
+	world    *Grid   // the frame, taking damage
+	pristine *Grid   // the frame as frozen, for the glyph a cleared cell sheds
+	frame    *Grid   // scratch buffer each Render composes into
+	damage   []uint8 // per cell: 0 intact, 1 cracked, 2 gone
+
+	Actor    Actor
+	probes   []Probe
+	bursts   []Burst
+	falling  []Debris
+	heap     [][]Cell // per column, bottom-up: debris that has landed
+	flash    int
+	shake    int
+	tick     int
+	power    float64
+	rng      *rand.Rand
+	showKeys bool
+
+	entering bool // driving in from off-screen; input is ignored until parked
+	razed    int  // frame cells cleared by impacts
+
+	// Speech: one line at a time, each event line said once.
+	bubble     string
+	bubbleLeft int
+	said       [8]bool
+
+	// Leaving: the frame is released row by row into debris, and the run
+	// ends once it has settled (or collapseCap ticks have passed).
+	collapsing  bool
+	collapseRow int
+	collapseAge int
+	done        bool
+}
+
+// New starts a scene over a frozen frame. The actor spawns on the floor at
+// the right, facing in; launch velocity scales with the frame so a 45° probe
+// crosses about two thirds of the width and a vertical one just clears the
+// top row — whichever asks for more. The card is stamped into the frame
+// itself, so it is as much a target as everything else.
+func New(screen *Grid, seed uint64) *Scene {
+	s := &Scene{
+		W:        screen.W,
+		H:        screen.H,
+		world:    screen,
+		pristine: NewGrid(screen.W, screen.H),
+		frame:    NewGrid(screen.W, screen.H),
+		damage:   make([]uint8, screen.W*screen.H),
+		heap:     make([][]Cell, screen.W),
+		rng:      rand.New(rand.NewPCG(seed, seed^0x9e3779b97f4a7c15)),
+	}
+	s.stampCard()
+	s.pristine.CopyFrom(screen)
+	byWidth := math.Sqrt(1.4 * float64(s.W) * probeGravity)
+	byHeight := 2 * math.Sqrt(2*probeGravity*float64(s.H+2))
+	s.power = min(max(byWidth, byHeight, 1.8), 5)
+	// Parked position is the right edge; the actor starts past it and drives in.
+	s.Actor = Actor{X: float64(s.W + 2), Facing: -1, Angle: 45}
+	s.entering = true
+	return s
+}
+
+// parkX is where the entrance ends.
+func (s *Scene) parkX() float64 { return float64(s.W - SpriteW - 1) }
+
+// Done reports that the run has ended and the frame can be dropped.
+func (s *Scene) Done() bool { return s.done }
+
+// say puts a line of speech above the actor. Each event's line is said once.
+func (s *Scene) say(q int) {
+	if q >= len(quips) || s.said[q] {
+		return
+	}
+	s.said[q] = true
+	s.bubble = quips[q]
+	s.bubbleLeft = bubbleTicks
+}
+
+// stampCard writes the card, centred, into the world grid. It lives there
+// rather than in the status line so it takes damage like anything else.
+func (s *Scene) stampCard() {
+	if len(card) == 0 {
+		return
+	}
+	w := len([]rune(card[0]))
+	x0, y0 := (s.W-w)/2, (s.H-len(card))/2-1
+	if x0 < 0 || y0 < 1 {
+		return // too small a frame to hold it; the status legend still exists
+	}
+	for r, row := range card {
+		for i, ch := range []rune(row) {
+			style := cardStyle
+			switch {
+			case r == 1 && ch != '│':
+				style = cardTitleStyle
+			case r == 0 || r == len(card)-1 || ch == '│':
+				style = cardEdgeStyle
+			}
+			s.world.Set(x0+i, y0+r, Cell{Content: string(ch), Width: 1, Style: style})
+		}
+	}
+}
+
+// Key applies one keypress (Bubble Tea's Key.String() spelling). It reports
+// true when the run should end now. The first exit key starts the collapse
+// instead; a second one during it ends the run at once.
+func (s *Scene) Key(k string) (exit bool) {
+	switch k {
+	case "esc", "q", "ctrl+c":
+		if s.collapsing {
+			return true
+		}
+		s.beginCollapse()
+		return false
+	}
+	if s.entering || s.collapsing {
+		return false
+	}
+	switch k {
+	case "left", "h", "a":
+		s.drive(-1)
+	case "right", "l", "d":
+		s.drive(1)
+	case "up", "k", "w":
+		s.Actor.Angle = min(90, s.Actor.Angle+angleStep)
+	case "down", "j", "s":
+		s.Actor.Angle = max(0, s.Actor.Angle-angleStep)
+	case "space", "enter", "f":
+		s.emit()
+	case "?":
+		s.showKeys = !s.showKeys
+	}
+	return false
+}
+
+// beginCollapse starts releasing the frame into debris, top row first.
+func (s *Scene) beginCollapse() {
+	s.collapsing = true
+	s.collapseRow = 0
+	s.collapseAge = 0
+	s.say(quipBye)
+}
+
+// drive banks a few ticks of motion per key event. Terminals report no key
+// release, so "held" arrives as repeats ~30ms apart; banking (rather than
+// setting) keeps the actor rolling between them, and a tap still moves a step.
+func (s *Scene) drive(dir int) {
+	if dir != s.Actor.Facing {
+		s.Actor.driveLeft = 0 // turning around cancels the old momentum
+	}
+	s.Actor.Facing = dir
+	s.Actor.vx = float64(dir) * driveSpeed
+	s.Actor.driveLeft = min(s.Actor.driveLeft+driveTicks, driveMax)
+}
+
+// Step advances the simulation one tick.
+func (s *Scene) Step() {
+	s.tick++
+	a := &s.Actor
+	if s.bubbleLeft > 0 {
+		s.bubbleLeft--
+	}
+	if a.recoil > 0 {
+		a.recoil--
+	}
+	if s.entering {
+		a.X -= driveSpeed
+		a.trackPhase++
+		if a.X <= s.parkX() {
+			a.X = s.parkX()
+			s.entering = false
+			s.say(quipStart)
+		}
+	}
+	if s.collapsing {
+		s.stepCollapse()
+	}
+	if a.driveLeft > 0 {
+		a.driveLeft--
+		a.trackPhase++
+		a.X += a.vx
+		lo, hi := s.xRange()
+		a.X = min(max(a.X, lo), hi)
+	}
+	if a.cooldown > 0 {
+		a.cooldown--
+	}
+	if s.flash > 0 {
+		s.flash--
+	}
+	if s.shake > 0 {
+		s.shake--
+	}
+	s.stepProbes()
+	s.stepBursts()
+	s.stepDebris()
+	s.relaxHeap()
+	if !s.collapsing && s.H-SpriteH-s.top() >= 3 {
+		s.say(quipBuried)
+	}
+}
+
+// stepCollapse releases the next rows of the frame as debris and ends the
+// run once everything released has landed.
+func (s *Scene) stepCollapse() {
+	s.collapseAge++
+	for n := 0; n < collapseRows && s.collapseRow < s.H; n++ {
+		y := s.collapseRow
+		s.collapseRow++
+		for x := 0; x < s.W; x++ {
+			i := y*s.W + x
+			if s.damage[i] == 2 || !s.world.Solid(x, y) {
+				continue
+			}
+			s.damage[i] = 2
+			s.world.Set(x, y, blank)
+			s.fling(x, y, s.pristine.At(x, y), s.rng.IntN(3)-1)
+		}
+	}
+	if (s.collapseRow >= s.H && len(s.falling) == 0) || s.collapseAge >= collapseCap {
+		s.done = true
+	}
+}
+
+// xRange is the span the sprite origin may occupy so the base stays on screen.
+func (s *Scene) xRange() (lo, hi float64) {
+	if s.Actor.Facing > 0 {
+		return -1, float64(s.W - SpriteW)
+	}
+	return 0, float64(s.W - SpriteW + 1)
+}
+
+// baseSpan is the columns the bottom row covers.
+func (s *Scene) baseSpan() (x0, x1 int) {
+	x := int(math.Round(s.Actor.X))
+	if s.Actor.Facing > 0 {
+		return x + 1, x + SpriteW - 1
+	}
+	return x, x + SpriteW - 2
+}
+
+// top is the row of the sprite's first row: the actor rides on the tallest
+// debris under its base, which is what lets it climb what it knocks down.
+func (s *Scene) top() int {
+	x0, x1 := s.baseSpan()
+	lift := 0
+	for x := max(x0, 0); x <= x1 && x < s.W; x++ {
+		lift = max(lift, len(s.heap[x]))
+	}
+	return s.H - SpriteH - lift
+}
+
+// pivot is the cell the arm sprite hangs off: just past the base's end.
+func (s *Scene) pivot() (x, y int) {
+	x = int(math.Round(s.Actor.X))
+	if s.Actor.Facing > 0 {
+		return x + SpriteW, s.top() + pivotRow
+	}
+	return x - 1, s.top() + pivotRow
+}
+
+// nozzle is the cell a probe leaves from.
+func (s *Scene) nozzle() (x, y int) {
+	px, py := s.pivot()
+	tip := arms[armBucket(s.Actor.Angle)].tip
+	return px + s.Actor.Facing*tip[0], py + tip[1]
+}
+
+// emit launches a probe from the nozzle. The actor kicks back a column and
+// the arm dips for a moment.
+func (s *Scene) emit() {
+	if s.Actor.cooldown > 0 {
+		return
+	}
+	s.Actor.cooldown = emitCooldown
+	s.flash = flashTicks
+	nx, ny := s.nozzle()
+	s.probes = append(s.probes, s.launch(float64(nx), float64(ny)))
+	s.Actor.recoil = recoilTicks
+	lo, hi := s.xRange()
+	s.Actor.X = min(max(s.Actor.X-float64(s.Actor.Facing), lo), hi)
+}
+
+// launch builds a probe leaving (x, y) at the actor's current elevation.
+func (s *Scene) launch(x, y float64) Probe {
+	rad := float64(s.Actor.Angle) * math.Pi / 180
+	return Probe{
+		x:  x,
+		y:  y,
+		vx: float64(s.Actor.Facing) * s.power * math.Cos(rad),
+		vy: -s.power * math.Sin(rad) / 2,
+	}
+}
+
+// advance moves a probe one sub-step and reports the cell it hit, if any.
+// Above the frame it keeps flying (it will come back down); off either side
+// or below the floor it is gone.
+func (s *Scene) advance(p *Probe) (hit, gone bool, hx, hy int) {
+	p.vy += probeGravity / probeSubsteps
+	p.x += p.vx / probeSubsteps
+	p.y += p.vy / probeSubsteps
+	cx, cy := int(math.Round(p.x)), int(math.Round(p.y))
+	if cx < 0 || cx >= s.W || cy < -4*s.H {
+		return false, true, 0, 0
+	}
+	if cy >= s.H {
+		return true, false, cx, s.H - 1
+	}
+	if cy >= 0 && s.solid(cx, cy) {
+		return true, false, cx, cy
+	}
+	return false, false, 0, 0
+}
+
+// solid is anything a probe stops on: surviving text, or landed debris.
+func (s *Scene) solid(x, y int) bool {
+	if s.heapAt(x, y) {
+		return true
+	}
+	return s.damage[y*s.W+x] < 2 && s.world.Solid(x, y)
+}
+
+func (s *Scene) heapAt(x, y int) bool {
+	return x >= 0 && x < s.W && y >= s.H-len(s.heap[x]) && y < s.H
+}
+
+func (s *Scene) stepProbes() {
+	kept := s.probes[:0]
+	for i := range s.probes {
+		p := s.probes[i]
+		var hit, gone bool
+		var hx, hy int
+		for sub := 0; sub < probeSubsteps && !hit && !gone; sub++ {
+			hit, gone, hx, hy = s.advance(&p)
+		}
+		switch {
+		case hit:
+			s.impact(hx, hy)
+		case gone:
+		default:
+			kept = append(kept, p)
+		}
+	}
+	s.probes = kept
+}
+
+// impact damages a footprint around the hit: a wide, shallow ellipse (rows
+// are tall). The core — the impact cell and two neighbours either side on its
+// row — is cleared outright; the ring cracks on the first hit and clears on
+// the next, so text visibly breaks before it disappears. Landed debris in the
+// footprint is thrown back into the air.
+func (s *Scene) impact(cx, cy int) {
+	s.bursts = append(s.bursts, Burst{x: cx, y: cy})
+	s.shake = shakeTicks
+	if x0, x1 := s.baseSpan(); cx >= x0 && cx <= x1 && cy >= s.top() {
+		s.say(quipSelfHit)
+	}
+	for dy := -1; dy <= 1; dy++ {
+		for dx := -3; dx <= 3; dx++ {
+			if dx*dx+4*dy*dy > 10 {
+				continue
+			}
+			x, y := cx+dx, cy+dy
+			if !s.world.In(x, y) {
+				continue
+			}
+			if s.heapAt(x, y) {
+				s.fling(x, y, s.popHeap(x, y), dx)
+				continue
+			}
+			i := y*s.W + x
+			if s.damage[i] == 2 || !s.world.Solid(x, y) {
+				continue
+			}
+			core := dy == 0 && dx >= -2 && dx <= 2
+			if s.damage[i] == 0 && !core {
+				c := s.world.At(x, y)
+				s.world.Set(x, y, Cell{Content: "▒", Width: 1, Style: c.Style})
+				s.damage[i] = 1
+				continue
+			}
+			s.damage[i] = 2
+			s.world.Set(x, y, blank)
+			s.fling(x, y, s.pristine.At(x, y), dx)
+			s.razed++
+			switch s.pristine.At(x, y).Content {
+			case "●", "◐", "✻", "◇", "△", "✕":
+				s.say(quipSessionHit)
+			}
+		}
+	}
+	s.say(quipFirstHit)
+	if s.razed >= 300 {
+		s.say(quipRazed300)
+	} else if s.razed >= 100 {
+		s.say(quipRazed100)
+	}
+}
+
+// fling turns a cell into falling debris, popped up and away from the impact
+// so the heap it lands in spreads instead of stacking.
+func (s *Scene) fling(x, y int, c Cell, dx int) {
+	cap := maxDebris
+	if s.collapsing {
+		cap = s.W * s.H // the whole frame is coming down; the cap is for play
+	}
+	if len(s.falling) >= cap || c.Width == 0 {
+		return
+	}
+	if c.Content == "" || c.Content == " " {
+		c.Content = "▪" // a filled space sheds a chip, not an invisible one
+	}
+	c.Width = 1
+	away := float64(dx) * 0.12
+	s.falling = append(s.falling, Debris{
+		x:    float64(x),
+		y:    float64(y),
+		vx:   away + (s.rng.Float64()-0.5)*0.6,
+		vy:   -(0.35 + s.rng.Float64()*0.55),
+		cell: c,
+	})
+}
+
+// popHeap removes the debris cell at (x, y) from its column; what sat above
+// it settles down one row.
+func (s *Scene) popHeap(x, y int) Cell {
+	col := s.heap[x]
+	i := s.H - 1 - y
+	c := col[i]
+	s.heap[x] = append(col[:i], col[i+1:]...)
+	return c
+}
+
+func (s *Scene) stepBursts() {
+	kept := s.bursts[:0]
+	for _, b := range s.bursts {
+		b.age++
+		if b.age < len(bursts)*burstFrame {
+			kept = append(kept, b)
+		}
+	}
+	s.bursts = kept
+}
+
+// stepDebris drops falling glyphs through the (background) text until they
+// meet the floor or a heap, then stacks them.
+func (s *Scene) stepDebris() {
+	kept := s.falling[:0]
+	for _, d := range s.falling {
+		d.vy += debrisGravity
+		d.vx *= 0.9
+		d.x += d.vx
+		d.y += d.vy
+		col := int(math.Round(d.x))
+		if col < 0 || col >= s.W {
+			continue
+		}
+		landing := float64(s.H - 1 - len(s.heap[col]))
+		if d.y >= landing {
+			if len(s.heap[col]) < s.H {
+				s.heap[col] = append(s.heap[col], d.cell)
+			}
+			continue
+		}
+		kept = append(kept, d)
+	}
+	s.falling = kept
+}
+
+// relaxHeap lets debris slide off steep columns, one cell per column per
+// tick, so heaps settle into mounds the actor can drive up. Alternating the
+// sweep direction keeps the mounds from leaning.
+func (s *Scene) relaxHeap() {
+	height := func(x int) int {
+		if x < 0 || x >= s.W {
+			return math.MaxInt32 // the frame edge is a wall
+		}
+		return len(s.heap[x])
+	}
+	sweep := func(x int) {
+		h := height(x)
+		if h < 2 {
+			return
+		}
+		l, r := height(x-1), height(x+1)
+		to := -1
+		switch {
+		case h-l >= 2 && h-r >= 2:
+			to = x - 1
+			if r < l || (r == l && s.rng.IntN(2) == 0) {
+				to = x + 1
+			}
+		case h-l >= 2:
+			to = x - 1
+		case h-r >= 2:
+			to = x + 1
+		}
+		if to < 0 {
+			return
+		}
+		top := s.heap[x][h-1]
+		s.heap[x] = s.heap[x][:h-1]
+		s.heap[to] = append(s.heap[to], top)
+	}
+	if s.tick%2 == 0 {
+		for x := 0; x < s.W; x++ {
+			sweep(x)
+		}
+	} else {
+		for x := s.W - 1; x >= 0; x-- {
+			sweep(x)
+		}
+	}
+}
+
+// trace follows where a probe launched now would go, as a sparse dotted arc
+// that stops at the first thing it would hit. It is the only precise sight:
+// the arm sprite has four elevations, the angle has nineteen.
+func (s *Scene) trace() [][2]int {
+	nx, ny := s.nozzle()
+	p := s.launch(float64(nx), float64(ny))
+	var dots [][2]int
+	for step := 0; step < 200 && len(dots) < traceDots; step++ {
+		var hit, gone bool
+		for sub := 0; sub < probeSubsteps && !hit && !gone; sub++ {
+			hit, gone, _, _ = s.advance(&p)
+		}
+		if hit || gone {
+			break
+		}
+		if step%2 == 1 {
+			dots = append(dots, [2]int{int(math.Round(p.x)), int(math.Round(p.y))})
+		}
+	}
+	return dots
+}
+
+// Render composes the next frame: the damaged screen, then landed and
+// falling debris, the trace, the actor, probes, bursts and the status line.
+func (s *Scene) Render() string {
+	f := s.frame
+	f.CopyFrom(s.world)
+	for x := 0; x < s.W; x++ {
+		for i, c := range s.heap[x] {
+			f.Set(x, s.H-1-i, c)
+		}
+	}
+	for _, d := range s.falling {
+		f.Set(int(math.Round(d.x)), int(math.Round(d.y)), d.cell)
+	}
+	if !s.entering && !s.collapsing {
+		for _, d := range s.trace() {
+			if f.In(d[0], d[1]) && !f.Solid(d[0], d[1]) {
+				f.Set(d[0], d[1], Cell{Content: "·", Width: 1, Style: traceStyle})
+			}
+		}
+	}
+	s.drawActor(f)
+	if s.bubbleLeft > 0 {
+		s.drawBubble(f)
+	}
+	for _, p := range s.probes {
+		f.Set(int(math.Round(p.x)), int(math.Round(p.y)), Cell{Content: "●", Width: 1, Style: probeStyle})
+	}
+	for _, b := range s.bursts {
+		for _, c := range bursts[b.age/burstFrame] {
+			f.Set(b.x+c.dx, b.y+c.dy, Cell{Content: c.g, Width: 1, Style: c.style})
+		}
+	}
+	if s.flash > 0 {
+		nx, ny := s.nozzle()
+		f.Set(nx, ny, Cell{Content: "✦", Width: 1, Style: flashStyle})
+	}
+	s.drawStatus(f)
+	shift := 0
+	if s.shake > 0 {
+		shift = 1 - 2*(s.tick%2)
+	}
+	return f.Render(shift)
+}
+
+func (s *Scene) drawActor(f *Grid) {
+	x0, y0 := int(math.Round(s.Actor.X)), s.top()
+	rows := spriteRows
+	if s.Actor.driveLeft > 0 && s.Actor.trackPhase%2 == 1 {
+		rows[SpriteH-1] = altBase
+	}
+	if s.Actor.Facing < 0 {
+		for i := range rows {
+			rows[i] = mirrorRow(rows[i])
+		}
+	}
+	styles := [SpriteH]uv.Style{actorStyle, actorStyle, baseStyle, trackStyle}
+	for r, row := range rows {
+		for i, ch := range []rune(row) {
+			if ch != ' ' {
+				f.Set(x0+i, y0+r, Cell{Content: string(ch), Width: 1, Style: styles[r]})
+			}
+		}
+	}
+	px, py := s.pivot()
+	bucket := armBucket(s.Actor.Angle)
+	if s.Actor.recoil > 0 && bucket > 0 {
+		bucket-- // the arm dips with the kick
+	}
+	for _, c := range arms[bucket].cells {
+		ch := c.g
+		if s.Actor.Facing < 0 {
+			ch = mirrorRune(ch)
+		}
+		f.Set(px+s.Actor.Facing*c.dx, py+c.dy, Cell{Content: string(ch), Width: 1, Style: armStyle})
+	}
+}
+
+// drawBubble draws the current line of speech in a box above the actor's
+// head, its tail over the head's centre, kept on screen. Skipped when there
+// is no room above.
+func (s *Scene) drawBubble(f *Grid) {
+	text := []rune(s.bubble)
+	w := len(text) + 4
+	x0 := int(math.Round(s.Actor.X))
+	tail := x0 + 6 // the head's centre column, either facing
+	bx := min(max(tail-3, 0), s.W-w)
+	by := s.top() - 4
+	if by < 1 || w > s.W {
+		return
+	}
+	put := func(x, y int, r rune) {
+		f.Set(x, y, Cell{Content: string(r), Width: 1, Style: bubbleStyle})
+	}
+	for i := 0; i < w; i++ {
+		top, bottom := '─', '─'
+		switch i {
+		case 0:
+			top, bottom = '╭', '╰'
+		case w - 1:
+			top, bottom = '╮', '╯'
+		}
+		if bx+i == tail && i > 0 && i < w-1 {
+			bottom = '┬'
+		}
+		put(bx+i, by, top)
+		put(bx+i, by+2, bottom)
+	}
+	put(bx, by+1, '│')
+	put(bx+1, by+1, ' ')
+	for i, r := range text {
+		put(bx+2+i, by+1, r)
+	}
+	put(bx+w-2, by+1, ' ')
+	put(bx+w-1, by+1, '│')
+}
+
+// drawStatus writes the elevation (and, on `?`, the keys — for after the
+// card is gone) into the top right corner. Right-aligned because the frozen
+// header's breadcrumb is on the left and is a target like anything else.
+func (s *Scene) drawStatus(f *Grid) {
+	text := fmt.Sprintf(" ∠ %2d° ", s.Actor.Angle)
+	if s.showKeys {
+		text = " ←→ drive  ↑↓ aim  space fire  esc back  " + text
+	}
+	rs := []rune(text)
+	x0 := s.W - len(rs)
+	for i, ch := range rs {
+		f.Set(x0+i, 0, Cell{Content: string(ch), Width: 1, Style: statusStyle})
+	}
+}

--- a/internal/frost/scene_test.go
+++ b/internal/frost/scene_test.go
@@ -1,6 +1,7 @@
 package frost
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -60,8 +61,8 @@ func TestUnpackedAssetsHaveTheExpectedShape(t *testing.T) {
 	if len(card) != cardRows {
 		t.Fatalf("card has %d rows, want %d", len(card), cardRows)
 	}
-	if len(quips) < 8 {
-		t.Fatalf("only %d quips unpacked", len(quips))
+	if len(quips) != quipCount {
+		t.Fatalf("%d quips unpacked, want %d", len(quips), quipCount)
 	}
 	w := len([]rune(card[0]))
 	for i, row := range card {
@@ -93,7 +94,7 @@ func TestImpactCracksThenClearsAndShedsDebris(t *testing.T) {
 	settle(s)
 	// Hit the 'w' (x=16). The core — that cell and two either side — is
 	// cleared outright; the rest of the footprint only cracks.
-	s.impact(16, 3)
+	s.impact(16, 3, false)
 	if got := ansi.Strip(s.world.Render(0)); !strings.Contains(got, "hel▒     ▒d") {
 		t.Fatalf("after one hit: %q", got)
 	}
@@ -103,7 +104,7 @@ func TestImpactCracksThenClearsAndShedsDebris(t *testing.T) {
 	if c := s.falling[0].cell.Content; c == " " || c == "▒" {
 		t.Fatalf("debris should carry the original glyph, got %q", c)
 	}
-	s.impact(16, 3)
+	s.impact(16, 3, false)
 	if c := s.world.At(13, 3); c.Content != " " {
 		t.Fatalf("second hit should clear the cracked cell, got %q", c.Content)
 	}
@@ -223,17 +224,17 @@ func TestEmitDipsTheArmWithoutMoving(t *testing.T) {
 func TestSpeaksOnFirstHitAndSessionGlyph(t *testing.T) {
 	s := New(screenWith(60, 20, 10, 3, "● run"), 1)
 	settle(s)
-	s.impact(13, 3) // the 'r'; ● sits in the ring and survives as a crack
+	s.impact(13, 3, false) // the 'r'; ● sits in the ring and survives as a crack
 	if s.bubble != quips[quipFirstHit] {
 		t.Fatalf("first hit should say %q, got %q", quips[quipFirstHit], s.bubble)
 	}
-	s.impact(10, 3) // the ● itself
+	s.impact(10, 3, false) // the ● itself
 	if s.bubble != quips[quipSessionHit] {
 		t.Fatalf("hitting a session glyph should say %q, got %q", quips[quipSessionHit], s.bubble)
 	}
 	// Each line is said once.
 	s.bubbleLeft = 0
-	s.impact(10, 3)
+	s.impact(10, 3, false)
 	if s.bubbleLeft != 0 {
 		t.Fatal("a line should not repeat")
 	}
@@ -248,9 +249,20 @@ func TestExitCollapsesTheFrameThenFinishes(t *testing.T) {
 	if !s.collapsing || s.Done() {
 		t.Fatal("collapse should be running")
 	}
-	for i := 0; i < collapseCap+5 && !s.Done(); i++ {
+	// Everything falls, then the debris stays up for a beat before the run ends.
+	for i := 0; i < collapseCap && (s.collapseRow < s.H || len(s.falling) > 0); i++ {
 		s.Step()
 	}
+	if s.Done() {
+		t.Fatal("the run ended the moment the debris settled; it should linger first")
+	}
+	for i := 0; i < collapseLinger && !s.Done(); i++ {
+		s.Step()
+	}
+	if s.Done() {
+		t.Fatalf("the run ended %d ticks into a %d-tick linger", s.settled, collapseLinger)
+	}
+	s.Step()
 	if !s.Done() {
 		t.Fatal("collapse never finished")
 	}
@@ -287,7 +299,7 @@ func TestCardIsStampedAndTakesDamage(t *testing.T) {
 	for y := 0; y < s.H; y++ {
 		for x := 0; x < s.W; x++ {
 			if s.world.At(x, y).Content == "╭" {
-				s.impact(x+5, y)
+				s.impact(x+5, y, false)
 				if c := s.world.At(x+5, y); c.Content != " " {
 					t.Fatalf("card edge should be cleared at the impact, got %q", c.Content)
 				}
@@ -413,5 +425,157 @@ func TestChipHittingAMoundSideStaysInItsColumn(t *testing.T) {
 	stillFalling := len(s.falling) == 1 && s.falling[0].x == 9 && s.falling[0].vx == 0
 	if !landed && !stillFalling {
 		t.Fatalf("chip should stay in column 9: falling=%+v heap[9]=%d", s.falling, len(s.heap[9]))
+	}
+}
+
+func TestCritClearsAWiderFootprintOutright(t *testing.T) {
+	text := "abcdefghijklmnopqrstuvwxyz0123456789"
+	build := func() *Scene {
+		g := screenWith(40, 8, 2, 4, text)
+		for x := 2; x < 2+len(text); x++ {
+			g.Set(x, 2, Cell{Content: "#", Width: 1})
+			g.Set(x, 6, Cell{Content: "#", Width: 1})
+		}
+		return New(g, 1)
+	}
+	cell := func(s *Scene, x, y int) string { return s.world.At(x, y).Content }
+
+	plain := build()
+	plain.impact(20, 4, false)
+	if cell(plain, 17, 4) != "▒" || cell(plain, 16, 4) == " " || cell(plain, 20, 2) != "#" {
+		t.Fatalf("a plain impact should crack ±3 on its row and leave rows ±2 alone: %q %q %q",
+			cell(plain, 17, 4), cell(plain, 16, 4), cell(plain, 20, 2))
+	}
+
+	crit := build()
+	crit.impact(20, 4, true)
+	for dx := -6; dx <= 6; dx++ {
+		if got := cell(crit, 20+dx, 4); got != " " {
+			t.Fatalf("crit left %q at dx=%d on its row; want everything within ±6 cleared", got, dx)
+		}
+	}
+	if cell(crit, 13, 4) == " " || cell(crit, 27, 4) == " " {
+		t.Fatal("crit reached past ±6 on its row")
+	}
+	if cell(crit, 20, 2) != " " || cell(crit, 24, 2) != " " || cell(crit, 25, 2) != "#" {
+		t.Fatalf("crit should clear rows ±2 out to ±4: %q %q %q", cell(crit, 20, 2), cell(crit, 24, 2), cell(crit, 25, 2))
+	}
+	for y := 0; y < crit.H; y++ {
+		for x := 0; x < crit.W; x++ {
+			if cell(crit, x, y) == "▒" {
+				t.Fatalf("crit cracked (%d,%d) instead of clearing it", x, y)
+			}
+		}
+	}
+	if crit.shake != critShake || !crit.bursts[0].big {
+		t.Fatalf("crit should shake longer with a big burst: shake=%d big=%v", crit.shake, crit.bursts[0].big)
+	}
+	if crit.bubble != quips[quipCrit] {
+		t.Fatalf("crit should say %q, got %q", quips[quipCrit], crit.bubble)
+	}
+}
+
+func TestCritProbeDrawsATrailAndOutlivesAPlainBurst(t *testing.T) {
+	// Tall frame, straight up: the shot is in the air far longer than any
+	// cooldown, so what fires below is not confused with what lands.
+	s := New(NewGrid(200, 60), 1)
+	settle(s)
+	s.Actor.Angle = 90
+	s.fire(true)
+	s.Step()
+	out := s.Render()
+	if !strings.Contains(out, "◉") || !strings.Contains(out, "✦") {
+		t.Fatal("a crit in flight should draw as ◉ with a ✦ trail")
+	}
+	px, py := int(math.Round(s.probes[0].x)), int(math.Round(s.probes[0].y))
+	if l, r := s.frame.At(px-1, py).Content, s.frame.At(px+1, py).Content; l != "◖" || r != "◗" {
+		t.Fatalf("the ball should be three cells wide, got %q ◉ %q", l, r)
+	}
+	// A crit holds the next shot longer than a plain one; the sim keeps running.
+	if s.Actor.cooldown != critCooldown-1 {
+		t.Fatalf("cooldown = %d one tick after a crit, want %d", s.Actor.cooldown, critCooldown-1)
+	}
+	for s.Actor.cooldown > 0 {
+		s.emit()
+		s.Step()
+	}
+	if len(s.probes) != 1 {
+		t.Fatalf("%d probes in the air; nothing should fire during the crit cooldown", len(s.probes))
+	}
+	s.emit()
+	if len(s.probes) != 2 {
+		t.Fatal("firing should work again once the crit cooldown has run out")
+	}
+	for i := 0; i < 400 && len(s.bursts) == 0; i++ {
+		s.Step()
+	}
+	if len(s.bursts) == 0 || !s.bursts[0].big {
+		t.Fatalf("crit impact should leave a big burst, got %+v", s.bursts)
+	}
+	s.Render()
+	b := s.bursts[0]
+	if got := s.frame.At(b.x, b.y).Style; !got.Equal(&critGlow) {
+		t.Fatalf("a big burst should draw in the crit palette, got %+v", got)
+	}
+	ticks := 0
+	for ; len(s.bursts) > 0 && ticks < 50; ticks++ {
+		s.Step()
+	}
+	if want := len(bursts)*burstFrame + bigBurstLag*burstFrame - 1; ticks != want {
+		t.Fatalf("big burst lived %d ticks, want %d", ticks, want)
+	}
+}
+
+func TestCritRollsAboutOneInEight(t *testing.T) {
+	s := New(NewGrid(40, 10), 7)
+	settle(s)
+	const shots = 800
+	crits := 0
+	for i := 0; i < shots; i++ {
+		s.Actor.cooldown = 0
+		s.emit()
+	}
+	if len(s.probes) != shots {
+		t.Fatalf("%d probes launched, want %d", len(s.probes), shots)
+	}
+	for _, p := range s.probes {
+		if p.crit {
+			crits++
+		}
+	}
+	if crits < shots/critOdds/2 || crits > shots/critOdds*2 {
+		t.Fatalf("%d crits in %d shots; want about 1 in %d", crits, shots, critOdds)
+	}
+	// Never back to back: at least critGap plain shots separate two crits.
+	since := critGap
+	for i, p := range s.probes {
+		if !p.crit {
+			since++
+			continue
+		}
+		if since < critGap {
+			t.Fatalf("shot %d crit only %d shots after the previous crit", i, since)
+		}
+		since = 0
+	}
+}
+
+func TestCritGapIsEnforcedEvenWhenTheRollWouldHit(t *testing.T) {
+	s := New(NewGrid(40, 10), 1)
+	settle(s)
+	s.fire(true)
+	for i := 0; i < 2000; i++ {
+		s.Actor.cooldown = 0
+		s.emit()
+	}
+	plain := 0
+	for _, p := range s.probes[1:] {
+		if p.crit {
+			break
+		}
+		plain++
+	}
+	if plain < critGap {
+		t.Fatalf("a crit came %d shots after a forced one, want at least %d", plain, critGap)
 	}
 }

--- a/internal/frost/scene_test.go
+++ b/internal/frost/scene_test.go
@@ -1,0 +1,353 @@
+package frost
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// screenWith builds a blank w×h frame with text written at (x, y).
+func screenWith(w, h, x, y int, text string) *Grid {
+	g := NewGrid(w, h)
+	for _, r := range text {
+		cw := ansi.StringWidth(string(r))
+		g.Set(x, y, Cell{Content: string(r), Width: cw})
+		x += cw
+	}
+	return g
+}
+
+// settle runs the entrance so the actor is parked and taking input.
+func settle(s *Scene) {
+	for i := 0; i < 100 && s.entering; i++ {
+		s.Step()
+	}
+}
+
+func TestMirrorIsAnInvolution(t *testing.T) {
+	for _, row := range spriteRows {
+		if got := mirrorRow(mirrorRow(row)); got != row {
+			t.Errorf("mirror twice: %q → %q", row, got)
+		}
+	}
+	for r, m := range mirror {
+		if back := mirror[m]; back != r {
+			t.Errorf("mirror[%q]=%q but mirror[%q]=%q", r, m, m, back)
+		}
+	}
+}
+
+func TestUnpackedAssetsHaveTheExpectedShape(t *testing.T) {
+	for i, row := range spriteRows {
+		if n := len([]rune(row)); n != SpriteW {
+			t.Errorf("row %d is %d wide, want %d", i, n, SpriteW)
+		}
+	}
+	if n := len([]rune(altBase)); n != SpriteW {
+		t.Errorf("altBase is %d wide, want %d", n, SpriteW)
+	}
+	for i, a := range arms {
+		if len(a.cells) != len(armGeom[i].at) {
+			t.Errorf("arm %d has %d cells, want %d", i, len(a.cells), len(armGeom[i].at))
+		}
+	}
+	for i, b := range bursts {
+		if len(b) != len(burstGeom[i]) {
+			t.Errorf("burst %d has %d cells, want %d", i, len(b), len(burstGeom[i]))
+		}
+	}
+	if len(card) != cardRows {
+		t.Fatalf("card has %d rows, want %d", len(card), cardRows)
+	}
+	if len(quips) < 8 {
+		t.Fatalf("only %d quips unpacked", len(quips))
+	}
+	w := len([]rune(card[0]))
+	for i, row := range card {
+		if n := len([]rune(row)); n != w {
+			t.Errorf("card row %d is %d wide, want %d", i, n, w)
+		}
+	}
+}
+
+func TestFreezeKeepsTextAndStyle(t *testing.T) {
+	frame := "ab\n" + "\x1b[38;2;217;119;87mcd\x1b[m"
+	g := Freeze(frame, 4, 2)
+	if got := g.At(0, 0).Content + g.At(1, 0).Content; got != "ab" {
+		t.Fatalf("row 0: got %q", got)
+	}
+	if c := g.At(0, 1); c.Content != "c" || c.Style.Fg == nil {
+		t.Fatalf("row 1 col 0: %+v, want styled c", c)
+	}
+	if c := g.At(2, 0); !c.Style.IsZero() || c.Content != " " {
+		t.Fatalf("unwritten cell should be a plain blank: %+v", c)
+	}
+	if got := ansi.Strip(g.Render(0)); got != "ab  \ncd  " {
+		t.Fatalf("render: %q", got)
+	}
+}
+
+func TestImpactCracksThenClearsAndShedsDebris(t *testing.T) {
+	s := New(screenWith(40, 10, 10, 3, "hello world"), 1)
+	settle(s)
+	// Hit the 'w' (x=16). The core — that cell and two either side — is
+	// cleared outright; the rest of the footprint only cracks.
+	s.impact(16, 3)
+	if got := ansi.Strip(s.world.Render(0)); !strings.Contains(got, "hel▒     ▒d") {
+		t.Fatalf("after one hit: %q", got)
+	}
+	if len(s.falling) == 0 {
+		t.Fatal("cleared glyphs should become debris")
+	}
+	if c := s.falling[0].cell.Content; c == " " || c == "▒" {
+		t.Fatalf("debris should carry the original glyph, got %q", c)
+	}
+	s.impact(16, 3)
+	if c := s.world.At(13, 3); c.Content != " " {
+		t.Fatalf("second hit should clear the cracked cell, got %q", c.Content)
+	}
+}
+
+func TestDebrisLandsAndActorClimbsIt(t *testing.T) {
+	s := New(NewGrid(40, 10), 1)
+	settle(s)
+	before := s.top()
+	under, _ := s.baseSpan()
+	for i := 0; i < 3; i++ {
+		s.falling = append(s.falling, Debris{x: float64(under + 3), y: 2, cell: Cell{Content: "x", Width: 1}})
+		for step := 0; step < 200 && len(s.falling) > 0; step++ {
+			s.stepDebris()
+		}
+	}
+	if len(s.falling) != 0 {
+		t.Fatal("debris never landed")
+	}
+	total := 0
+	for x := range s.heap {
+		total += len(s.heap[x])
+	}
+	if total != 3 {
+		t.Fatalf("heap holds %d cells, want 3", total)
+	}
+	if got := s.top(); got >= before {
+		t.Fatalf("actor should ride up on debris: top %d, was %d", got, before)
+	}
+}
+
+func TestHeapRelaxesIntoAMound(t *testing.T) {
+	s := New(NewGrid(20, 10), 1)
+	for i := 0; i < 6; i++ {
+		s.heap[10] = append(s.heap[10], Cell{Content: "x", Width: 1})
+	}
+	for i := 0; i < 50; i++ {
+		s.tick++
+		s.relaxHeap()
+	}
+	for x := 1; x < s.W; x++ {
+		if d := len(s.heap[x]) - len(s.heap[x-1]); d > 1 || d < -1 {
+			t.Fatalf("column %d differs from its neighbour by %d", x, d)
+		}
+	}
+}
+
+func TestProbeArcsAndHits(t *testing.T) {
+	s := New(screenWith(60, 12, 20, 6, "target"), 1)
+	settle(s)
+	s.Actor.Angle = 30
+	s.emit()
+	if len(s.probes) != 1 {
+		t.Fatal("emit should launch a probe")
+	}
+	hit := false
+	for i := 0; i < 400 && !hit; i++ {
+		s.Step()
+		hit = len(s.bursts) > 0
+	}
+	if !hit {
+		t.Fatal("probe never hit anything")
+	}
+	if len(s.probes) != 0 {
+		t.Fatal("a probe that hit should be gone")
+	}
+}
+
+func TestTraceStopsAtTheFirstHit(t *testing.T) {
+	s := New(screenWith(60, 12, 20, 9, "wall"), 1)
+	settle(s)
+	s.Actor.Facing, s.Actor.Angle = -1, 0
+	for _, d := range s.trace() {
+		if d[0] <= 23 && d[1] == 9 {
+			t.Fatalf("trace dot %v is inside the wall", d)
+		}
+	}
+}
+
+func TestDrivesInFromTheRightAndParks(t *testing.T) {
+	s := New(NewGrid(80, 24), 1)
+	if s.Actor.Facing != -1 || !s.entering {
+		t.Fatal("actor should start off-screen right, facing in")
+	}
+	if x0, _ := s.baseSpan(); x0 < 80 {
+		t.Fatalf("actor should start off-screen, base at %d", x0)
+	}
+	s.Key("space")
+	if len(s.probes) != 0 {
+		t.Fatal("input during the entrance should be ignored")
+	}
+	settle(s)
+	if s.entering {
+		t.Fatal("entrance never finished")
+	}
+	if x0, x1 := s.baseSpan(); x0 < 60 || x1 >= 80 {
+		t.Fatalf("base %d..%d should park at the right edge", x0, x1)
+	}
+	if s.bubble != quips[quipStart] || s.bubbleLeft == 0 {
+		t.Fatalf("should speak on arrival, got %q", s.bubble)
+	}
+}
+
+func TestEmitKicksBackAndDipsTheArm(t *testing.T) {
+	s := New(NewGrid(80, 24), 1)
+	settle(s)
+	x := s.Actor.X
+	s.emit()
+	if s.Actor.X != x+1 {
+		t.Fatalf("facing left, emit should kick right: %v → %v", x, s.Actor.X)
+	}
+	if s.Actor.recoil == 0 {
+		t.Fatal("recoil should be set")
+	}
+}
+
+func TestSpeaksOnFirstHitAndSessionGlyph(t *testing.T) {
+	s := New(screenWith(60, 20, 10, 3, "● run"), 1)
+	settle(s)
+	s.impact(13, 3) // the 'r'; ● sits in the ring and survives as a crack
+	if s.bubble != quips[quipFirstHit] {
+		t.Fatalf("first hit should say %q, got %q", quips[quipFirstHit], s.bubble)
+	}
+	s.impact(10, 3) // the ● itself
+	if s.bubble != quips[quipSessionHit] {
+		t.Fatalf("hitting a session glyph should say %q, got %q", quips[quipSessionHit], s.bubble)
+	}
+	// Each line is said once.
+	s.bubbleLeft = 0
+	s.impact(10, 3)
+	if s.bubbleLeft != 0 {
+		t.Fatal("a line should not repeat")
+	}
+}
+
+func TestExitCollapsesTheFrameThenFinishes(t *testing.T) {
+	s := New(screenWith(60, 16, 5, 2, "the whole frame comes down"), 1)
+	settle(s)
+	if s.Key("esc") {
+		t.Fatal("the first esc should start the collapse, not exit")
+	}
+	if !s.collapsing || s.Done() {
+		t.Fatal("collapse should be running")
+	}
+	for i := 0; i < collapseCap+5 && !s.Done(); i++ {
+		s.Step()
+	}
+	if !s.Done() {
+		t.Fatal("collapse never finished")
+	}
+	for y := 0; y < s.H; y++ {
+		for x := 0; x < s.W; x++ {
+			if s.damage[y*s.W+x] < 2 && s.world.Solid(x, y) {
+				t.Fatalf("cell (%d,%d) %q survived the collapse", x, y, s.world.At(x, y).Content)
+			}
+		}
+	}
+	total := 0
+	for x := range s.heap {
+		total += len(s.heap[x])
+	}
+	if total == 0 {
+		t.Fatal("the frame should have landed as debris")
+	}
+	// A second exit key during a collapse ends the run immediately.
+	s2 := New(NewGrid(40, 10), 1)
+	settle(s2)
+	s2.Key("q")
+	if !s2.Key("q") {
+		t.Fatal("second exit key should end the run at once")
+	}
+}
+
+func TestCardIsStampedAndTakesDamage(t *testing.T) {
+	s := New(NewGrid(80, 24), 1)
+	out := ansi.Strip(s.world.Render(0))
+	title := strings.TrimSpace(strings.Trim(card[1], "│"))
+	if !strings.Contains(out, title) {
+		t.Fatalf("card missing:\n%s", out)
+	}
+	for y := 0; y < s.H; y++ {
+		for x := 0; x < s.W; x++ {
+			if s.world.At(x, y).Content == "╭" {
+				s.impact(x+5, y)
+				if c := s.world.At(x+5, y); c.Content != " " {
+					t.Fatalf("card edge should be cleared at the impact, got %q", c.Content)
+				}
+				if len(s.falling) == 0 {
+					t.Fatal("card glyphs should fall as debris")
+				}
+				return
+			}
+		}
+	}
+	t.Fatal("card corner not found")
+}
+
+func TestCardSkippedOnATinyFrame(t *testing.T) {
+	s := New(NewGrid(20, 6), 1)
+	if strings.Contains(ansi.Strip(s.world.Render(0)), "╭") {
+		t.Fatal("card should not be stamped where it cannot fit")
+	}
+}
+
+func TestRenderIsAlwaysFullSize(t *testing.T) {
+	s := New(screenWith(30, 8, 3, 2, "abc 漢字 def"), 1)
+	settle(s)
+	s.Actor.Facing = -1
+	s.Actor.X = 0
+	s.emit()
+	s.bubble, s.bubbleLeft = "wide 漢 bubble", bubbleTicks
+	for i := 0; i < 30; i++ {
+		s.Step()
+		for shift := -1; shift <= 1; shift++ {
+			s.shake = 1
+			s.tick = shift + 1
+			out := ansi.Strip(s.Render())
+			for y, line := range strings.Split(out, "\n") {
+				if w := ansi.StringWidth(line); w != s.W {
+					t.Fatalf("tick %d row %d is %d wide, want %d: %q", i, y, w, s.W, line)
+				}
+			}
+		}
+	}
+}
+
+func TestKeysDriveAimEmitExit(t *testing.T) {
+	s := New(NewGrid(40, 10), 1)
+	settle(s)
+	s.Key("up")
+	if s.Actor.Angle != 50 {
+		t.Fatalf("angle %d, want 50", s.Actor.Angle)
+	}
+	s.Key("left")
+	if s.Actor.Facing != -1 || s.Actor.driveLeft == 0 {
+		t.Fatal("left should face left and start driving")
+	}
+	x := s.Actor.X
+	s.Step()
+	if s.Actor.X >= x {
+		t.Fatal("actor should have moved left")
+	}
+	s.Key("space")
+	if len(s.probes) != 1 {
+		t.Fatal("space should emit")
+	}
+}

--- a/internal/frost/scene_test.go
+++ b/internal/frost/scene_test.go
@@ -207,13 +207,13 @@ func TestDrivesInFromTheRightAndParks(t *testing.T) {
 	}
 }
 
-func TestEmitKicksBackAndDipsTheArm(t *testing.T) {
+func TestEmitDipsTheArmWithoutMoving(t *testing.T) {
 	s := New(NewGrid(80, 24), 1)
 	settle(s)
 	x := s.Actor.X
 	s.emit()
-	if s.Actor.X != x+1 {
-		t.Fatalf("facing left, emit should kick right: %v → %v", x, s.Actor.X)
+	if s.Actor.X != x {
+		t.Fatalf("emit must not move the actor: %v → %v", x, s.Actor.X)
 	}
 	if s.Actor.recoil == 0 {
 		t.Fatal("recoil should be set")

--- a/internal/frost/scene_test.go
+++ b/internal/frost/scene_test.go
@@ -351,3 +351,67 @@ func TestKeysDriveAimEmitExit(t *testing.T) {
 		t.Fatal("space should emit")
 	}
 }
+
+func TestFreezeClipsAnOversizedFrame(t *testing.T) {
+	// Bubble Tea clips a line wider than the terminal; a naive replay would
+	// wrap it and scroll the top row off.
+	g := Freeze("row0\nAAAAAAAAAA\nrow2", 8, 2)
+	var rows []string
+	for y := 0; y < 2; y++ {
+		var b strings.Builder
+		for x := 0; x < 8; x++ {
+			b.WriteString(g.At(x, y).Content)
+		}
+		rows = append(rows, b.String())
+	}
+	if rows[0] != "row0    " || rows[1] != "AAAAAAAA" {
+		t.Fatalf("rows = %q, want the first line kept and the second clipped", rows)
+	}
+}
+
+func TestSetBlanksTheSpacerOfTheGlyphItCovers(t *testing.T) {
+	g := NewGrid(6, 1)
+	g.Set(0, 0, Cell{Content: "🔥", Width: 2})
+	g.Set(2, 0, Cell{Content: "🔥", Width: 2})
+	g.Set(1, 0, Cell{Content: "🔥", Width: 2}) // covers the left half of the second
+	if c := g.At(3, 0); c.Width != 1 || c.Content != " " || g.Solid(3, 0) {
+		t.Fatalf("cell 3 = %+v (solid=%v), want a blank, not an orphaned spacer", c, g.Solid(3, 0))
+	}
+	if c := g.At(1, 0); c.Content != "🔥" || c.Width != 2 || g.At(2, 0).Width != 0 {
+		t.Fatalf("the glyph written last should own cells 1–2, got %+v / %+v", c, g.At(2, 0))
+	}
+}
+
+func TestWideGlyphShedsAOneColumnChip(t *testing.T) {
+	s := New(NewGrid(12, 4), 1)
+	s.fling(5, 3, Cell{Content: "🔥", Width: 2}, 0)
+	if len(s.falling) != 1 || s.falling[0].cell.Content != "▪" || s.falling[0].cell.Width != 1 {
+		t.Fatalf("falling = %+v, want one ▪ chip", s.falling)
+	}
+	// A heap holds one column per cell, so a chip beside another must render.
+	s.falling = nil
+	s.heap[5] = append(s.heap[5], Cell{Content: "▪", Width: 1})
+	s.heap[6] = append(s.heap[6], Cell{Content: "x", Width: 1})
+	s.Render()
+	if a, b := s.frame.At(5, 3).Content, s.frame.At(6, 3).Content; a != "▪" || b != "x" {
+		t.Fatalf("bottom row renders %q %q, want ▪ x", a, b)
+	}
+}
+
+func TestChipHittingAMoundSideStaysInItsColumn(t *testing.T) {
+	s := New(NewGrid(20, 10), 1)
+	for i := 0; i < 6; i++ {
+		s.heap[10] = append(s.heap[10], Cell{Content: "#", Width: 1})
+	}
+	// Row 8, drifting right into a mound whose top is at row 3.
+	s.falling = []Debris{{x: 9.4, y: 8, vx: 0.3, cell: Cell{Content: "c", Width: 1}}}
+	s.stepDebris()
+	if len(s.heap[10]) != 6 {
+		t.Fatalf("the chip was stacked on top of the mound it ran into (heap[10] = %d tall)", len(s.heap[10]))
+	}
+	landed := len(s.heap[9]) == 1
+	stillFalling := len(s.falling) == 1 && s.falling[0].x == 9 && s.falling[0].vx == 0
+	if !landed && !stillFalling {
+		t.Fatalf("chip should stay in column 9: falling=%+v heap[9]=%d", s.falling, len(s.heap[9]))
+	}
+}

--- a/internal/frost/scene_test.go
+++ b/internal/frost/scene_test.go
@@ -1,6 +1,7 @@
 package frost
 
 import (
+	"hash/fnv"
 	"math"
 	"strings"
 	"testing"
@@ -63,6 +64,9 @@ func TestUnpackedAssetsHaveTheExpectedShape(t *testing.T) {
 	}
 	if len(quips) != quipCount {
 		t.Fatalf("%d quips unpacked, want %d", len(quips), quipCount)
+	}
+	if g := Gate(); g.Label == "" || g.Keywords == "" || g.Prompt == "" || g.Wrong == "" || g.Hint == "" {
+		t.Fatalf("gate copy is incomplete: %+v", g)
 	}
 	w := len([]rune(card[0]))
 	for i, row := range card {
@@ -577,5 +581,24 @@ func TestCritGapIsEnforcedEvenWhenTheRollWouldHit(t *testing.T) {
 	}
 	if plain < critGap {
 		t.Fatalf("a crit came %d shots after a forced one, want at least %d", plain, critGap)
+	}
+}
+
+func TestUnlockIgnoresCaseAndSpace(t *testing.T) {
+	old := gateKey
+	defer func() { gateKey = old }()
+	f := fnv.New64a()
+	_, _ = f.Write([]byte("open sesame"))
+	gateKey = f.Sum64()
+
+	for _, ok := range []string{"open sesame", "  Open Sesame\t", "OPEN SESAME"} {
+		if !Unlock(ok) {
+			t.Errorf("Unlock(%q) = false", ok)
+		}
+	}
+	for _, bad := range []string{"", "open", "opensesame", "open sesame!"} {
+		if Unlock(bad) {
+			t.Errorf("Unlock(%q) = true", bad)
+		}
 	}
 }

--- a/internal/frost/world.go
+++ b/internal/frost/world.go
@@ -1,0 +1,164 @@
+package frost
+
+import (
+	"strings"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/vt"
+)
+
+// Cell is one screen cell: a grapheme, its column width and its style. Width
+// 2 is a wide glyph whose right half is a Width-0 spacer in the next cell.
+type Cell struct {
+	Content string
+	Width   int
+	Style   uv.Style
+}
+
+var blank = Cell{Content: " ", Width: 1}
+
+// Grid is a fixed-size buffer of cells, row-major.
+type Grid struct {
+	W, H  int
+	cells []Cell
+}
+
+// NewGrid returns a w×h grid of blanks.
+func NewGrid(w, h int) *Grid {
+	g := &Grid{W: w, H: h, cells: make([]Cell, w*h)}
+	for i := range g.cells {
+		g.cells[i] = blank
+	}
+	return g
+}
+
+// Freeze captures a rendered frame (an ANSI string, one line per row, as
+// Bubble Tea would paint it) into a Grid, styles intact. It replays the frame
+// through a virtual terminal rather than parsing escapes by hand, so anything
+// the real terminal would have shown — colors, bold, faint, wide glyphs —
+// lands in the right cell. Lines are joined with CRLF because the emulator
+// treats a bare LF as line-feed only.
+func Freeze(frame string, w, h int) *Grid {
+	g := NewGrid(w, h)
+	if w <= 0 || h <= 0 {
+		return g
+	}
+	emu := vt.NewEmulator(w, h)
+	_, _ = emu.Write([]byte(strings.ReplaceAll(frame, "\n", "\r\n")))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			c := emu.CellAt(x, y)
+			if c == nil {
+				continue
+			}
+			cell := Cell{Content: c.Content, Width: c.Width, Style: c.Style}
+			if cell.Content == "" && cell.Width != 0 {
+				cell = Cell{Content: " ", Width: 1, Style: c.Style}
+			}
+			g.cells[y*w+x] = cell
+		}
+	}
+	return g
+}
+
+// In reports whether (x, y) is inside the grid.
+func (g *Grid) In(x, y int) bool { return x >= 0 && x < g.W && y >= 0 && y < g.H }
+
+// At returns the cell at (x, y), or a blank outside the grid.
+func (g *Grid) At(x, y int) Cell {
+	if !g.In(x, y) {
+		return blank
+	}
+	return g.cells[y*g.W+x]
+}
+
+// Set writes a cell, keeping wide glyphs consistent: overwriting either half of
+// a wide glyph blanks the other half, so a row never comes out a column short.
+func (g *Grid) Set(x, y int, c Cell) {
+	if !g.In(x, y) {
+		return
+	}
+	i := y*g.W + x
+	switch g.cells[i].Width {
+	case 2:
+		if x+1 < g.W {
+			g.cells[i+1] = blank
+		}
+	case 0:
+		if x > 0 {
+			g.cells[i-1] = blank
+		}
+	}
+	if c.Width == 0 {
+		c.Width = 1
+	}
+	if c.Content == "" {
+		c.Content = " "
+	}
+	if c.Width == 1 && ansi.StringWidth(c.Content) == 2 {
+		c.Width = 2 // a caller that guessed wrong would leave the row a column wide
+	}
+	g.cells[i] = c
+	if c.Width == 2 {
+		if x+1 < g.W {
+			g.cells[i+1] = Cell{Width: 0}
+		} else {
+			g.cells[i] = blank
+		}
+	}
+}
+
+// CopyFrom overwrites this grid with src's cells (same dimensions assumed).
+func (g *Grid) CopyFrom(src *Grid) { copy(g.cells, src.cells) }
+
+// Solid reports whether the cell is something a probe stops on: any visible
+// glyph, or a space carrying a background fill (a selection pill is a wall).
+func (g *Grid) Solid(x, y int) bool {
+	if !g.In(x, y) {
+		return false
+	}
+	c := g.cells[y*g.W+x]
+	if c.Width == 0 {
+		return true // right half of a wide glyph
+	}
+	return (c.Content != "" && c.Content != " ") || c.Style.Bg != nil
+}
+
+// Render serialises the grid as one ANSI line per row, emitting a style
+// sequence only where the style changes. shift moves the whole picture that
+// many columns (screen shake); cells shifted off an edge are dropped and the
+// vacated edge is blank.
+func (g *Grid) Render(shift int) string {
+	var b strings.Builder
+	b.Grow(g.W * g.H * 4)
+	for y := 0; y < g.H; y++ {
+		if y > 0 {
+			b.WriteByte('\n')
+		}
+		var cur uv.Style
+		for col := 0; col < g.W; {
+			c := blank
+			if sx := col - shift; sx >= 0 && sx < g.W {
+				c = g.cells[y*g.W+sx]
+			}
+			if c.Width == 2 && col+1 >= g.W {
+				c = blank
+			}
+			if c.Width == 0 || c.Content == "" {
+				c = Cell{Content: " ", Width: 1, Style: c.Style}
+			}
+			if !c.Style.Equal(&cur) {
+				b.WriteString(ansi.ResetStyle)
+				if !c.Style.IsZero() {
+					b.WriteString(c.Style.String())
+				}
+				cur = c.Style
+			}
+			b.WriteString(c.Content)
+			col += c.Width
+		}
+		b.WriteString(ansi.ResetStyle)
+	}
+	return b.String()
+}

--- a/internal/frost/world.go
+++ b/internal/frost/world.go
@@ -39,13 +39,24 @@ func NewGrid(w, h int) *Grid {
 // the real terminal would have shown — colors, bold, faint, wide glyphs —
 // lands in the right cell. Lines are joined with CRLF because the emulator
 // treats a bare LF as line-feed only.
+//
+// The frame is clipped to w×h first. Bubble Tea's renderer clips what it
+// paints, so a line wider than the terminal is invisible live — but the
+// emulator would wrap it and scroll the top row away.
 func Freeze(frame string, w, h int) *Grid {
 	g := NewGrid(w, h)
 	if w <= 0 || h <= 0 {
 		return g
 	}
+	lines := strings.Split(frame, "\n")
+	if len(lines) > h {
+		lines = lines[:h]
+	}
+	for i, line := range lines {
+		lines[i] = ansi.Truncate(line, w, "")
+	}
 	emu := vt.NewEmulator(w, h)
-	_, _ = emu.Write([]byte(strings.ReplaceAll(frame, "\n", "\r\n")))
+	_, _ = emu.Write([]byte(strings.Join(lines, "\r\n")))
 	for y := 0; y < h; y++ {
 		for x := 0; x < w; x++ {
 			c := emu.CellAt(x, y)
@@ -102,6 +113,9 @@ func (g *Grid) Set(x, y int, c Cell) {
 	g.cells[i] = c
 	if c.Width == 2 {
 		if x+1 < g.W {
+			if g.cells[i+1].Width == 2 && x+2 < g.W {
+				g.cells[i+2] = blank // the glyph being covered owned that spacer
+			}
 			g.cells[i+1] = Cell{Width: 0}
 		} else {
 			g.cells[i] = blank

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -257,6 +257,7 @@ type Home struct {
 	newDialog             *NewSessionDialog
 	confirmDialog         *ConfirmDialog
 	renameDialog          *RenameDialog
+	gate                  *gateDialog
 	helpOverlay           *HelpOverlay
 	settingsDialog        *SettingsDialog
 	worktreeDialog        *WorktreeDialog
@@ -586,6 +587,7 @@ func NewHome(storage *session.StateDB, cfg *config.Config, version string, ident
 		newDialog:              NewNewSessionDialog(),
 		confirmDialog:          NewConfirmDialog(),
 		renameDialog:           NewRenameDialog(),
+		gate:                   newGateDialog(),
 		helpOverlay:            NewHelpOverlay(),
 		settingsDialog:         NewSettingsDialog(cfg),
 		worktreeDialog:         NewWorktreeDialog(),
@@ -886,6 +888,7 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.newDialog.SetSize(msg.Width, msg.Height)
 		h.confirmDialog.SetSize(msg.Width, msg.Height)
 		h.renameDialog.SetSize(msg.Width, msg.Height)
+		h.gate.SetSize(msg.Width, msg.Height)
 		h.helpOverlay.SetSize(msg.Width, msg.Height)
 		h.settingsDialog.SetSize(msg.Width, msg.Height)
 		h.worktreeDialog.SetSize(msg.Width, msg.Height)
@@ -2390,6 +2393,7 @@ func (h *Home) modalOpen() bool {
 		h.newDialog.IsVisible() ||
 		h.confirmDialog.IsVisible() ||
 		h.renameDialog.IsVisible() ||
+		h.gate.IsVisible() ||
 		h.commandPalette.IsVisible() ||
 		h.contextMenu.IsVisible() ||
 		h.snoozeDialog.IsVisible() ||
@@ -2449,6 +2453,9 @@ func (h *Home) renderBody() string {
 	}
 	if h.renameDialog.IsVisible() {
 		return h.renameDialog.View()
+	}
+	if h.gate.IsVisible() {
+		return h.gate.View()
 	}
 
 	// First-run launchpad owns the screen while the fleet is empty.
@@ -2784,6 +2791,10 @@ func (h *Home) routeToModal(msg tea.Msg) (tea.Cmd, bool) {
 	case h.renameDialog.IsVisible():
 		dialog, cmd := h.renameDialog.Update(msg)
 		h.renameDialog = dialog
+		return cmd, true
+	case h.gate.IsVisible():
+		dialog, cmd := h.gate.Update(msg)
+		h.gate = dialog
 		return cmd, true
 	}
 	return nil, false
@@ -8610,6 +8621,7 @@ func (h *Home) buildPaletteItems() []PaletteItem {
 		{Kind: PaletteKindCommand, ID: "whats_new", Name: "What's New", Shortcut: "Shift+W"},
 		{Kind: PaletteKindCommand, ID: "release_notes", Name: "Release Notes"},
 		{Kind: PaletteKindCommand, ID: "reload_all", Name: "Reload All Sessions"},
+		{Kind: PaletteKindCommand, ID: "frost_gate", Name: frost.Gate().Label, Haystack: frost.Gate().Label + " " + frost.Gate().Keywords, Hidden: true},
 		{Kind: PaletteKindCommand, ID: "suspend_session", Name: "Suspend This Session"},
 		{Kind: PaletteKindCommand, ID: "suspend_now", Name: "Suspend Idle Sessions Now"},
 		{Kind: PaletteKindCommand, ID: "mark_all_read", Name: "Mark All as Read"},
@@ -8626,7 +8638,9 @@ func (h *Home) buildPaletteItems() []PaletteItem {
 		commands = append(commands, PaletteItem{Kind: PaletteKindCommand, ID: "open_fda", Name: "Open Full Disk Access Settings"})
 	}
 	for i := range commands {
-		commands[i].Haystack = commands[i].Name
+		if commands[i].Haystack == "" {
+			commands[i].Haystack = commands[i].Name
+		}
 	}
 
 	// Lock-free read of the immutable git/PR snapshot.
@@ -8810,6 +8824,9 @@ func (h *Home) dispatchCommand(id string) (tea.Model, tea.Cmd) {
 		h.connectJira.Show()
 		return h, nil
 
+	case "frost_gate":
+		h.gate.Show()
+		return h, nil
 	case "connect_linear":
 		h.actionLog.Add("connect linear", "", true)
 		// Opening the dialog is the feature the tip teaches, so this is where

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -866,8 +866,9 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		h.renderStats.RecordResize(msg.Width, msg.Height)
+		resized := msg.Width != h.width || msg.Height != h.height
 		// Only log resizes after the initial one (startup always sends one).
-		if h.width > 0 && (msg.Width != h.width || msg.Height != h.height) {
+		if h.width > 0 && resized {
 			debuglog.Logger.Info("window resized",
 				"from", fmt.Sprintf("%dx%d", h.width, h.height),
 				"to", fmt.Sprintf("%dx%d", msg.Width, msg.Height),
@@ -877,7 +878,9 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.width = msg.Width
 		h.height = msg.Height
 		h.sidebarDirty = true
-		if h.frost != nil {
+		// Bubble Tea sends one of these on every SIGWINCH, size change or not —
+		// a tmux client attaching is enough — so only a real change ends the run.
+		if h.frost != nil && resized {
 			h.endFrost() // the frozen frame no longer fits
 		}
 		h.newDialog.SetSize(msg.Width, msg.Height)
@@ -2218,8 +2221,24 @@ func (h *Home) View() tea.View {
 		return h.chrome(RenderSplash(h.width, h.height, h.bootProgress(), h.splashFrame))
 	}
 	if h.frost != nil {
-		return h.chrome(h.frost.Render())
+		// The run owns the keys, not the toasts: worker and async results still
+		// land, and an error raised mid-run has to be shown before its TTL
+		// prunes it. The tip is already held back by modalOpen.
+		base := h.frost.Render()
+		if toast := h.toasts.View(h.width); toast != "" {
+			base = h.anchorBottomRight(toast, base)
+		}
+		return h.chrome(base)
 	}
+	return h.chrome(h.composeScreen())
+}
+
+// composeScreen paints everything View shows once the app is up: the body,
+// the header overlays, any dropdown or palette, and the tip/toast stack. It
+// is what a caller freezing "the current frame" wants — beginQuit's dimmed
+// backdrop and the frost freeze both take it — so a frozen picture matches
+// the live one instead of renderBody alone.
+func (h *Home) composeScreen() string {
 	base := h.renderBody()
 	// Animated "What's New" badge, top-right of the header row. Only when there
 	// are unseen highlights and no modal owns the screen (a modal makes
@@ -2293,10 +2312,9 @@ func (h *Home) View() tea.View {
 	}
 	toast := h.toasts.View(h.width)
 	if tip == "" && toast == "" {
-		return h.chrome(base)
+		return base
 	}
-	// Stack toast(s) above the tip, then anchor the block bottom-right with a
-	// 1-cell right margin and a 1-row lift so it clears the help-bar baseline.
+	// Stack toast(s) above the tip.
 	stack := toast
 	if tip != "" {
 		if stack != "" {
@@ -2305,9 +2323,15 @@ func (h *Home) View() tea.View {
 			stack = tip
 		}
 	}
-	x := h.width - lipgloss.Width(stack) - 1
-	y := h.height - lipgloss.Height(stack) - 1
-	return h.chrome(overlayAt(stack, base, x, y))
+	return h.anchorBottomRight(stack, base)
+}
+
+// anchorBottomRight composites block onto base at the bottom-right, with a
+// 1-cell right margin and a 1-row lift so it clears the help-bar baseline.
+func (h *Home) anchorBottomRight(block, base string) string {
+	x := h.width - lipgloss.Width(block) - 1
+	y := h.height - lipgloss.Height(block) - 1
+	return overlayAt(block, base, x, y)
 }
 
 // chrome wraps rendered content into the tea.View that carries fleet's terminal
@@ -2809,12 +2833,16 @@ func (h *Home) handlePaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 }
 
 func (h *Home) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	// An active frost run owns every key until the user leaves it.
+	// An active frost run owns every key until the user leaves it — except
+	// fleet's own quit key, which ends the run and quits, as the help bar says.
 	if h.frost != nil {
-		if h.frost.Key(normalizeKey(msg).String()) {
-			h.endFrost()
+		if msg.String() != "ctrl+c" {
+			if h.frost.Key(normalizeKey(msg).String()) {
+				h.endFrost()
+			}
+			return h, nil
 		}
-		return h, nil
+		h.endFrost()
 	}
 
 	// Route to the active modal dialog/overlay first (keys + paste share this).
@@ -3261,7 +3289,7 @@ func (h *Home) beginQuit(source string) tea.Cmd {
 	case !h.booted:
 		h.frozenFrame = RenderSplash(h.width, h.height, h.bootProgress(), h.splashFrame)
 	default:
-		h.frozenFrame = h.renderBody()
+		h.frozenFrame = h.composeScreen()
 	}
 	h.cancel() // stop the worker now so it stops feeding Update
 	return tea.Batch(h.shutdownTick(), h.performShutdown())

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1305,6 +1305,11 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case commandPaletteMsg:
 		return h.dispatchPaletteSelection(msg)
 
+	case gateOpenMsg:
+		// The prompt has already closed itself, so the frozen frame is the
+		// ordinary screen, not the prompt.
+		return h, h.startFrost()
+
 	case snoozeSelectedMsg:
 		// Same discipline as contextMenuMsg: the picker names a row, and an
 		// async rebuild may have moved the cursor while it was open, so put the

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -29,6 +29,7 @@ import (
 	"github.com/brizzai/fleet/internal/debuglog"
 	"github.com/brizzai/fleet/internal/discovery"
 	"github.com/brizzai/fleet/internal/editor"
+	"github.com/brizzai/fleet/internal/frost"
 	"github.com/brizzai/fleet/internal/git"
 	"github.com/brizzai/fleet/internal/github"
 	"github.com/brizzai/fleet/internal/hooks"
@@ -543,6 +544,11 @@ type Home struct {
 	shutdownFrame int
 	frozenFrame   string
 
+	// Frost mode (frost.go). frost is nil unless a run is active; keyTrail is
+	// the trailing window of sidebar keys its trigger matches against.
+	frost    *frost.Scene
+	keyTrail []string
+
 	// Rendering diagnostics (accumulated counters for bug reports).
 	renderStats RenderStats
 }
@@ -871,6 +877,9 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.width = msg.Width
 		h.height = msg.Height
 		h.sidebarDirty = true
+		if h.frost != nil {
+			h.endFrost() // the frozen frame no longer fits
+		}
 		h.newDialog.SetSize(msg.Width, msg.Height)
 		h.confirmDialog.SetSize(msg.Width, msg.Height)
 		h.renameDialog.SetSize(msg.Width, msg.Height)
@@ -1902,6 +1911,18 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
+	case frostTickMsg:
+		// Self-rescheduling only while a run is active.
+		if h.frost == nil {
+			return h, nil
+		}
+		h.frost.Step()
+		if h.frost.Done() {
+			h.endFrost()
+			return h, nil
+		}
+		return h, frostTickCmd()
+
 	case whatsNewTickMsg:
 		// Advance the badge shimmer; stop the loop (and stop burning CPU) the
 		// moment the badge is hidden or a modal takes the screen.
@@ -2196,6 +2217,9 @@ func (h *Home) View() tea.View {
 	if !h.booted {
 		return h.chrome(RenderSplash(h.width, h.height, h.bootProgress(), h.splashFrame))
 	}
+	if h.frost != nil {
+		return h.chrome(h.frost.Render())
+	}
 	base := h.renderBody()
 	// Animated "What's New" badge, top-right of the header row. Only when there
 	// are unseen highlights and no modal owns the screen (a modal makes
@@ -2347,6 +2371,7 @@ func (h *Home) modalOpen() bool {
 		h.snoozeDialog.IsVisible() ||
 		h.accountPicker.IsVisible() ||
 		h.allowedAccounts.IsVisible() ||
+		h.frost != nil ||
 		h.launchpadActive()
 }
 
@@ -2784,6 +2809,14 @@ func (h *Home) handlePaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 }
 
 func (h *Home) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	// An active frost run owns every key until the user leaves it.
+	if h.frost != nil {
+		if h.frost.Key(normalizeKey(msg).String()) {
+			h.endFrost()
+		}
+		return h, nil
+	}
+
 	// Route to the active modal dialog/overlay first (keys + paste share this).
 	if cmd, handled := h.routeToModal(msg); handled {
 		return h, cmd
@@ -2894,6 +2927,12 @@ func (h *Home) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// falls through rather than returning; it owns no text and matches on the US
 	// position itself, above.)
 	msg = normalizeKey(msg)
+
+	// Frost trigger (see noteTrail). Every key of the run still does its
+	// usual job; only the one that completes it is taken.
+	if h.noteTrail(msg.String()) {
+		return h, h.startFrost()
+	}
 
 	switch msg.String() {
 	case "`": // open the terminal drawer + move focus into it

--- a/internal/ui/command_palette.go
+++ b/internal/ui/command_palette.go
@@ -46,6 +46,10 @@ type PaletteItem struct {
 	Shortcut string // right-aligned keybinding hint (commands only)
 	Haystack string // string used for fuzzy matching
 
+	// Hidden rows surface only on a search that matches them, never in the
+	// unfiltered list (and so never as a recent either).
+	Hidden bool
+
 	// Group is a section header this row sits under when nothing is typed
 	// (ticket rows only — their Linear state). Empty means no section.
 	Group string
@@ -278,6 +282,9 @@ func (d *CommandPaletteDialog) rebuildFiltered() {
 	haystacks := make([]string, 0, len(d.items))
 	for _, it := range d.items {
 		if !itemMatchesTab(it, d.activeTab) || d.scopedOut(it, d.activeTab) {
+			continue
+		}
+		if it.Hidden && query == "" {
 			continue
 		}
 		tabItems = append(tabItems, it)

--- a/internal/ui/frost.go
+++ b/internal/ui/frost.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"hash/fnv"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/brizzai/fleet/internal/analytics"
+	"github.com/brizzai/fleet/internal/debuglog"
+	"github.com/brizzai/fleet/internal/frost"
+)
+
+// Frost mode: a particular run of sidebar keys freezes the frame into a cell
+// grid and hands it to internal/frost. This file is the trigger, the freeze
+// and the tick loop; everything else lives there.
+
+type frostTickMsg struct{}
+
+// frostTickInterval is the sim's frame time. 20 fps is plenty for cell-sized
+// motion, and every tick repaints the whole screen.
+const frostTickInterval = 50 * time.Millisecond
+
+// frostTickCmd paces the sim. Deliberately not gated on FreezeAnim: that flag
+// stills decorative loops so screen captures settle, and a frost run only
+// exists because someone asked for it — frozen, a capture would show nothing
+// of what it does.
+func frostTickCmd() tea.Cmd {
+	return tea.Tick(frostTickInterval, func(time.Time) tea.Msg { return frostTickMsg{} })
+}
+
+// A run of trailLen sidebar keys, matched by hash. Every key of it still does
+// its ordinary job; only the one that completes the run is taken.
+const trailLen = 8
+
+var trailKey uint64 = 0xd556428827d09ca5
+
+// noteTrail feeds one sidebar keypress into the detector and reports whether
+// it completed the run. The state is the last trailLen keys, so a stutter
+// (a key repeated once too often) still completes on the next try.
+func (h *Home) noteTrail(key string) bool {
+	h.keyTrail = append(h.keyTrail, key)
+	if len(h.keyTrail) > trailLen {
+		h.keyTrail = h.keyTrail[1:]
+	}
+	if len(h.keyTrail) < trailLen {
+		return false
+	}
+	f := fnv.New64a()
+	for _, k := range h.keyTrail {
+		_, _ = f.Write([]byte(k))
+		_, _ = f.Write([]byte{0})
+	}
+	if f.Sum64() != trailKey {
+		return false
+	}
+	h.keyTrail = nil
+	return true
+}
+
+// startFrost freezes what is on screen and starts the sim over it.
+func (h *Home) startFrost() tea.Cmd {
+	if h.width == 0 || !h.booted || h.frost != nil {
+		return nil
+	}
+	debuglog.Logger.Info("frost: start", "size", h.width*h.height)
+	h.actionLog.Add("frost", "start", true)
+	analytics.Track(analytics.EventFrostMode, nil)
+	screen := frost.Freeze(h.renderBody(), h.width, h.height)
+	h.frost = frost.New(screen, uint64(time.Now().UnixNano()))
+	return frostTickCmd()
+}
+
+// endFrost drops the sim; the next View paints the live UI again.
+func (h *Home) endFrost() {
+	h.frost = nil
+	h.sidebarDirty = true
+}

--- a/internal/ui/frost.go
+++ b/internal/ui/frost.go
@@ -66,7 +66,7 @@ func (h *Home) startFrost() tea.Cmd {
 	debuglog.Logger.Info("frost: start", "size", h.width*h.height)
 	h.actionLog.Add("frost", "start", true)
 	analytics.Track(analytics.EventFrostMode, nil)
-	screen := frost.Freeze(h.renderBody(), h.width, h.height)
+	screen := frost.Freeze(h.composeScreen(), h.width, h.height)
 	h.frost = frost.New(screen, uint64(time.Now().UnixNano()))
 	return frostTickCmd()
 }

--- a/internal/ui/frost_gate.go
+++ b/internal/ui/frost_gate.go
@@ -10,17 +10,21 @@ import (
 	"github.com/brizzai/fleet/internal/frost"
 )
 
-// gateDialog is the palette-side front of frost mode: a small prompt that
-// takes an answer and, given the right one, drops a hint. Its palette row is
-// hidden until a search matches it, and every line of copy comes from the
-// frost package, so nothing here says what it is for.
+// gateOpenMsg is sent when the prompt has been answered correctly and has
+// closed itself; the app starts a run in reply.
+type gateOpenMsg struct{}
+
+// gateDialog is the palette-side front of frost mode. It names the other way
+// in — a key sequence, hinted at but not spelled out — and takes an answer as
+// a shortcut past it. Its palette row is hidden until a search matches it,
+// and every line of copy comes from the frost package, so nothing here says
+// what it is for.
 type gateDialog struct {
 	input   textinput.Model
 	visible bool
 	width   int
 	height  int
-	note    string // what the last answer earned: nothing yet, the wrong line, or the hint
-	open    bool   // the answer was right; enter now closes
+	note    string // what the last answer earned: nothing yet, or the wrong line
 
 	// unlock checks an answer. A field so a test can install its own.
 	unlock func(string) bool
@@ -37,7 +41,6 @@ func newGateDialog() *gateDialog {
 // Show opens the prompt fresh: empty answer, nothing said yet.
 func (d *gateDialog) Show() {
 	d.visible = true
-	d.open = false
 	d.note = ""
 	d.input.SetValue("")
 	d.input.Focus()
@@ -57,23 +60,14 @@ func (d *gateDialog) Update(msg tea.Msg) (*gateDialog, tea.Cmd) {
 			d.Hide()
 			return d, nil
 		case "enter":
-			if d.open {
-				d.Hide()
-				return d, nil
-			}
 			if d.unlock(d.input.Value()) {
-				d.open = true
-				d.note = frost.Gate().Hint
-				d.input.Blur()
-				return d, nil
+				d.Hide()
+				return d, func() tea.Msg { return gateOpenMsg{} }
 			}
 			d.note = frost.Gate().Wrong
 			d.input.SetValue("")
 			return d, nil
 		}
-	}
-	if d.open {
-		return d, nil
 	}
 	var cmd tea.Cmd
 	d.input, cmd = d.input.Update(msg)
@@ -85,21 +79,17 @@ func (d *gateDialog) View() string {
 	var b strings.Builder
 	b.WriteString(TitleStyle.Render(g.Label))
 	b.WriteString("\n\n")
-	if d.open {
-		b.WriteString(g.Hint)
+	b.WriteString(g.Hint)
+	b.WriteString("\n\n")
+	b.WriteString(DimStyle.Render(g.Prompt))
+	b.WriteString("\n")
+	b.WriteString(d.input.View())
+	b.WriteString("\n\n")
+	if d.note != "" {
+		b.WriteString(ErrorStyle.Render(d.note))
 		b.WriteString("\n\n")
-		b.WriteString(DimStyle.Render("enter: close"))
-	} else {
-		b.WriteString(DimStyle.Render(g.Prompt))
-		b.WriteString("\n")
-		b.WriteString(d.input.View())
-		b.WriteString("\n\n")
-		if d.note != "" {
-			b.WriteString(ErrorStyle.Render(d.note))
-			b.WriteString("\n\n")
-		}
-		b.WriteString(DimStyle.Render("enter: answer • esc: close"))
 	}
+	b.WriteString(DimStyle.Render("enter: try • esc: close"))
 
 	dialogWidth := min(max(d.width-4, 30), 64)
 	box := DialogStyle.Width(dialogWidth).Render(b.String())

--- a/internal/ui/frost_gate.go
+++ b/internal/ui/frost_gate.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/brizzai/fleet/internal/frost"
+)
+
+// gateDialog is the palette-side front of frost mode: a small prompt that
+// takes an answer and, given the right one, drops a hint. Its palette row is
+// hidden until a search matches it, and every line of copy comes from the
+// frost package, so nothing here says what it is for.
+type gateDialog struct {
+	input   textinput.Model
+	visible bool
+	width   int
+	height  int
+	note    string // what the last answer earned: nothing yet, the wrong line, or the hint
+	open    bool   // the answer was right; enter now closes
+
+	// unlock checks an answer. A field so a test can install its own.
+	unlock func(string) bool
+}
+
+func newGateDialog() *gateDialog {
+	ti := NewTextInput()
+	ti.EchoMode = textinput.EchoPassword
+	ti.CharLimit = 64
+	ti.SetWidth(32)
+	return &gateDialog{input: ti, unlock: frost.Unlock}
+}
+
+// Show opens the prompt fresh: empty answer, nothing said yet.
+func (d *gateDialog) Show() {
+	d.visible = true
+	d.open = false
+	d.note = ""
+	d.input.SetValue("")
+	d.input.Focus()
+}
+
+func (d *gateDialog) Hide()           { d.visible = false; d.input.Blur() }
+func (d *gateDialog) IsVisible() bool { return d.visible }
+func (d *gateDialog) SetSize(w, h int) {
+	d.width = w
+	d.height = h
+}
+
+func (d *gateDialog) Update(msg tea.Msg) (*gateDialog, tea.Cmd) {
+	if key, ok := msg.(tea.KeyMsg); ok {
+		switch key.String() {
+		case "esc":
+			d.Hide()
+			return d, nil
+		case "enter":
+			if d.open {
+				d.Hide()
+				return d, nil
+			}
+			if d.unlock(d.input.Value()) {
+				d.open = true
+				d.note = frost.Gate().Hint
+				d.input.Blur()
+				return d, nil
+			}
+			d.note = frost.Gate().Wrong
+			d.input.SetValue("")
+			return d, nil
+		}
+	}
+	if d.open {
+		return d, nil
+	}
+	var cmd tea.Cmd
+	d.input, cmd = d.input.Update(msg)
+	return d, cmd
+}
+
+func (d *gateDialog) View() string {
+	g := frost.Gate()
+	var b strings.Builder
+	b.WriteString(TitleStyle.Render(g.Label))
+	b.WriteString("\n\n")
+	if d.open {
+		b.WriteString(g.Hint)
+		b.WriteString("\n\n")
+		b.WriteString(DimStyle.Render("enter: close"))
+	} else {
+		b.WriteString(DimStyle.Render(g.Prompt))
+		b.WriteString("\n")
+		b.WriteString(d.input.View())
+		b.WriteString("\n\n")
+		if d.note != "" {
+			b.WriteString(ErrorStyle.Render(d.note))
+			b.WriteString("\n\n")
+		}
+		b.WriteString(DimStyle.Render("enter: answer • esc: close"))
+	}
+
+	dialogWidth := min(max(d.width-4, 30), 64)
+	box := DialogStyle.Width(dialogWidth).Render(b.String())
+	return lipgloss.Place(d.width, d.height, lipgloss.Center, lipgloss.Center, box)
+}

--- a/internal/ui/frost_test.go
+++ b/internal/ui/frost_test.go
@@ -1,0 +1,62 @@
+package ui
+
+import (
+	"hash/fnv"
+	"testing"
+)
+
+// trailOf is the detector's own hash of a key run, so a test can install a
+// run of its choosing.
+func trailOf(keys ...string) uint64 {
+	f := fnv.New64a()
+	for _, k := range keys {
+		_, _ = f.Write([]byte(k))
+		_, _ = f.Write([]byte{0})
+	}
+	return f.Sum64()
+}
+
+func TestTrailFiresOnlyOnTheFullRun(t *testing.T) {
+	run := []string{"x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8"}
+	old := trailKey
+	trailKey = trailOf(run...)
+	defer func() { trailKey = old }()
+
+	h := &Home{}
+	for i, k := range run {
+		if fire := h.noteTrail(k); fire != (i == len(run)-1) {
+			t.Fatalf("key %d %q: fire=%v", i, k, fire)
+		}
+	}
+	if len(h.keyTrail) != 0 {
+		t.Fatalf("detector should reset after firing, got %v", h.keyTrail)
+	}
+	// A stray key mid-run breaks it; repeating the run from the top completes.
+	for _, k := range append([]string{"x1", "x2", "j"}, run...) {
+		if h.noteTrail(k) && k != "x8" {
+			t.Fatalf("fired early at %q", k)
+		}
+	}
+	// A stutter on the first key still completes: the last eight are the run.
+	h.keyTrail = nil
+	for _, k := range append([]string{"x1"}, run...) {
+		if h.noteTrail(k) && k != "x8" {
+			t.Fatalf("fired early at %q", k)
+		}
+	}
+	if len(h.keyTrail) != 0 {
+		t.Fatal("the stuttered run should have fired and reset")
+	}
+}
+
+func TestTrailNeverFiresOnPlainNavigation(t *testing.T) {
+	h := &Home{}
+	for _, k := range []string{"j", "j", "k", "k", "enter", "space", "j", "k", "j", "k", "a", "d"} {
+		if h.noteTrail(k) {
+			t.Fatalf("fired on %q", k)
+		}
+	}
+	if len(h.keyTrail) != trailLen {
+		t.Fatalf("trail should stay bounded at %d, got %d", trailLen, len(h.keyTrail))
+	}
+}

--- a/internal/ui/frost_test.go
+++ b/internal/ui/frost_test.go
@@ -124,7 +124,7 @@ func TestHiddenPaletteRowSurfacesOnlyOnASearch(t *testing.T) {
 	}
 }
 
-func TestGateRevealsTheHintOnlyToTheRightAnswer(t *testing.T) {
+func TestGateShowsTheHintAndOpensOnTheRightAnswer(t *testing.T) {
 	d := newGateDialog()
 	d.unlock = func(a string) bool { return a == "yes" }
 	d.SetSize(80, 24)
@@ -136,34 +136,35 @@ func TestGateRevealsTheHintOnlyToTheRightAnswer(t *testing.T) {
 		}
 	}
 	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	// The box wraps a long line, so look for the hint's opening words.
+	opening := strings.Join(strings.Fields(frost.Gate().Hint)[:2], " ")
+
+	// The hint is the other way in, so it shows before any answer is given.
+	if v := d.View(); !strings.Contains(v, opening) || !strings.Contains(v, frost.Gate().Label) || !strings.Contains(v, frost.Gate().Prompt) {
+		t.Fatal("the prompt should show the label, the hint and the ask up front")
+	}
 
 	type_("no")
-	d.Update(enter) //nolint:errcheck // the dialog state is the assertion
-	if !d.IsVisible() || d.open || d.note != frost.Gate().Wrong || d.input.Value() != "" {
-		t.Fatalf("a wrong answer should stay open, say %q and clear the field: open=%v note=%q value=%q",
-			frost.Gate().Wrong, d.open, d.note, d.input.Value())
+	_, cmd := d.Update(enter)
+	if cmd != nil || !d.IsVisible() || d.note != frost.Gate().Wrong || d.input.Value() != "" {
+		t.Fatalf("a wrong answer should stay open, say %q and clear the field: note=%q value=%q",
+			frost.Gate().Wrong, d.note, d.input.Value())
 	}
-	if v := d.View(); !strings.Contains(v, frost.Gate().Wrong) || strings.Contains(v, frost.Gate().Hint) {
-		t.Fatal("the view should show the wrong line and not the hint")
+	if v := d.View(); !strings.Contains(v, frost.Gate().Wrong) || !strings.Contains(v, opening) {
+		t.Fatal("the view should show the wrong line and still the hint")
 	}
 
 	type_("yes")
-	d.Update(enter) //nolint:errcheck // the dialog state is the assertion
-	if !d.IsVisible() || !d.open || d.note != frost.Gate().Hint {
-		t.Fatalf("the right answer should reveal the hint: open=%v note=%q", d.open, d.note)
+	_, cmd = d.Update(enter)
+	if d.IsVisible() || cmd == nil {
+		t.Fatal("the right answer should close the prompt and hand back a command")
 	}
-	// The box wraps a long line, so look for the hint's opening words.
-	opening := strings.Join(strings.Fields(frost.Gate().Hint)[:2], " ")
-	if v := d.View(); !strings.Contains(v, opening) || !strings.Contains(v, frost.Gate().Label) {
-		t.Fatal("the view should show the hint under the label")
-	}
-	d.Update(enter) //nolint:errcheck // the dialog state is the assertion
-	if d.IsVisible() {
-		t.Fatal("enter on the hint should close the prompt")
+	if _, ok := cmd().(gateOpenMsg); !ok {
+		t.Fatal("the command should announce the unlock")
 	}
 
 	d.Show()
-	if d.open || d.note != "" {
+	if d.note != "" || d.input.Value() != "" {
 		t.Fatal("reopening should start fresh")
 	}
 	d.Update(tea.KeyPressMsg{Code: tea.KeyEscape}) //nolint:errcheck // the dialog state is the assertion
@@ -204,5 +205,11 @@ func TestGateIsReachableFromThePalette(t *testing.T) {
 	}
 	if !strings.Contains(h.renderBody(), frost.Gate().Label) {
 		t.Fatal("the body should render the prompt while it is open")
+	}
+	// The unlock message starts a run, the same one the key sequence starts.
+	h.gate.Hide()
+	h.Update(gateOpenMsg{}) //nolint:errcheck // the run is the assertion
+	if h.frost == nil {
+		t.Fatal("the unlock should start a run")
 	}
 }

--- a/internal/ui/frost_test.go
+++ b/internal/ui/frost_test.go
@@ -3,6 +3,10 @@ package ui
 import (
 	"hash/fnv"
 	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/brizzai/fleet/internal/frost"
 )
 
 // trailOf is the detector's own hash of a key run, so a test can install a
@@ -58,5 +62,39 @@ func TestTrailNeverFiresOnPlainNavigation(t *testing.T) {
 	}
 	if len(h.keyTrail) != trailLen {
 		t.Fatalf("trail should stay bounded at %d, got %d", trailLen, len(h.keyTrail))
+	}
+}
+
+// runningFrost gives a booted, sized Home with a run in progress.
+func runningFrost(t *testing.T) *Home {
+	t.Helper()
+	h := newPersistTestHome(t)
+	h.booted = true
+	h.Update(tea.WindowSizeMsg{Width: 80, Height: 24}) //nolint:errcheck // sizing only
+	h.frost = frost.New(frost.NewGrid(80, 24), 1)
+	return h
+}
+
+func TestOnlyARealResizeEndsTheRun(t *testing.T) {
+	h := runningFrost(t)
+	// Bubble Tea reports the size on every SIGWINCH, changed or not.
+	h.Update(tea.WindowSizeMsg{Width: 80, Height: 24}) //nolint:errcheck // the run is the assertion
+	if h.frost == nil {
+		t.Fatal("a same-size WindowSizeMsg ended the run")
+	}
+	h.Update(tea.WindowSizeMsg{Width: 80, Height: 23}) //nolint:errcheck // the run is the assertion
+	if h.frost != nil {
+		t.Fatal("a real resize should end the run")
+	}
+}
+
+func TestQuitKeyEndsTheRunInOnePress(t *testing.T) {
+	h := runningFrost(t)
+	h.handleKey(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}) //nolint:errcheck // quitting is the assertion
+	if h.frost != nil {
+		t.Fatal("ctrl+c left the run active")
+	}
+	if !h.quitting {
+		t.Fatal("ctrl+c should quit fleet in one press, not just leave the run")
 	}
 }

--- a/internal/ui/frost_test.go
+++ b/internal/ui/frost_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"hash/fnv"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -96,5 +97,112 @@ func TestQuitKeyEndsTheRunInOnePress(t *testing.T) {
 	}
 	if !h.quitting {
 		t.Fatal("ctrl+c should quit fleet in one press, not just leave the run")
+	}
+}
+
+func TestHiddenPaletteRowSurfacesOnlyOnASearch(t *testing.T) {
+	d := NewCommandPaletteDialog()
+	items := []PaletteItem{
+		{Kind: PaletteKindCommand, ID: "plain", Name: "Plain Command"},
+		{Kind: PaletteKindCommand, ID: "shy", Name: "Zzz", Haystack: "Zzz needle words", Hidden: true},
+	}
+	d.Show(items, []string{"shy"}) // even a recent pick stays hidden
+	ids := func() []string {
+		var out []string
+		for _, it := range d.filtered {
+			out = append(out, it.ID)
+		}
+		return out
+	}
+	if got := ids(); len(got) != 1 || got[0] != "plain" {
+		t.Fatalf("unfiltered list = %v, want only the plain command", got)
+	}
+	d.filterInput.SetValue("needle")
+	d.rebuildFiltered()
+	if got := ids(); len(got) != 1 || got[0] != "shy" {
+		t.Fatalf("searching a hidden row's keyword gave %v, want the hidden row", got)
+	}
+}
+
+func TestGateRevealsTheHintOnlyToTheRightAnswer(t *testing.T) {
+	d := newGateDialog()
+	d.unlock = func(a string) bool { return a == "yes" }
+	d.SetSize(80, 24)
+	d.Show()
+
+	type_ := func(s string) {
+		for _, r := range s {
+			d.Update(tea.KeyPressMsg{Code: r, Text: string(r)}) //nolint:errcheck // the dialog state is the assertion
+		}
+	}
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+
+	type_("no")
+	d.Update(enter) //nolint:errcheck // the dialog state is the assertion
+	if !d.IsVisible() || d.open || d.note != frost.Gate().Wrong || d.input.Value() != "" {
+		t.Fatalf("a wrong answer should stay open, say %q and clear the field: open=%v note=%q value=%q",
+			frost.Gate().Wrong, d.open, d.note, d.input.Value())
+	}
+	if v := d.View(); !strings.Contains(v, frost.Gate().Wrong) || strings.Contains(v, frost.Gate().Hint) {
+		t.Fatal("the view should show the wrong line and not the hint")
+	}
+
+	type_("yes")
+	d.Update(enter) //nolint:errcheck // the dialog state is the assertion
+	if !d.IsVisible() || !d.open || d.note != frost.Gate().Hint {
+		t.Fatalf("the right answer should reveal the hint: open=%v note=%q", d.open, d.note)
+	}
+	// The box wraps a long line, so look for the hint's opening words.
+	opening := strings.Join(strings.Fields(frost.Gate().Hint)[:2], " ")
+	if v := d.View(); !strings.Contains(v, opening) || !strings.Contains(v, frost.Gate().Label) {
+		t.Fatal("the view should show the hint under the label")
+	}
+	d.Update(enter) //nolint:errcheck // the dialog state is the assertion
+	if d.IsVisible() {
+		t.Fatal("enter on the hint should close the prompt")
+	}
+
+	d.Show()
+	if d.open || d.note != "" {
+		t.Fatal("reopening should start fresh")
+	}
+	d.Update(tea.KeyPressMsg{Code: tea.KeyEscape}) //nolint:errcheck // the dialog state is the assertion
+	if d.IsVisible() {
+		t.Fatal("esc should close the prompt")
+	}
+}
+
+func TestGateIsReachableFromThePalette(t *testing.T) {
+	h := newPersistTestHome(t)
+	h.booted = true
+	h.Update(tea.WindowSizeMsg{Width: 80, Height: 24}) //nolint:errcheck // sizing only
+	found := false
+	for _, it := range h.buildPaletteItems() {
+		if it.ID == "frost_gate" {
+			found = it.Hidden && it.Name == frost.Gate().Label
+		}
+	}
+	if !found {
+		t.Fatal("the palette should carry a hidden row for the gate, named from the pack")
+	}
+	// Through the real list, not a hand-built one: a later pass over the
+	// commands must not reset the search text the row relies on.
+	h.commandPalette.Show(h.buildPaletteItems(), nil)
+	h.commandPalette.filterInput.SetValue(strings.Fields(frost.Gate().Keywords)[0])
+	h.commandPalette.rebuildFiltered()
+	hit := false
+	for _, it := range h.commandPalette.filtered {
+		hit = hit || it.ID == "frost_gate"
+	}
+	if !hit {
+		t.Fatal("searching the first keyword did not surface the row")
+	}
+	h.commandPalette.Hide()
+	h.dispatchCommand("frost_gate") //nolint:errcheck // the dialog is the assertion
+	if !h.gate.IsVisible() || !h.modalOpen() {
+		t.Fatal("dispatching the row should open the prompt as a modal")
+	}
+	if !strings.Contains(h.renderBody(), frost.Gate().Label) {
+		t.Fatal("the body should render the prompt while it is open")
 	}
 }


### PR DESCRIPTION
## Summary

Freeze the rendered frame into a styled cell grid — replayed through the `x/vt` emulator so colors, attributes and wide glyphs land where the terminal put them — and run a small cell-level sim over it (`internal/frost`, no Bubble Tea or tmux dependencies). Started from the sidebar by a particular run of keys; ends on resize or `esc`. Ships with `/no-changelog`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] Documentation updated (if applicable)
- [ ] Changelog fragment added in `changelog/unreleased/` (if user-facing change; see `changelog/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrTXgxsLtRGid8ijrxi7nm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a hidden Frost mode that transforms the current screen into an interactive frozen scene.
  - Players can aim, fire, damage the frozen display, navigate debris, and trigger visual effects.
  - Frost mode includes animated rendering, speech bubbles, status information, and a collapse sequence when exiting.
  - The mode preserves the current screen, including overlays, and exits cleanly on completion, quit, or terminal resize.
  - Added a Frost unlock prompt accessible through command palette search.
  - Added analytics tracking for Frost mode sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->