### PR TITLE
feat(ui): sweep a shine across the boot splash wordmark

### DIFF
--- a/changelog/unreleased/splash-shine.md
+++ b/changelog/unreleased/splash-shine.md
@@ -1,0 +1,4 @@
+---
+type: improved
+---
+**The boot splash catches the light.** A shine now sweeps across the `FLEET` wordmark while fleet starts up, instead of the letters sitting still.

--- a/demo/drive.sh
+++ b/demo/drive.sh
@@ -370,11 +370,17 @@ wait_booted() {
     exit 3
 }
 
-# Two consecutive identical captures, polled at 120ms. The interval is not
-# 100ms on purpose: fleet's tick cadences are 100ms (spinners), 80ms (splash)
-# and 60ms (shimmer), and a 100ms sampler aliases onto the spinner exactly —
-# it would report a spinning dialog as settled. 120ms shares no small-integer
-# ratio with any of them.
+# Two consecutive identical captures, polled at 120ms.
+#
+# Nothing here should animate in the first place: fleet_env exports
+# FLEET_FREEZE_ANIM=1, which makes every self-rescheduling tick return nil, so
+# no spinner turns and no shimmer sweeps. The interval is a hedge for anyone
+# pointing this sampler at an unfrozen fleet, and 120ms rather than 100ms
+# because a 100ms sampler aliases exactly onto the 100ms dialog spinners and
+# would report a spinning dialog as settled. It does NOT clear every cadence —
+# it is 6x the 20ms splash tick — but the splash is gone by the time wait_stable
+# runs (every caller goes through wait_booted first), so that overlap is
+# unreachable.
 wait_stable() {
     local ansi="$1" want="$2"
     local prev="" cur="" elapsed=0 capargs="-p"

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3202,9 +3202,17 @@ func (h *Home) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return h, nil
 }
 
-// shutdownTick schedules the next shutdown-overlay spinner advance (~80ms,
-// matching splashTick). Self-rescheduled by Update while `quitting`, until the
-// teardown command emits tea.Quit and the program exits.
+// shutdownTick schedules the next shutdown-overlay spinner advance (~80ms).
+//
+// That is splashTick's interval times splashSpinnerDiv, and the equality is the
+// point rather than a coincidence: the splash runs its tick fast for the shine
+// and divides the counter back down for its spinner, so both spinners advance
+// at the same wall-clock rate off different tick rates. Move either constant
+// and the other has to follow, or the two spinners visibly disagree on a
+// screen the user sees fleet start and stop with.
+//
+// Self-rescheduled by Update while `quitting`, until the teardown command emits
+// tea.Quit and the program exits.
 func (h *Home) shutdownTick() tea.Cmd {
 	if FreezeAnim {
 		return nil

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -6274,12 +6274,27 @@ func (h *Home) bootProgress() float64 {
 	return float64(resolved) / float64(h.bootstrapRepos)
 }
 
-// splashTick schedules the next splash-spinner advance (~80ms cadence).
+// splashTick schedules the next splash frame (~20ms cadence).
+//
+// Four times the rate of the shutdown overlay's otherwise-identical tick, and
+// that asymmetry is the point: the shine sweeping the wordmark is the only
+// thing here that moves continuously, and frame rate is the only currency that
+// buys it speed without cost. At a fixed rate a faster sweep must jump further
+// per frame, which is paid for by widening the glint until it reads as a glow
+// rather than a line — so each speed-up came as a rate bump instead, and the
+// bar got narrower each time rather than broader. The spinner and the label are
+// held to their original cadence by dividing this counter down at the call site
+// (see RenderSplash), so only the shine spends the extra frames.
+//
+// 50fps is affordable here and was measured, not assumed: RenderSplash costs
+// ~284us, so the splash burns ~1.4% of one core while it is up — for one to
+// three seconds, on a screen with nothing else competing for the loop. The
+// drawer slide already animates at 45fps.
 func (h *Home) splashTick() tea.Cmd {
 	if FreezeAnim {
 		return nil
 	}
-	return tea.Tick(80*time.Millisecond, func(t time.Time) tea.Msg {
+	return tea.Tick(20*time.Millisecond, func(t time.Time) tea.Msg {
 		return splashFrameMsg(t)
 	})
 }

--- a/internal/ui/splash.go
+++ b/internal/ui/splash.go
@@ -20,6 +20,11 @@ var fleetWordmark = []string{
 	"╚═╝      ╚══════╝ ╚══════╝ ╚══════╝    ╚═╝   ",
 }
 
+// fleetWordmarkWidth is the wordmark's column count. Every row is exactly this
+// many single-width runes, so a rune index IS a terminal column — the property
+// the shine's vertical bar is built on. TestFleetWordmarkColumnsAlign pins it.
+var fleetWordmarkWidth = len([]rune(fleetWordmark[0]))
+
 var splashSpinnerFrames = []string{
 	"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
 }
@@ -28,8 +33,69 @@ const (
 	splashBarCells   = 32
 	splashFilledChar = "▰"
 	splashEmptyChar  = "▱"
-	splashLabelDwell = 12 // spinner frames each label sticks for (~1s at 80ms)
+	splashLabelDwell = 48 // frames each label sticks for (~1s at 20ms)
+	splashSpinnerDiv = 4  // frames per spinner glyph — holds the spinner at its
+	//                       original 80ms cadence now that the tick runs at 20ms
+	//                       for the shine's benefit. Keep it an exact divisor of
+	//                       the tick's ratio to 80ms, or the spinner drifts.
 )
+
+// Shine sweep — a narrow vertical glint travels left→right across the wordmark,
+// lifting the glyphs in the columns it passes toward white, then parks
+// off-screen for splashShineRest frames before the next pass.
+//
+// splashShineSpeed and splashShineWidth are tuned together, not independently:
+// their ratio sets how many frames each column spends ramping up and back down,
+// and below ~3 the sweep starts to read as a stepping bar rather than a moving
+// light. At 1.7/2.85 each column is lit across ~3.4 frames.
+//
+// Going faster is what drove the tick from 80ms to 20ms (see splashTick): at a
+// fixed frame rate the only way to speed the sweep up is to widen the glint —
+// the width is the motion blur — until it stops reading as a line and starts
+// reading as a glow. Raising the rate buys speed and narrowness at once, which
+// is why the glint is 5.7 columns wide here and was 8 at a third of this speed.
+//
+// splashShineRest is long enough that the sweep reads as a punctuated glint
+// rather than a near-continuous scan — the wordmark is still for roughly as
+// long as the glint takes to cross it. It is also picked to keep the cycle
+// off-harmonic with the other two animations on this screen: 55.8 frames
+// against the spinner's 40 and the label's 48, so ratios of 1.40 and 1.16.
+// Landing near 1.00 (or 0.50) would make the sweep fire at the same spinner
+// glyph or the same label every pass, which reads as a mechanism rather than a
+// flourish.
+//
+// splashShineMax sits well under the badge's 0.55 because these are solid
+// blocks: a full-cell glyph shows a white blend far harder than a thin letter,
+// and there are six stacked rows of it.
+//
+// 0.28 is also the floor, and it is a hard one rather than a matter of taste:
+// below it the accent end of the gradient downsamples to the SAME xterm-256
+// index as its own base (#ff77c6 and its 0.26 lift both land on 212), so the
+// shine disappears outright for anyone not on a truecolor terminal while
+// looking fine to whoever tuned it. Measured against colorprofile.ANSI256 —
+// re-measure before lowering this, and note the threshold moves with the
+// palette's accent.
+const (
+	splashShineWidth = 2.85 // half-width of the glint, in columns
+	splashShineMax   = 0.28 // peak blend toward white (floor — see above)
+	splashShineSpeed = 1.7  // columns per frame (~0.6s per sweep at 20ms)
+	splashShineRest  = 26   // frames parked between sweeps (~0.52s)
+)
+
+// splashShineCrest returns the column the glint's center sits on for frame, or
+// +Inf while the sweep rests between passes (crest off-screen → every column
+// renders at its base gradient color). Frame 0 parks the crest exactly
+// splashShineWidth left of column 0, where the falloff contributes zero — so a
+// FLEET_FREEZE_ANIM capture, which pins frame at 0, is byte-identical to the
+// un-shined wordmark. Don't change the frame-0 phase without checking that.
+func splashShineCrest(frame int) float64 {
+	travel := (float64(fleetWordmarkWidth) + 2*splashShineWidth) / splashShineSpeed
+	t := math.Mod(float64(frame), travel+splashShineRest)
+	if t >= travel {
+		return math.Inf(1)
+	}
+	return -splashShineWidth + t*splashShineSpeed
+}
 
 // splashLabels rotate while the bootstrap runs. Ops humor — feels lived-in
 // without being chatty. Order matters: first one greets the user, the rest
@@ -54,7 +120,8 @@ var splashLabels = []string{
 // bar, and a short label — centered in the given viewport.
 //
 //   - progress is clamped to [0,1] and drives the bar fill.
-//   - frame advances every ~80ms to animate the spinner.
+//   - frame advances every ~20ms, driving the wordmark shine; the spinner and
+//     label divide it down so they keep their slower original cadence.
 //
 // Returns "" when width/height are non-positive so the caller can no-op
 // before WindowSizeMsg lands.
@@ -63,10 +130,13 @@ func RenderSplash(width, height int, progress float64, frame int) string {
 		return ""
 	}
 
+	// One crest for every row: that is what makes the glint a single vertical
+	// bar rather than six independently-lit rows.
 	wordmarkWidth := lipgloss.Width(fleetWordmark[0])
+	crest := splashShineCrest(frame)
 	gradient := make([]string, len(fleetWordmark))
 	for i, row := range fleetWordmark {
-		gradient[i] = gradientLine(row)
+		gradient[i] = gradientLine(row, crest)
 	}
 
 	// Progress bar — longer cell count for a more granular fill animation.
@@ -83,7 +153,7 @@ func RenderSplash(width, height int, progress float64, frame int) string {
 	barEmpty := lipgloss.NewStyle().Foreground(ColorBorder).Render(strings.Repeat(splashEmptyChar, splashBarCells-filled))
 	bar := barFilled + barEmpty
 
-	spinner := renderSpinnerGlyph(frame, ColorPurple)
+	spinner := renderSpinnerGlyph(frame/splashSpinnerDiv, ColorPurple)
 	label := lipgloss.NewStyle().Foreground(ColorTextDim).Italic(true).Render(splashLabels[(frame/splashLabelDwell)%len(splashLabels)])
 
 	// Layout width = whichever is wider: the wordmark or the bar — so the
@@ -132,9 +202,12 @@ func renderShutdownBox(frame int) string {
 }
 
 // gradientLine colors each rune of s by lerping ColorAccent → ColorPurple
-// across the row. Spaces pass through uncolored to keep the gap glyphs from
-// burning extra escape sequences.
-func gradientLine(s string) string {
+// across the row, then lifts the columns near crest toward white — the
+// travelling shine. Spaces pass through uncolored to keep the gap glyphs from
+// burning extra escape sequences and, for free, keep the gaps between letters
+// dark as the glint crosses them: the light lands on the letterforms, not as a
+// scanline through the whole row. Pass math.Inf(1) for no shine.
+func gradientLine(s string, crest float64) string {
 	runes := []rune(s)
 	n := len(runes)
 	if n == 0 {
@@ -154,6 +227,15 @@ func gradientLine(s string) string {
 		}
 		t := float64(i) / denom
 		col := lerpRGB(c1, c2, t)
+		// Raised-cosine falloff, not the badge's linear one: it reaches zero
+		// with zero slope, so the glint's outer columns melt into the gradient.
+		// Linear would end on a visible step across six stacked rows of solid
+		// blocks, and its spiked peak would make brightness jitter as the
+		// fractional crest slid between cells.
+		if d := math.Abs(float64(i) - crest); d <= splashShineWidth {
+			lift := splashShineMax * 0.5 * (1 + math.Cos(math.Pi*d/splashShineWidth))
+			col = lerpRGB(col, rgbColor{255, 255, 255}, lift)
+		}
 		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(rgbToHex(col))).Render(string(r)))
 	}
 	return b.String()

--- a/internal/ui/splash_test.go
+++ b/internal/ui/splash_test.go
@@ -57,21 +57,26 @@ func TestSplashShineCrestSweepsThenRests(t *testing.T) {
 }
 
 // The shine may change color and nothing else — a splash that reflows every
-// 80ms is the most visible jitter fleet can ship.
+// 20ms is the most visible jitter fleet can ship.
 func TestRenderSplashShineIsColorOnly(t *testing.T) {
-	// Frames 1 and 3 fall inside one spinner window (splashSpinnerDiv frames
+	// These two frames fall inside one spinner window (splashSpinnerDiv frames
 	// per glyph) and one label bucket (splashLabelDwell), so the shine is the
-	// only thing that can differ. Both are mid-sweep, so both are lit.
-	a := RenderSplash(80, 24, 0.5, 1)
-	b := RenderSplash(80, 24, 0.5, 3)
+	// only thing that can differ. Both are mid-sweep, so both are lit. Every
+	// message below reports them rather than restating them: the pair has had
+	// to move twice already as the tick rate changed, and a hand-written frame
+	// number in a failure string is what sends the next reader to inspect a
+	// comparison that never happened.
+	const fa, fb = 1, 3
+	a := RenderSplash(80, 24, 0.5, fa)
+	b := RenderSplash(80, 24, 0.5, fb)
 
 	if ansi.Strip(a) != ansi.Strip(b) {
-		t.Error("the shine changed the splash's layout; it must only change color")
+		t.Errorf("frames %d and %d differ once stripped of color: the shine changed the splash's layout, and it must only change color", fa, fb)
 	}
 	if lipgloss.Width(a) != lipgloss.Width(b) {
-		t.Errorf("splash width moved between frames: %d vs %d", lipgloss.Width(a), lipgloss.Width(b))
+		t.Errorf("splash width moved between frames %d and %d: %d vs %d", fa, fb, lipgloss.Width(a), lipgloss.Width(b))
 	}
 	if a == b {
-		t.Error("frames 0 and 10 render identically; the shine is not animating")
+		t.Errorf("frames %d and %d render identically; the shine is not animating", fa, fb)
 	}
 }

--- a/internal/ui/splash_test.go
+++ b/internal/ui/splash_test.go
@@ -1,0 +1,77 @@
+package ui
+
+import (
+	"math"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The shine is a single vertical bar only because a rune index in one row is
+// the same terminal column as that rune index in every other row. Redraw the
+// ASCII art with a ragged row or a double-width rune and nothing panics — the
+// bar just goes quietly crooked. Both halves matter: the rune count catches a
+// ragged row, the display width catches a wide rune that leaves layout correct
+// while skewing the shine.
+func TestFleetWordmarkColumnsAlign(t *testing.T) {
+	for i, row := range fleetWordmark {
+		if n := len([]rune(row)); n != fleetWordmarkWidth {
+			t.Errorf("row %d has %d runes, want %d", i, n, fleetWordmarkWidth)
+		}
+		if w := lipgloss.Width(row); w != fleetWordmarkWidth {
+			t.Errorf("row %d renders %d columns, want %d (a wide rune would skew the shine)", i, w, fleetWordmarkWidth)
+		}
+	}
+}
+
+func TestSplashShineCrestSweepsThenRests(t *testing.T) {
+	// Frame 0 parks the crest where the falloff contributes exactly zero, so a
+	// FLEET_FREEZE_ANIM capture matches the un-shined wordmark byte for byte.
+	if got := splashShineCrest(0); got != -splashShineWidth {
+		t.Fatalf("frame 0 crest = %v, want the glint parked off the left edge at %v", got, -splashShineWidth)
+	}
+
+	prev := splashShineCrest(0)
+	inRest, sawRest, restarted := false, false, false
+	for f := 1; f <= 200; f++ {
+		c := splashShineCrest(f)
+		switch {
+		case math.IsInf(c, 1):
+			// Resting: the sweep that just ended must have carried the glint
+			// past the final column, so no pass stops mid-wordmark.
+			if !inRest && prev <= float64(fleetWordmarkWidth-1) {
+				t.Fatalf("frame %d rests with the crest still at %v — sweep ended early", f, prev)
+			}
+			inRest, sawRest = true, true
+		case inRest:
+			restarted, inRest = true, false
+		case c <= prev:
+			t.Fatalf("frame %d: crest %v did not advance past %v", f, c, prev)
+		}
+		prev = c
+	}
+	if !sawRest || !restarted {
+		t.Errorf("in 200 frames: rested=%v restarted=%v, want both (the sweep should loop)", sawRest, restarted)
+	}
+}
+
+// The shine may change color and nothing else — a splash that reflows every
+// 80ms is the most visible jitter fleet can ship.
+func TestRenderSplashShineIsColorOnly(t *testing.T) {
+	// Frames 1 and 3 fall inside one spinner window (splashSpinnerDiv frames
+	// per glyph) and one label bucket (splashLabelDwell), so the shine is the
+	// only thing that can differ. Both are mid-sweep, so both are lit.
+	a := RenderSplash(80, 24, 0.5, 1)
+	b := RenderSplash(80, 24, 0.5, 3)
+
+	if ansi.Strip(a) != ansi.Strip(b) {
+		t.Error("the shine changed the splash's layout; it must only change color")
+	}
+	if lipgloss.Width(a) != lipgloss.Width(b) {
+		t.Errorf("splash width moved between frames: %d vs %d", lipgloss.Width(a), lipgloss.Width(b))
+	}
+	if a == b {
+		t.Error("frames 0 and 10 render identically; the shine is not animating")
+	}
+}


### PR DESCRIPTION
A narrow vertical glint now travels left→right through the `FLEET` wordmark while fleet boots, brightening the block glyphs in the columns it passes. Spaces pass through uncolored, so the light lands on the letterforms rather than reading as a scanline across the whole row.

```
t=0.00s |.............................................|
t=0.08s |..░▓█▓░......................................|
t=0.16s |........░▒██▓░...............................|
t=0.24s |...............░▒██▒░........................|
t=0.32s |......................░▓██▒░.................|
t=0.40s |.............................░▓█▓▒...........|
t=0.48s |....................................░▓█▓░....|
t=0.56s |..........................................░▒█|
t=0.64s |.............................................|  rest
  ...                                                    (0.52s)
t=1.12s |░............................................|  next pass
```

## Approach

This is the What's New badge's glint applied to the wordmark, not a second dialect — same `hexToRGB`/`lerpRGB`/`rgbToHex` helpers, same "sweep once then rest" shape. Two things differ, both because the target is six stacked rows of solid `█` rather than a line of thin text:

- **One crest, computed per frame in `RenderSplash` and shared by all six rows.** That is what makes it a single vertical bar instead of six independently lit rows.
- **Raised-cosine falloff instead of linear.** Over a band this wide on solid blocks, linear ends on a visible step, and its spiked peak makes brightness jitter as the fractional crest slides between cells. The cosine reaches zero with zero slope, so the glint's outer columns melt into the gradient.

Because the lift is a *fraction* toward white rather than a fixed near-white, each column keeps its hue under the bar — it looks pink over the `F` and violet over the `T`, which is the physically right read for a light crossing a colored surface.

## Two constants are pinned, not free

**`splashShineMax = 0.28` is a hard floor.** Below it the accent end of the gradient downsamples to the *same* xterm-256 index as its own base (`#ff77c6` and its 0.26 lift both land on 212), so the shine disappears outright for anyone not on a truecolor terminal while looking fine to whoever tuned it. Measured against `colorprofile.ANSI256`; the threshold moves with the palette's accent, so re-measure before lowering.

**`splashShineSpeed` and `splashShineWidth` move together.** Their ratio sets how many frames each column spends ramping up and back down; below ~3 the sweep reads as a stepping bar rather than a moving light.

## Why the tick went 80ms → 20ms

That second constraint is the whole reason. At a fixed frame rate, a faster sweep can only be bought by widening the glint — the width *is* the motion blur — until it stops reading as a line and starts reading as a glow. Raising the rate buys speed and narrowness at once: the glint is **5.7 columns** here and was **8** at a third of this speed.

`splashSpinnerDiv` and `splashLabelDwell` divide the counter back down, so the spinner keeps its 80ms cadence and the label its ~1s dwell — only the shine spends the extra frames. The shutdown overlay has its own tick and is untouched.

**50fps was measured, not assumed:** `RenderSplash` benchmarks at ~284µs, so the splash burns ~1.4% of one core for the one to three seconds it is up. The drawer slide already animates at 45fps.

`splashShineRest` is also picked to keep the cycle off-harmonic with the other two animations on this screen — 55.8 frames against the spinner's 40 and the label's 48. Landing near 1.00 would fire the sweep on the same spinner glyph every pass, which reads as a mechanism rather than a flourish.

## FreezeAnim

No new guard needed, and it gets a free win: `FLEET_FREEZE_ANIM` already pins `frame` at 0, where the crest sits exactly `splashShineWidth` from column 0 and the falloff evaluates to zero. Captures stay byte-identical to the un-shined wordmark, so `demo/drive.sh` doesn't churn.

## Tests

`splash.go` had none. The load-bearing addition is **`TestFleetWordmarkColumnsAlign`** — the bar is only vertical because every row is 45 single-width runes, and redrawing the ASCII art would skew it silently with nothing else failing. It checks rune count *and* display width, since a double-width rune would leave layout correct while shearing the shine.

Plus `TestSplashShineCrestSweepsThenRests` (the phase machine: advances, carries past the final column before resting, loops) and `TestRenderSplashShineIsColorOnly` (the shine may change color and never layout — a splash that reflows every frame is the most visible jitter fleet can ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TyDiTSYXo2Q65sH7t3WDh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a sweeping shine effect across the FLEET wordmark during boot startup.
  - Improved splash animation smoothness with faster frame updates while preserving spinner and status-label timing.

- **Documentation**
  - Updated demo and splash-screen documentation to reflect the revised animation timing and capture behavior.

- **Tests**
  - Added coverage for wordmark alignment, shine animation progression, looping, and consistent rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->